### PR TITLE
Add pointerrest and pointerrestout events to map component

### DIFF
--- a/examples/popup/gx-popup.html
+++ b/examples/popup/gx-popup.html
@@ -14,11 +14,20 @@
 
     <div id='description'>
         <p>
-            This example shows a simple popup showing the position you clicked.
+            This example shows a simple popup showing the position that was
+            hovered.
         </p>
         <p>
-            Have a look at <a href="gx-popup.js">simple-ol-popup.js</a> to see how this is
-            done.
+            To achieve this effect, the <code>GeoExt.component.Map</code> is
+            instantiated with <code>pointerRest: true</code>, so that the
+            events <code>pointerrest</code> and <code>pointerout</code> become
+            available. Whenever <code>pointerrest</code> is fired, an instance
+            of <code>GeoExt.panel.Popup</code> is positioned and its HTML
+            updated.
+        </p>
+        <p>
+            Have a look at <a href="gx-popup.js">gx-popup.js</a> to see how this
+            is done.
         </p>
     </div>
 

--- a/examples/popup/gx-popup.js
+++ b/examples/popup/gx-popup.js
@@ -3,7 +3,7 @@ Ext.require([
 ]);
 
 var olMap,
-    mapPanel,
+    mapComp,
     popup;
 
 Ext.application({
@@ -38,24 +38,31 @@ Ext.application({
             bodyPadding: 5
         });
 
-        /**
-         * Add a click handler to the map to render the popup.
-         */
-        olMap.on('singleclick', function(evt) {
-            var coordinate = evt.coordinate,
-                hdms = ol.coordinate.toStringHDMS(ol.proj.transform(
-                coordinate, 'EPSG:3857', 'EPSG:4326'));
-
-            // set content and position popup
-            popup.setHtml('You clicked here:<br><code>' + hdms + '</code>');
-            popup.position(coordinate);
-        });
-
-        mapPanel = Ext.create('GeoExt.component.Map', {
+        mapComp = Ext.create('GeoExt.component.Map', {
             title: 'GeoExt.panel.Map Example',
             map: olMap,
-            region: 'center'
+            region: 'center',
+            pointerRest: true,
+            pointerRestInterval: 750,
+            pointerRestPixelTolerance: 5
         });
+
+        // Add a pointerrest handler to the map component to render the popup.
+        mapComp.on('pointerrest', function(evt) {
+            var coordinate = evt.coordinate,
+            hdms = ol.coordinate.toStringHDMS(ol.proj.transform(
+                    coordinate, 'EPSG:3857', 'EPSG:4326'));
+            // Insert a linebreak after either N or S in hdms
+            hdms = hdms.replace(/([NS])/, '$1<br>');
+
+            // set content and position popup
+            popup.setHtml('Pointer rested on: <br /><code>' + hdms + '</code>');
+            popup.position(coordinate);
+            popup.show();
+        });
+
+        // hide the popup once it isn't on the map any longer
+        mapComp.on('pointerrestout', popup.hide, popup);
 
         description = Ext.create('Ext.panel.Panel', {
             contentEl: 'description',
@@ -69,7 +76,7 @@ Ext.application({
         Ext.create('Ext.Viewport', {
             layout: "border",
             items: [
-                mapPanel,
+                mapComp,
                 description
             ]
         });

--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -30,6 +30,74 @@ Ext.define("GeoExt.component.Map", {
     ],
 
     /**
+     * @event pointerrest
+     *
+     * Fires if the user has left the pointer for an amount
+     * of #pointerRestInterval milliseconds at the *same location*. Use the
+     * configuration #pointerRestPixelTolerance to configure how long a pixel is
+     * considered to be on the *same location*.
+     *
+     * Please note that this event will only fire if the map has #pointerRest
+     * configured with `true`.
+     *
+     * @param {ol.MapBrowserEvent} olEvt The original and most recent
+     *     MapBrowserEvent event.
+     *  @param {ol.Pixel} lastPixel The originally captured pixel, which defined
+     *     the center of the tolerance bounds (itself configurable with the the
+     *     configuration #pointerRestPixelTolerance). If this is null, a
+     *     completely *new* pointerrest event just happened.
+     *
+     */
+
+    /**
+     * @event pointerrestout
+     *
+     * Fires if the user first was resting his pointer on the map element, but
+     * then moved the pointer out of the map completely.
+     *
+     * Please note that this event will only fire if the map has #pointerRest
+     * configured with `true`.
+     *
+     * @param {ol.MapBrowserEvent} olEvt The MapBrowserEvent event.
+     */
+
+    config: {
+        /**
+         * A configured map or a configuration object for the map constructor.
+         *
+         * @cfg {ol.Map} map
+         */
+        map: null,
+
+        /**
+         * A boolean flag to control whether the map component will fire the
+         * events #pointerrest and #pointerrestout. If this is set to `false`
+         * (the default), no such events will be fired.
+         *
+         * @cfg {boolean} pointerRest Whether the component shall provide the
+         *     `pointerrest` and `pointerrestout` events.
+         */
+        pointerRest: false,
+
+        /**
+         * The amount of milliseconds after which we will consider a rested
+         * pointer as `pointerrest`. Only relevant if #pointerRest is `true`.
+         *
+         * @cfg {Number} pointerRestInterval The interval in milliseconds.
+         */
+        pointerRestInterval: 1000,
+
+        /**
+         * The amount of pixels that a pointer may move in both vertical and
+         * horizontal direction, and still be considered to be a #pointerrest.
+         * Only relevant if #pointerRest is `true`.
+         *
+         * @cfg {Number} pointerRestPixelTolerance The tolerance in pixels.
+         */
+        pointerRestPixelTolerance: 3
+    },
+
+    /**
      * Whether we already rendered an ol.Map in this component. Will be
      * updated in #onResize, after the first rendering happened.
      *
@@ -44,14 +112,27 @@ Ext.define("GeoExt.component.Map", {
      */
     layerStore: null,
 
-    config: {
-        /**
-         * A configured map or a configuration object for the map constructor.
-         * @cfg {ol.Map} map
-         */
-        map: null
-    },
+    /**
+     * The location of the last mousemove which we track to be able to fire
+     * the #pointerrest event. Only usable if #pointerRest is `true`.
+     *
+     * @property {ol.Pixel} lastPointerPixel
+     * @private
+     */
+    lastPointerPixel: null,
 
+    /**
+     * Whether the pointer is currently over the map component. Only usable if
+     * the configuration #pointerRest is `true`.
+     *
+     * @property {boolean} isMouseOverMapEl
+     * @private
+     */
+    isMouseOverMapEl: null,
+
+    /**
+     * @inheritdoc
+     */
     initComponent: function() {
         var me = this;
         if(!(me.getMap() instanceof ol.Map)){
@@ -73,6 +154,9 @@ Ext.define("GeoExt.component.Map", {
         me.callParent();
     },
 
+    /**
+     * (Re-)render the map when size changes.
+     */
     onResize: function(){
         // Get the corresponding view of the controller (the mapComponent).
         var me = this;
@@ -82,6 +166,162 @@ Ext.define("GeoExt.component.Map", {
         } else {
             me.getMap().updateSize();
         }
+    },
+
+    /**
+     * Will contain a buffered version of #unbufferedPointerMove, but only if
+     * the configuration #pointerRest is true.
+     *
+     * @private
+     */
+    bufferedPointerMove: Ext.emptyFn,
+
+    /**
+     * Bound as a eventlistener for pointermove on the OpenLayers map, but only
+     * if the configuration #pointerRest is true. Will eventually fire the
+     * special events #pointerrest or #pointerrestout.
+     *
+     * @param {ol.MapBrowserEvent} olEvt The MapBrowserEvent event.
+     * @private
+     */
+    unbufferedPointerMove: function(olEvt){
+        var me = this;
+        var tolerance = me.getPointerRestPixelTolerance();
+        var pixel = olEvt.pixel;
+
+        if (!me.isMouseOverMapEl) {
+            me.fireEvent('pointerrestout', olEvt);
+            return;
+        }
+
+        if (me.lastPointerPixel) {
+            var deltaX = Math.abs(me.lastPointerPixel[0] - pixel[0]);
+            var deltaY = Math.abs(me.lastPointerPixel[1] - pixel[1]);
+            if (deltaX > tolerance || deltaY > tolerance) {
+                me.lastPointerPixel = pixel;
+            } else {
+                // fire pointerrest, and include the original pointer pixel
+                me.fireEvent('pointerrest', olEvt, me.lastPointerPixel);
+                return;
+            }
+        } else {
+            me.lastPointerPixel = pixel;
+        }
+        // a new pointerrest event, the second argument (the 'original' pointer
+        // pixel) must be null, as we start from a totally new position
+        me.fireEvent('pointerrest', olEvt, null);
+    },
+
+    /**
+     * Creates #bufferedPointerMove from #unbufferedPointerMove and binds it
+     * to `pointermove` on the OpenLayers map.
+     *
+     * @private
+     */
+    registerPointerRestEvents: function(){
+        var me = this;
+        var map = me.getMap();
+
+        if (me.bufferedPointerMove === Ext.emptyFn) {
+            me.bufferedPointerMove = Ext.Function.createBuffered(
+                me.unbufferedPointerMove,
+                me.getPointerRestInterval(),
+                me
+            );
+        }
+
+        // Check if we have to fire any pointer* events
+        map.on('pointermove', me.bufferedPointerMove);
+
+        if (!me.rendered) {
+            // make sure we do not fire any if the pointer left the component
+            me.on('afterrender', me.bindEnterLeaveListeners, me);
+        } else {
+            me.bindEnterLeaveListeners();
+        }
+
+    },
+
+    /**
+     * Registers listeners that'll take care of setting #isMouseOverMapEl to
+     * correct values.
+     *
+     * @private
+     */
+    bindEnterLeaveListeners: function() {
+        var me = this;
+        var mapEl = me.getEl();
+        if (mapEl) {
+            mapEl.on({
+                mouseenter: me.onMouseEnter,
+                mouseleave: me.onMouseLeave,
+                scope: me
+            });
+        }
+    },
+
+    /**
+     * Unregisters listeners that'll take care of setting #isMouseOverMapEl to
+     * correct values.
+     *
+     * @private
+     */
+    unbindEnterLeaveListeners: function() {
+        var me = this;
+        var mapEl = me.getEl();
+        if (mapEl) {
+            mapEl.un({
+                mouseenter: me.onMouseEnter,
+                mouseleave: me.onMouseLeave,
+                scope: me
+            });
+        }
+    },
+
+    /**
+     * Sets isMouseOverMapEl to true, see #pointerRest.
+     *
+     * @private
+     */
+    onMouseEnter: function() {
+        this.isMouseOverMapEl = true;
+    },
+
+    /**
+     * Sets isMouseOverMapEl to false, see #pointerRest.
+     *
+     * @private
+     */
+    onMouseLeave: function() {
+        this.isMouseOverMapEl = false;
+    },
+
+    /**
+     * Unregisters the #bufferedPointerMove event listener and unbinds the
+     * enter- and leave-listeners.
+     */
+    unregisterPointerRestEvents: function(){
+        var map = this.getMap();
+        this.unbindEnterLeaveListeners();
+        if (map) {
+            map.un('pointermove', this.bufferedPointerMove);
+        }
+    },
+
+    /**
+     * Whenever the value of #pointerRest is changed, this method will take
+     * care of registering or unregistering internal event listeners.
+     *
+     * @param {boolean} val The new value that someone set for `pointerRest`.
+     * @return {boolean} The passed new value for  `pointerRest` unchanged.
+     */
+    applyPointerRest: function(val) {
+        if (val) {
+            this.registerPointerRestEvents();
+        } else {
+            this.unregisterPointerRestEvents();
+        }
+        return val;
     },
 
     /**


### PR DESCRIPTION
This PR suggest adding two new events to `GeoExt.component.Map`:  `pointerrest` and `pointerrestout`:

With these events it easy to create nice hovering effects, that do not fire as often as the raw pointermove does.

![pointerrest2](https://cloud.githubusercontent.com/assets/227934/8302440/99bdb16a-1996-11e5-9e94-11202e4a5ea1.png)

The Popup example has been changed to now work with these new events.

Additionally some API docs were added to certain Map-properties.

Please review.