### PR TITLE
 Implement FeatureStore and FeatureModel classes

### DIFF
--- a/examples/features/grid.html
+++ b/examples/features/grid.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Feature Grid Example</title>
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.1.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all.css"/>
+</head>
+
+<body>
+
+    <div id='description'>
+        <p>
+            This example shows how to display features in grids.
+            <br><br>
+            The grid on the left side is created by passing an OpenLayers
+            collection (ol.Collection) with feature objects (ol.Feature)<br>
+            The grid on the right side is created from an existing vector 
+            layer and also highlights the selected feature in the grid on the 
+            map. 
+        </p>
+        <p>
+            Have a look at <a href="grid.js">grid.js</a> to see how this is
+            done.
+        </p>
+    </div>
+
+    <script src="http://openlayers.org/en/master/build/ol-debug.js"></script>
+    <script src="http://cdn.sencha.com/ext/gpl/5.1.0/build/ext-all.js"></script>
+    <script>
+        Ext.Loader.setConfig({
+            enabled: true,
+            paths: {
+                'GeoExt': '../../src/'
+            }
+        });
+    </script>
+
+    <script src="grid.js"></script>
+    <!-- Automatically reload on source changes, just append #reload to URL -->
+    <script src="../../util/live-reload.js"></script>
+</body>
+</html>

--- a/examples/features/grid.js
+++ b/examples/features/grid.js
@@ -1,0 +1,303 @@
+Ext.require([
+    'Ext.container.Container',
+    'Ext.panel.Panel',
+    'Ext.grid.Panel',
+    'GeoExt.component.Map',
+    'GeoExt.data.store.Features'
+]);
+
+var olMap, gridWest, gridEast, featStore1, featStore2;
+
+Ext.application({
+    name: 'FeatureGrids',
+    launch: function() {
+        var geojson1 = {
+            "type": "FeatureCollection",
+            "features": [
+              {
+                "type": "Feature",
+                "properties": {
+                  "city": "Hamburg",
+                  "pop": 1700000
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    10.107421874999998,
+                    53.527247970102465
+                  ]
+                }
+              },
+              {
+                "type": "Feature",
+                "properties": {
+                  "city": "Frankfurt / Main",
+                  "pop": 700000
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    8.76708984375,
+                    50.064191736659104
+                  ]
+                }
+              },
+              {
+                "type": "Feature",
+                "properties": {
+                  "city": "Berlin",
+                  "pop": 3500000
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    13.447265624999998,
+                    52.53627304145948
+                  ]
+                }
+              },
+              {
+                "type": "Feature",
+                "properties": {
+                  "city": "München",
+                  "pop": 1400000
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    11.6455078125,
+                    48.1367666796927
+                  ]
+                }
+              }
+            ]
+        };
+
+        var geojson2 = {
+            "type": "FeatureCollection",
+            "features": [
+              {
+                "type": "Feature",
+                "properties": {
+                  "city": "Dortmund"
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    7.481689453125,
+                    51.49506473014368
+                  ]
+                }
+              },
+              {
+                "type": "Feature",
+                "properties": {
+                  "city": "Köln"
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    6.976318359375,
+                    50.93073802371819
+                  ]
+                }
+              },
+              {
+                "type": "Feature",
+                "properties": {
+                  "city": "Kaiserslautern"
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    7.7838134765625,
+                    49.44670029695474
+                  ]
+                }
+              },
+              {
+                "type": "Feature",
+                "properties": {
+                  "city": "Bonn"
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    7.102661132812499,
+                    50.74688365485319
+                  ]
+                }
+              },
+              {
+                "type": "Feature",
+                "properties": {
+                  "city": "Stuttgart"
+                },
+                "geometry": {
+                  "type": "Point",
+                  "coordinates": [
+                    9.1461181640625,
+                    48.77429274267509
+                  ]
+                }
+              }
+            ]
+        };
+
+        // style objects
+        var blueStyle = new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 6,
+                fill: new ol.style.Fill({
+                    color: '#0099CC'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: '#fff',
+                    width: 2
+                })
+            })
+        });
+        var redStyle = new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 6,
+                fill: new ol.style.Fill({
+                    color: '#8B0000'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: '#fff',
+                    width: 2
+                })
+            })
+        });
+        var selectStyle = new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 6,
+                fill: new ol.style.Fill({
+                    color: '#EE0000'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'gray',
+                    width: 3
+                })
+            })
+        });
+
+        // create a feature collection in order to put into a feature store
+        var vectorSource = new ol.source.Vector({
+            features: (new ol.format.GeoJSON()).readFeatures(geojson1, {
+                dataProjection: 'EPSG:4326',
+                featureProjection: 'EPSG:3857'
+            })
+        });
+        var featColl = new ol.Collection(vectorSource.getFeatures());
+
+        // loading data via into ol source and create a vector layer to bind a
+        // vector layer to a feature store
+        var vectorLayer = new ol.layer.Vector({
+            source: new ol.source.Vector({
+                features: (new ol.format.GeoJSON()).readFeatures(geojson2, {
+                    dataProjection: 'EPSG:4326',
+                    featureProjection: 'EPSG:3857'
+                })
+            }),
+            style: redStyle
+        });
+
+        olMap = new ol.Map({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.TileWMS({
+                        url: 'http://ows.terrestris.de/osm-gray/service',
+                        params: {'LAYERS': 'OSM-WMS', 'TILED': true}
+                    })
+                }),
+                vectorLayer
+            ],
+            view: new ol.View({
+                center: ol.proj.fromLonLat([8, 50]),
+                zoom: 5
+            })
+        });
+
+        // create feature store by passing a feature collection
+        featStore1 = Ext.create('GeoExt.data.store.Features', {
+            features: featColl,
+            map: olMap,
+            createLayer: true,
+            style: blueStyle
+        });
+        // create feature store by passing a vector layer
+        featStore2 = Ext.create('GeoExt.data.store.Features', {
+            layer: vectorLayer,
+            map: olMap
+        });
+
+        // default feature grid
+        gridWest = Ext.create('Ext.grid.Panel', {
+            title: 'Feature Grid',
+            border: true,
+            region: 'west',
+            store: featStore1,
+            columns: [
+                {text: 'Name', dataIndex: 'city', flex: 1},
+                {
+                    text: 'Population',
+                    dataIndex: 'pop',
+                    xtype: 'numbercolumn',
+                    format: '0,000',
+                    flex: 1
+                }
+            ],
+            width: 250
+        });
+
+        // feature grid with some selection logic
+        gridEast = Ext.create('Ext.grid.Panel', {
+            title: 'Feature Grid with selection',
+            border: true,
+            region: 'east',
+            store: featStore2,
+            columns: [
+                { text: 'Name', dataIndex: 'city', flex: 2}
+            ],
+            width: 250,
+            listeners: {
+                'selectionchange': function(grid, selected) {
+                    // reset all selections
+                    featStore2.each(function(rec) {
+                        rec.getFeature().setStyle(redStyle);
+                    });
+                    // highlight grid selection in map
+                    Ext.each(selected, function(rec) {
+                        rec.getFeature().setStyle(selectStyle);
+                    });
+                }
+            }
+        });
+
+        var mapComponent = Ext.create('GeoExt.component.Map', {
+            map: olMap
+        });
+        var mapPanel = Ext.create('Ext.panel.Panel', {
+            region: 'center',
+            height: 400,
+            layout: 'fit',
+            items: [mapComponent]
+        });
+
+        var description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            region: 'south',
+            title: 'Description',
+            height: 180,
+            border: false,
+            bodyPadding: 5,
+            autoScroll: true
+        });
+
+        Ext.create('Ext.Viewport', {
+            layout: 'border',
+            items: [mapPanel, gridWest, gridEast, description]
+        });
+    }
+});

--- a/src/data/model/Feature.js
+++ b/src/data/model/Feature.js
@@ -1,0 +1,18 @@
+/**
+ * Data model holding an OpenLayers feature.
+ *
+ * @class
+ */
+Ext.define('GeoExt.data.model.Feature', {
+    extend: 'GeoExt.data.model.Object',
+
+    /**
+     * Returns the underlying Feature of this record.
+     *
+     * @return {ol.Feature}
+     */
+    getFeature: function() {
+        return this.olObject;
+    }
+
+});

--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -1,0 +1,151 @@
+/**
+ * A data store holding OpenLayers feature objects.
+ *
+ * @class
+ */
+Ext.define('GeoExt.data.store.Features', {
+    extend: 'GeoExt.data.store.Collection',
+    requires: [],
+
+    model: 'GeoExt.data.model.Feature',
+
+    config: {
+
+        /**
+         * @cfg {ol.Layer}
+         * Initial layer holding features which will be added to the store
+         */
+        /**
+         * @property {ol.Layer}
+         * @readonly
+         * The layer object which is in sync with this store
+         */
+        layer: null
+    },
+
+    /**
+     * @cfg {ol.Map}
+     * a map object to which a possible #layer will be added
+     */
+    map: null,
+
+    /**
+     * @cfg
+     * Set this flag to true will create a vector #layer with the given
+     * #features and ads it to the given #map (if available)
+     */
+    createLayer: false,
+
+    /**
+     * @private
+     * @property
+     * Shows if the #layer has been created by constructor
+     */
+    layerCreated: false,
+
+    /**
+     * @cfg {ol.Style}
+     * An OpenLayers 3 style object to style the vector #layer representing
+     * the features of this store
+     */
+    style: null,
+
+    /**
+     * @cfg {ol.Collection<ol.Feature>}
+     * Initial set of features. Has to be an ol.Collection object with
+     * ol.Feature objects in it.
+     */
+    features: null,
+
+
+    /**
+     * @private
+     */
+    constructor: function(config) {
+        var me = this,
+            cfg = config || {};
+
+        if (me.style === null) {
+            me.style = new ol.style.Style({
+                image: new ol.style.Circle({
+                    radius: 6,
+                    fill: new ol.style.Fill({
+                        color: '#3399CC'
+                    }),
+                    stroke: new ol.style.Stroke({
+                        color: '#fff',
+                        width: 2
+                    })
+                })
+            });
+        }
+
+        if(cfg.features) {
+            cfg.data = cfg.features;
+        } else if(cfg.layer && cfg.layer instanceof ol.layer.Vector) {
+            if(cfg.layer.getSource()) {
+                cfg.data = cfg.layer.getSource().getFeatures();
+            } else {
+                cfg.data = [];
+            }
+        }
+
+        me.callParent([cfg]);
+
+        // create a vector layer and add to map if configured accordingly
+        if (me.createLayer === true && !me.layer) {
+            me.drawFeaturesOnMap();
+        }
+    },
+
+    /**
+     * Returns the FeatureCollection which is in sync with this store.
+     *
+     * @returns {ol.Collection<ol.Featrues>}
+     *   The underlying OpenLayers FeatureCollection
+     */
+    getFeatures: function() {
+        return this.olCollection;
+    },
+
+    /**
+     * @protected
+     *
+     * Overwrites the destroy function to ensure the #layer is removed from
+     * the #map when it has been created automatically while construction in
+     * case of destruction of this store.
+     */
+    destroy: function() {
+        var me = this;
+        if (me.map && me.layerCreated === true) {
+            me.map.removeLayer(me.layer);
+        }
+
+        me.callParent(arguments);
+    },
+
+    /**
+     * @private
+     *
+     * Draws the given #features on the #map
+     */
+    drawFeaturesOnMap: function() {
+        var me = this;
+
+        // create a layer representation of our features
+        me.source = new ol.source.Vector({
+            features: me.getFeatures()
+        });
+        me.layer = new ol.layer.Vector({
+            source: me.source,
+            style: me.style
+        });
+        // add layer to connected map, if available
+        if(me.map) {
+            me.map.addLayer(me.layer);
+        }
+
+        me.layerCreated = true;
+    }
+
+});

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -5,14 +5,16 @@
         dependencies = [
             'GeoExt/component/Map.test.js',
             'GeoExt/component/OverviewMap.test.js',
+            'GeoExt/data/model/Feature.test.js',
             'GeoExt/data/model/Object.test.js',
             'GeoExt/data/model/Layer.test.js',
             'GeoExt/data/store/Collection.test.js',
             'GeoExt/component/FeatureRenderer.test.js',
+            'GeoExt/data/store/Features.test.js',
             'GeoExt/data/LayerStore.test.js',
             'GeoExt/data/MapfishPrintProvider.test.js',
             'GeoExt/data/TreeStore.test.js',
-            'GeoExt/panel/Popup.test.js',
+            'GeoExt/panel/Popup.test.js'
         ],
         getScriptTag = global.TestUtil.getExternalScriptTag,
         dependencyCnt = dependencies.length,

--- a/test/spec/GeoExt/data/model/Feature.test.js
+++ b/test/spec/GeoExt/data/model/Feature.test.js
@@ -1,0 +1,43 @@
+Ext.Loader.syncRequire(['GeoExt.data.model.Feature']);
+
+describe('GeoExt.data.model.Feature', function() {
+
+    describe('basics', function() {
+        it('is defined', function() {
+            expect(GeoExt.data.model.Feature).not.to.be(undefined);
+        });
+    });
+
+    describe('constructor', function() {
+        var feat, rec;
+        beforeEach(function() {
+            feat = new ol.Feature();
+            rec = Ext.create('GeoExt.data.model.Feature', feat);
+        });
+        afterEach(function() {
+            rec = null;
+            feat = null;
+        });
+        it('constucts an instance of GeoExt.data.model.Feature', function() {
+            expect(rec).to.be.an(GeoExt.data.model.Feature);
+        });
+    });
+
+    describe('#getFeature', function() {
+        var feat, rec;
+        beforeEach(function() {
+            feat = new ol.Feature();
+            rec = Ext.create('GeoExt.data.model.Feature', feat);
+        });
+        afterEach(function() {
+            rec = null;
+            feat = null;
+        });
+        it('is defined', function() {
+            expect(rec.getFeature).not.to.be(undefined);
+        });
+        it('returnes the correct feature', function() {
+            expect(rec.getFeature()).to.be(feat);
+        });
+    });
+});

--- a/test/spec/GeoExt/data/store/Features.test.js
+++ b/test/spec/GeoExt/data/store/Features.test.js
@@ -1,0 +1,189 @@
+Ext.Loader.syncRequire(['GeoExt.data.store.Features']);
+
+describe('GeoExt.data.store.Features', function() {
+
+    describe('basics', function() {
+        it('is defined', function() {
+            expect(GeoExt.data.store.Features).not.to.be(undefined);
+        });
+    });
+
+    describe('constructor (no arguments)', function() {
+        var store;
+
+        beforeEach(function() {
+            store = Ext.create('GeoExt.data.store.Features');
+        });
+        afterEach(function() {
+            store = null;
+        });
+
+
+        it('constucts an instance of GeoExt.data.store.Features', function() {
+            expect(store).to.be.an(GeoExt.data.store.Features);
+        });
+        it('constucts an empty store', function() {
+            expect(store.count()).to.be(0);
+        });
+    });
+
+    describe('constructor (with features)', function() {
+        var coll,
+            store;
+        beforeEach(function() {
+            coll = new ol.Collection();
+            coll.push(new ol.Feature());
+            store = Ext.create('GeoExt.data.store.Features', {features: coll});
+        });
+        afterEach(function() {
+            store = null;
+            coll = null;
+        });
+
+        it('constucts an instance of GeoExt.data.store.Features', function() {
+            expect(store).to.be.an(GeoExt.data.store.Features);
+        });
+        it('constucts the store with the right amount of records', function() {
+            expect(store.count()).to.be(1);
+        });
+        it('constucts the store with the correct FC reference', function() {
+            expect(store.getFeatures()).to.be(coll);
+        });
+
+    });
+
+    describe('constructor (with layer)', function() {
+        var layer,
+            store;
+        beforeEach(function() {
+            layer = new ol.layer.Vector({
+                source: new ol.source.Vector({
+                    features: [new ol.Feature()]
+                })
+            });
+            store = Ext.create('GeoExt.data.store.Features', {layer: layer});
+        });
+        afterEach(function() {
+            store = null;
+            layer = null;
+        });
+
+        it('constucts an instance of GeoExt.data.store.Features', function() {
+            expect(store).to.be.an(GeoExt.data.store.Features);
+        });
+        it('constucts the store with the right amount of records', function() {
+            expect(store.count()).to.be(1);
+        });
+        it('constucts the store with the correct layer reference', function() {
+            expect(store.getLayer()).to.be(layer);
+        });
+
+    });
+
+    describe('#getFeatures', function() {
+        var coll,
+            store;
+        beforeEach(function() {
+            coll = new ol.Collection();
+            coll.push(new ol.Feature());
+            store = Ext.create('GeoExt.data.store.Features', {features: coll});
+        });
+        afterEach(function() {
+            store = null;
+            coll = null;
+        });
+
+        it('is defined', function() {
+            expect(store.getFeatures).not.to.be(undefined);
+        });
+        it('returns the right ol.Collection reference', function() {
+            expect(store.getFeatures()).to.be(coll);
+        });
+    });
+
+    describe('config option "createLayer" without a map', function() {
+        var coll,
+            store,
+            map,
+            div;
+        beforeEach(function() {
+            div = document.createElement('div');
+            document.body.appendChild(div);
+            var source = new ol.source.MapQuest({layer: 'sat'});
+            var layer = new ol.layer.Tile({
+                source: source
+            });
+            map = new ol.Map({
+                target: div,
+                layers: [layer],
+                view: new ol.View({
+                    center: [0, 0],
+                    zoom: 2
+                })
+            });
+            coll = new ol.Collection();
+            coll.push(new ol.Feature());
+            store = Ext.create('GeoExt.data.store.Features', {
+                features: coll,
+                map: map,
+                createLayer: true
+            });
+        });
+        afterEach(function() {
+            store = null;
+            coll = null;
+            map = null;
+            document.body.removeChild(div);
+        });
+
+        it('creates a new vector layer object', function() {
+            expect(store.getLayer()).to.be.an(ol.layer.Vector);
+        });
+        it('creates a layer with correct amount of features', function() {
+            expect(store.getLayer().getSource().getFeatures().length).to.be(store.count());
+        });
+    });
+
+    describe('config option "createLayer"', function() {
+        var coll,
+            store,
+            map,
+            div;
+        beforeEach(function() {
+            div = document.createElement('div');
+            document.body.appendChild(div);
+            var source = new ol.source.MapQuest({layer: 'sat'});
+            var layer = new ol.layer.Tile({
+                source: source
+            });
+            map = new ol.Map({
+                target: div,
+                layers: [layer],
+                view: new ol.View({
+                    center: [0, 0],
+                    zoom: 2
+                })
+            });
+            coll = new ol.Collection();
+            coll.push(new ol.Feature());
+            store = Ext.create('GeoExt.data.store.Features', {
+                features: coll,
+                map: map,
+                createLayer: true
+            });
+        });
+        afterEach(function() {
+            store = null;
+            coll = null;
+            map = null;
+            document.body.removeChild(div);
+        });
+
+        it('creates a new layer on the given map', function() {
+            expect(map.getLayers().getLength()).to.be(2);
+        });
+        it('creates the layer which is retrievable via #getLayer', function() {
+            expect(store.getLayer()).to.be(map.getLayers().item(1));
+        });
+    });
+});


### PR DESCRIPTION
This introduces a simple FeatureStore class (incl. the FeatureModel) in order to bind OpenLayers feature objects to the data management of ExtJS.
This also provides an example showing the different ways to create a grid with a FeatureStore as data container.