### PR TITLE
Use alias in favor of xtype

### DIFF
--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -20,7 +20,10 @@
  */
 Ext.define("GeoExt.component.Map", {
     extend: "Ext.Component",
-    alias: "widget.mapcomponent",
+    alias: [
+        "widget.gx_map",
+        "widget.gx_component_map"
+    ],
 
     requires: [
         'GeoExt.data.LayerStore'

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -42,7 +42,11 @@
  */
 Ext.define("GeoExt.component.OverviewMap", {
     extend: 'Ext.Component',
-    xtype: 'gx_overviewmap',
+    alias: [
+        'widget.gx_overview',
+        'widget.gx_overviewmap',
+        'widget.gx_component_overviewmap'
+    ],
 
     config: {
         /**

--- a/src/tree/Panel.js
+++ b/src/tree/Panel.js
@@ -38,7 +38,10 @@
  */
 Ext.define('GeoExt.tree.Panel', {
     extend: 'Ext.tree.Panel',
-    xtype: "gx_treepanel",
+    alias: [
+        "widget.gx_treepanel",
+        "widget.gx_tree_panel"
+    ],
 
     initComponent: function() {
         var me = this;


### PR DESCRIPTION
The alias is said to be faster (even though we'll hardly recognize it) and also
can be used in more places than for just components.

See e.g. http://stackoverflow.com/a/27470948/860988

Additionally more aliases are added to the classes, this was the outcome of internal discussions at the codesprint.