### PR TITLE
Harmonize store naming in data package

### DIFF
--- a/examples/tree/panel.js
+++ b/examples/tree/panel.js
@@ -1,7 +1,7 @@
 Ext.require([
     'GeoExt.component.Map',
     'GeoExt.tree.Panel',
-    'GeoExt.data.TreeStore'
+    'GeoExt.data.store.Tree'
 ]);
 
 var mapComponent,
@@ -60,7 +60,7 @@ Ext.application({
             items: [mapComponent]
         });
 
-        treeStore = Ext.create('GeoExt.data.TreeStore', {
+        treeStore = Ext.create('GeoExt.data.store.Tree', {
             layerGroup: olMap.getLayerGroup(),
             showLayerGroupNode: true
         });

--- a/examples/tree/tree-legend-simple.js
+++ b/examples/tree/tree-legend-simple.js
@@ -1,7 +1,7 @@
 Ext.require([
     'GeoExt.component.Map',
     'GeoExt.tree.Panel',
-    'GeoExt.data.TreeStore'
+    'GeoExt.data.store.Tree'
 ]);
 
 /**
@@ -133,7 +133,7 @@ Ext.application({
             items: [mapComponent]
         });
 
-        treeStore = Ext.create('GeoExt.data.TreeStore', {
+        treeStore = Ext.create('GeoExt.data.store.Tree', {
             layerGroup: olMap.getLayerGroup()
         });
 
@@ -162,7 +162,7 @@ Ext.application({
             }
         });
 
-        treeStore2 = Ext.create('GeoExt.data.TreeStore', {
+        treeStore2 = Ext.create('GeoExt.data.store.Tree', {
             layerGroup: olMap.getLayerGroup()
         });
 

--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -42,7 +42,7 @@ Ext.define("GeoExt.component.Map", {
     ],
 
     requires: [
-        'GeoExt.data.LayerStore'
+        'GeoExt.data.store.Layer'
     ],
 
     /**
@@ -123,7 +123,7 @@ Ext.define("GeoExt.component.Map", {
     mapRendered: false,
 
     /**
-     * @property {GeoExt.data.LayerStore} layerStore
+     * @property {GeoExt.data.store.Layer} layerStore
      * @private
      */
     layerStore: null,
@@ -161,7 +161,7 @@ Ext.define("GeoExt.component.Map", {
             me.setMap(olMap);
         }
 
-        me.layerStore = Ext.create('GeoExt.data.LayerStore', {
+        me.layerStore = Ext.create('GeoExt.data.store.Layer', {
             storeId: me.getId() + "-store",
             map: me.getMap()
         });
@@ -409,8 +409,8 @@ Ext.define("GeoExt.component.Map", {
     },
 
     /**
-     * Returns the GeoExt.data.LayerStore
-     * @return GeoExt.data.LayerStore
+     * Returns the GeoExt.data.store.Layer
+     * @return GeoExt.data.store.Layer
      */
     getStore: function(){
         return this.layerStore;

--- a/src/data/MapfishPrintProvider.js
+++ b/src/data/MapfishPrintProvider.js
@@ -42,7 +42,7 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
          * Will return an array of serialized layers for mapfish print servlet
          * v3.0.
          *
-         * @param {GeoExt.data.LayerStore, {ol.Collection.<ol.layer.Base>},
+         * @param {GeoExt.data.store.Layer, {ol.Collection.<ol.layer.Base>},
          * Array<ol.layer.Base>}
          *
          * @static
@@ -51,7 +51,7 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
             var serializedLayers = [];
             var inputLayers = [];
 
-            if(layers instanceof GeoExt.data.LayerStore){
+            if(layers instanceof GeoExt.data.store.Layer){
                 layers.each(function(layerRec) {
                     var layer = layerRec.getOlLayer();
                     inputLayers.push(layer);

--- a/src/data/store/Layer.js
+++ b/src/data/store/Layer.js
@@ -17,11 +17,12 @@
  * A store that synchronizes a layers array of an OpenLayers.Map with a
  * layer store holding {@link GeoExt.data.mode.layer.Base} instances.
  *
- * @class GeoExt.data.LayerStore
+ * @class GeoExt.data.store.Layer
  */
-Ext.define('GeoExt.data.LayerStore', {
+Ext.define('GeoExt.data.store.Layer', {
     extend: 'Ext.data.Store',
     requires: ['GeoExt.data.model.Layer'],
+    alternateClassName: ['GeoExt.data.LayerStore'],
     model: 'GeoExt.data.model.Layer',
 
     config: {

--- a/src/data/store/Tree.js
+++ b/src/data/store/Tree.js
@@ -18,8 +18,10 @@
  * A store that is synchronized with a GeoExt.data.LayerStore. It will be used
  * by a GeoExt.tree.Panel.
  */
-Ext.define('GeoExt.data.TreeStore', {
+Ext.define('GeoExt.data.store.Tree', {
     extend: 'Ext.data.TreeStore',
+
+    alternateClassName: ['GeoExt.data.TreeStore'],
 
     model: 'GeoExt.data.model.LayerTreeNode',
 

--- a/src/data/store/Tree.js
+++ b/src/data/store/Tree.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * A store that is synchronized with a GeoExt.data.LayerStore. It will be used
+ * A store that is synchronized with a GeoExt.data.store.Layer. It will be used
  * by a GeoExt.tree.Panel.
  */
 Ext.define('GeoExt.data.store.Tree', {

--- a/src/tree/Panel.js
+++ b/src/tree/Panel.js
@@ -36,7 +36,7 @@
  *         renderTo: 'mapDiv' // ID of the target <div>. Optional.
  *     });
  *
- *     var treeStore = Ext.create('GeoExt.data.TreeStore', {
+ *     var treeStore = Ext.create('GeoExt.data.store.Tree', {
  *         model: 'GeoExt.data.TreeModel',
  *         layerStore: mapPanel.getStore()
  *     });

--- a/test/spec/GeoExt/data/LayerStore.test.js
+++ b/test/spec/GeoExt/data/LayerStore.test.js
@@ -1,10 +1,10 @@
-Ext.Loader.syncRequire(['GeoExt.data.LayerStore']);
+Ext.Loader.syncRequire(['GeoExt.data.store.Layer']);
 
-describe('GeoExt.data.LayerStore', function() {
+describe('GeoExt.data.store.Layer', function() {
 
     describe('basics', function(){
         it('is defined', function(){
-            expect(GeoExt.data.LayerStore).not.to.be(undefined);
+            expect(GeoExt.data.store.Layer).not.to.be(undefined);
         });
     });
 });

--- a/test/spec/GeoExt/data/TreeStore.test.js
+++ b/test/spec/GeoExt/data/TreeStore.test.js
@@ -1,9 +1,9 @@
-Ext.Loader.syncRequire(['GeoExt.data.TreeStore', 'GeoExt.tree.Panel']);
+Ext.Loader.syncRequire(['GeoExt.data.store.Tree', 'GeoExt.tree.Panel']);
 
-describe('GeoExt.data.TreeStore', function() {
+describe('GeoExt.data.store.Tree', function() {
     describe('basics', function(){
         it('is defined', function(){
-            expect(GeoExt.data.TreeStore).not.to.be(undefined);
+            expect(GeoExt.data.store.Tree).not.to.be(undefined);
         });
     });
 
@@ -36,7 +36,7 @@ describe('GeoExt.data.TreeStore', function() {
                 map: olMap
             });
 
-            treeStore = Ext.create('GeoExt.data.TreeStore', {
+            treeStore = Ext.create('GeoExt.data.store.Tree', {
                 layerGroup: olMap.getLayerGroup()
             });
 
@@ -54,14 +54,14 @@ describe('GeoExt.data.TreeStore', function() {
         });
 
         it('can be created with ol.Map.getLayerGroup()', function() {
-            treeStore = Ext.create('GeoExt.data.TreeStore', {
+            treeStore = Ext.create('GeoExt.data.store.Tree', {
                 layerStore: olMap.getLayerGroup()
             });
-            expect(treeStore).to.be.a(GeoExt.data.TreeStore);
+            expect(treeStore).to.be.a(GeoExt.data.store.Tree);
         });
 
         it('will react to the showLayerGroupNode property', function() {
-            treeStore = Ext.create('GeoExt.data.TreeStore', {
+            treeStore = Ext.create('GeoExt.data.store.Tree', {
                 layerGroup: olMap.getLayerGroup(),
                 showLayerGroupNode: true
             });
@@ -110,7 +110,7 @@ describe('GeoExt.data.TreeStore', function() {
                 map: olMap
             });
 
-            treeStore = Ext.create('GeoExt.data.TreeStore', {
+            treeStore = Ext.create('GeoExt.data.store.Tree', {
                 layerGroup: olMap.getLayerGroup()
             });
 
@@ -128,7 +128,7 @@ describe('GeoExt.data.TreeStore', function() {
         });
 
         it('sets add/remove eventlisteners for ol.Collections (hidden LayerGroupNode)', function() {
-            treeStore = Ext.create('GeoExt.data.TreeStore', {
+            treeStore = Ext.create('GeoExt.data.store.Tree', {
                 layerGroup: olMap.getLayerGroup()
             });
 
@@ -158,7 +158,7 @@ describe('GeoExt.data.TreeStore', function() {
         });
 
         it('sets add/remove eventlisteners for ol.Collections (visible LayerGroupNode)', function() {
-            treeStore = Ext.create('GeoExt.data.TreeStore', {
+            treeStore = Ext.create('GeoExt.data.store.Tree', {
                 layerGroup: olMap.getLayerGroup(),
                 showLayerGroupNode: true
             });


### PR DESCRIPTION
This harmonizes the naming of the data package. Therefore this PR renames ``GeoExt.data.TreeStore`` to ``GeoExt.data.store.Tree`` and ``GeoExt.data.LayerStore`` to ``GeoExt.data.store.Layer``.
The old names are preserved as 'alternateClassName' to have a kind of backwards compatibility.