### PR TITLE
Changes store behaviour when adding layer to map

### DIFF
--- a/src/data/TreeStore.js
+++ b/src/data/TreeStore.js
@@ -135,7 +135,17 @@ Ext.define('GeoExt.data.TreeStore', {
      *  @private
      */
     onLayerCollectionChanged: function(){
-        this.getRootNode().removeAll();
-        this.addLayerNode(this.getRootNode(), this.getLayerGroup());
+        var me = this;
+        me.getRootNode().removeAll();
+        if(me.showLayerGroupNode) {
+            me.addLayerNode(me.getRootNode(), me.getLayerGroup());
+        } else {
+            var collection = me.getLayerGroup().getLayers();
+            collection.once('remove', me.onLayerCollectionChanged, me);
+            collection.once('add', me.onLayerCollectionChanged, me);
+            collection.forEach(function(layer){
+                me.addLayerNode(me.getRootNode(), layer);
+            });
+        }
     }
 });

--- a/test/spec/GeoExt/data/TreeStore.test.js
+++ b/test/spec/GeoExt/data/TreeStore.test.js
@@ -127,7 +127,51 @@ describe('GeoExt.data.TreeStore', function() {
             document.body.removeChild(div);
         });
 
-        it('sets add/remove eventlisteners for ol.Collections', function() {
+        it('sets add/remove eventlisteners for ol.Collections (hidden LayerGroupNode)', function() {
+            treeStore = Ext.create('GeoExt.data.TreeStore', {
+                layerGroup: olMap.getLayerGroup()
+            });
+
+            Ext.create('GeoExt.tree.Panel', {
+                title: 'GeoExt.tree.Panel Example',
+                store: treeStore,
+                rootVisible: false,
+                flex: 1,
+                border: false
+            });
+
+
+            var layer2 = new ol.layer.Tile({
+                source: new ol.source.MapQuest({
+                    layer: 'hyb'
+                }),
+                name: 'LAYERZWO'
+            });
+            mapComponent.addLayer(layer2);
+
+            var treeNode = treeStore.getRootNode().getChildAt(1);
+            expect(treeNode.get('text')).to.be(layer2.get('name'));
+
+            mapComponent.removeLayer(layer);
+            treeNode = treeStore.getRootNode().getChildAt(0);
+            expect(treeNode.get('text')).to.be(layer2.get('name'));
+        });
+
+        it('sets add/remove eventlisteners for ol.Collections (visible LayerGroupNode)', function() {
+            treeStore = Ext.create('GeoExt.data.TreeStore', {
+                layerGroup: olMap.getLayerGroup(),
+                showLayerGroupNode: true
+            });
+
+            Ext.create('GeoExt.tree.Panel', {
+                title: 'GeoExt.tree.Panel Example',
+                store: treeStore,
+                rootVisible: false,
+                flex: 1,
+                border: false
+            });
+
+
             var layer2 = new ol.layer.Tile({
                     source: new ol.source.MapQuest({
                         layer: 'hyb'
@@ -143,5 +187,7 @@ describe('GeoExt.data.TreeStore', function() {
             treeNode = treeStore.getRootNode().getChildAt(0).getChildAt(0);
             expect(treeNode.get('text')).to.be(layer2.get('name'));
         });
+
+
     });
 });


### PR DESCRIPTION
- When adding a layer to the map the state of showLayerGroupNode will be
  respected on rebuilding the treestore.
- Added the related test.