### PR TITLE
Small improvements to GeoExt.data.model.Object

### DIFF
--- a/examples/mapviewform/mapviewform.html
+++ b/examples/mapviewform/mapviewform.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Map View Form Example</title>
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.1.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all.css"/>
+</head>
+
+<body>
+
+    <div id='description'>
+        <p>
+            This example shows how to wrap OpenLayers classes as GeoExt.data.model.Objects. Changes on the Ext.data.Model are forwarded to the OpenLayers object and vice versa.
+        </p>
+        <p>
+            More layer settings like saturation and hue are available if WebGL is supported by your browser.</p>
+        <p>
+            Have a look at <a href="mapviewform.js">mapviewform.js</a> to see how this is done.
+        </p>
+    </div>
+
+    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="http://cdn.sencha.com/ext/gpl/5.1.0/build/ext-all.js"></script>
+    <script>
+        Ext.Loader.setConfig({
+            enabled: true,
+            paths: {
+                'GeoExt': '../../src/'
+            }
+        });
+    </script>
+
+    <script src="mapviewform.js"></script>
+    <!-- Automatically reload on source changes, just append #reload to URL -->
+    <script src="../../util/live-reload.js"></script>
+</body>
+</html>

--- a/examples/mapviewform/mapviewform.js
+++ b/examples/mapviewform/mapviewform.js
@@ -1,0 +1,154 @@
+Ext.require([
+    'Ext.form.Panel',
+    'GeoExt.component.Map',
+    'GeoExt.data.model.Object'
+]);
+
+Ext.application({
+    name: 'MapView',
+    launch: function() {
+        var view = new ol.View({
+            center: [1588081, 6993663],
+            zoom: 12
+        });
+
+        var layer = new ol.layer.Tile({
+            source: new ol.source.Stamen({
+                layer: 'watercolor'
+            })
+        });
+
+        // wrap ol.View in GeoExt Object model
+        var viewRecord = Ext.create('GeoExt.data.model.Object', view);
+
+        // wrap ol.layer.Layer in GeoExt Object model
+        var layerRecord = Ext.create('GeoExt.data.model.Object', layer);
+
+        var viewForm = Ext.create('Ext.form.Panel', {
+            title: 'View',
+            bodyPadding: 5,
+            defaults: {
+                listeners: {
+                    change: function() {
+                        // update record on form changes
+                        viewRecord.set(this.up('form').getValues());
+                    }
+                }
+            },
+            items: [{
+                xtype: 'numberfield',
+                fieldLabel: 'Resolution (m)',
+                minValue: 1,
+                step: 100,
+                name: 'resolution',
+                allowBlank: false
+            }, {
+                xtype: 'numberfield',
+                fieldLabel: 'Rotation (rad)',
+                step: 0.1,
+                name: 'rotation',
+                allowBlank: false
+            }]
+        });
+
+        var layerForm = Ext.create('Ext.form.Panel', {
+            title: 'Layer',
+            bodyPadding: 5,
+            defaults: {
+                xtype: 'numberfield',
+                decimalPrecision: 3,
+                step: 0.125,
+                listeners: {
+                    change: function() {
+                        // update record on form changes
+                        layerRecord.set(this.up('form').getValues());
+                    }
+                }
+            },
+            items: [{
+                fieldLabel: 'Opacity',
+                minValue: 0,
+                maxValue: 1,
+                name: 'opacity',
+                allowBlank: false
+            }]
+        });
+
+        // only possible if webgl renderer is enabled
+        if (ol.has.WEBGL) {
+            layerForm.add([{
+                fieldLabel: 'Brightness',
+                name: 'brightness',
+                allowBlank: false
+            }, {
+                fieldLabel: 'Contrast',
+                minValue: 0,
+                name: 'contrast',
+                allowBlank: false
+            }, {
+                fieldLabel: 'Hue',
+                name: 'hue',
+                allowBlank: false
+            }, {
+                fieldLabel: 'Saturation',
+                minValue: 0,
+                name: 'saturation',
+                allowBlank: false
+            }]);
+        }
+
+        // bind map view changes to form
+        view.on('propertychange', function() {
+            viewForm.loadRecord(viewRecord);
+        });
+
+        // bind layer to form
+        layer.on('propertychange', function() {
+            layerForm.loadRecord(layerRecord);
+        });
+
+        Ext.create('Ext.Viewport', {
+            layout: "border",
+            items: [{
+                region: 'center',
+                layout: 'fit',
+                items: [{
+                    xtype: 'gx_component_map',
+                    map: new ol.Map({
+                        layers: [
+                            layer,
+                            new ol.layer.Tile({
+                                source: new ol.source.Stamen({
+                                    layer: 'terrain-labels'
+                                })
+                            })
+                        ],
+                        view: view,
+                        renderer: ['webgl', 'canvas', 'dom']
+                    }),
+                    listeners: {
+                        boxready: function() {
+                            // init forms with record data
+                            viewForm.loadRecord(viewRecord);
+                            layerForm.loadRecord(layerRecord);
+                        }
+                    }
+                }]
+            }, {
+                region: 'east',
+                width: 300,
+                defaults: {
+                    bodyPadding: 5,
+                    border: false
+                },
+                items: [
+                    viewForm,
+                    layerForm,
+                {
+                    title: 'Description',
+                    contentEl: 'description'
+                }]
+            }]
+        });
+    }
+});

--- a/src/data/model/Object.js
+++ b/src/data/model/Object.js
@@ -109,18 +109,32 @@ Ext.define('GeoExt.data.model.Object', {
      * Overriden to foward changes to the underlying ol.Object. All changes on
      * the Ext.data.Models properties will be set on the ol.Object as well.
      *
-     * @param {String} key
+     * @param {String|Object} key
      * @param {Object} value
      * @param {Object} options
      *
      * @inheritDoc
      */
     set: function(key, newValue) {
+        var o = {};
+
         this.callParent(arguments);
 
         // forward changes to ol object
         this.__updating = true;
-        this.olObject.set(key, newValue);
+
+        // wrap simple set operations into an object
+        if (Ext.isString(key)) {
+            o[key] = newValue;
+        } else {
+            o = key;
+        }
+
+        // iterate over object setting changes to ol.Object
+        Ext.Object.each(o, function(k, v) {
+            this.olObject.set(k, v);
+        }, this);
+
         this.__updating = false;
     },
 


### PR DESCRIPTION
Ext allows setting model properties via property maps which wasn't working with the ol.Object wrapper.
Also, I added an example that shows how one may interact with the class.