### PR TITLE
Fix minor issues with source code comments

### DIFF
--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -13,6 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 /**
  * Create a component container for a map.
  *

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -13,8 +13,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 /**
- * An GeoExt.OverviewMap displays an overview map of an parent map.
+ * An GeoExt.component.OverviewMap displays an overview map of an parent map.
  * You can use this component as any other Ext.Component, e.g give it as an item
  * to a panel.
  *
@@ -53,7 +54,7 @@
  *         renderTo: 'panelDiv' // ID of the target <div>. Optional.
  *     });
  *
- * @class GeoExt.OverviewMap
+ * @class GeoExt.component.OverviewMap
  */
 Ext.define("GeoExt.component.OverviewMap", {
     extend: 'Ext.Component',
@@ -66,13 +67,13 @@ Ext.define("GeoExt.component.OverviewMap", {
     config: {
         /**
          * TODO
-         * @cfg {ol.Style} olStyle
+         * @cfg {ol.Style} anchorStyle
          */
         anchorStyle: null,
 
         /**
          * TODO
-         * @cfg {ol.Style} olStyle
+         * @cfg {ol.Style} boxStyle
          */
         boxStyle: null,
 
@@ -99,7 +100,7 @@ Ext.define("GeoExt.component.OverviewMap", {
         /**
          * A configured map or a configuration object for the map constructor.
          * This should be the map the overviewMap is bind to.
-         * @cfg {ol.Map} map
+         * @cfg {ol.Map} parentMap
          */
         parentMap: null,
 

--- a/src/data/MapfishPrintProvider.js
+++ b/src/data/MapfishPrintProvider.js
@@ -13,6 +13,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+/**
+ * Provides an interface to a Mapfish or GeoServer print module.
+ */
 Ext.define('GeoExt.data.MapfishPrintProvider', {
     extend: 'Ext.Base',
     mixins: ['Ext.mixin.Observable'],
@@ -21,14 +25,13 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
         'Ext.data.JsonStore'
     ],
 
-    // Events
     /**
      * @event ready
      * Fires after the PrintCapability store is loaded.
-     * @param {GeoExt.data.MapfishPrintProvider} GeoExt.data.MapfishPrintProvider
+     * @param {GeoExt.data.MapfishPrintProvider} provider
      * The GeoExt.data.MapfishPrintProvider itself
      */
-    // End Events
+
     config: {
         capabilities: null,
         url: ''

--- a/src/data/TreeStore.js
+++ b/src/data/TreeStore.js
@@ -13,11 +13,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 /**
  * A store that is synchronized with a GeoExt.data.LayerStore. It will be used
  * by a GeoExt.tree.Panel.
- *
- * @class GeoExt.data.TreeStore
  */
 Ext.define('GeoExt.data.TreeStore', {
     extend: 'Ext.data.TreeStore',
@@ -70,7 +69,7 @@ Ext.define('GeoExt.data.TreeStore', {
      * GeoExt.data.model.Layer or an ol.layer.Base.
      *
      * @param {Ext.data.NodeInterface} node
-     * @rec {GeoExt.data.model.Layer/ol.layer.Base} rec
+     * @param {GeoExt.data.model.Layer/ol.layer.Base} rec
      */
     addLayerNode: function(node, rec){
         var me = this,

--- a/src/data/model/Object.js
+++ b/src/data/model/Object.js
@@ -56,7 +56,7 @@ Ext.define('GeoExt.data.model.Object', {
 
     /**
      * the underlying ol.Object
-     * @type {[type]}
+     * @type {ol.Object}
      */
     olObject: null,
 

--- a/src/panel/Popup.js
+++ b/src/panel/Popup.js
@@ -70,12 +70,12 @@ Ext.define('GeoExt.panel.Popup', {
 
         me.callParent();
 
-        var ovl = new ol.Overlay(/** @type {olx.OverlayOptions} */ ({
+        var ovl = new ol.Overlay({
             autoPan: true,
             autoPanAnimation: {
                 duration: 250
             }
-        }));
+        });
 
         me.getMap().addOverlay(ovl);
         // fix layout of popup when its position changes


### PR DESCRIPTION
Still, jsduck complaints about missing Classes where Ext classes are
referenced. Also, overriden properties (e.g. proxy, fields) cause
erroneous output about duplicate properties.

No config file has been provided yet. Just run `jsduck` in the project folder.