### PR TITLE
Some enhancements for the tree

### DIFF
--- a/examples/tree/panel.js
+++ b/examples/tree/panel.js
@@ -61,7 +61,8 @@ Ext.application({
         });
 
         treeStore = Ext.create('GeoExt.data.TreeStore', {
-            layerGroup: olMap.getLayerGroup()
+            layerGroup: olMap.getLayerGroup(),
+            showLayerGroupNode: true
         });
 
         treePanel = Ext.create('GeoExt.tree.Panel', {


### PR DESCRIPTION
* TreeStore can be configured to show/hide the root GroupLayer Node (fixes #19)
* TreeStore reacts on adding/removing layers to the map or any ol.layer.Group within it

Still missing:
 - (Better) tests for the treestore
 - Map/ol.Collection should react correctly on removing nodes from the tree

@bentrm Maybe you can have a look at the second point