### PR TITLE
reversing the way we add layers in treestore

### DIFF
--- a/src/data/store/Tree.js
+++ b/src/data/store/Tree.js
@@ -79,9 +79,9 @@ Ext.define('GeoExt.data.store.Tree', {
             layer.getLayers().once('remove', this.onLayerCollectionChanged, this);
             layer.text = layer.get(me.getTextProperty());
             var folderNode = node.appendChild(layer);
-            layer.getLayers().forEach(function(childLayer){
+            Ext.each(layer.getLayers().getArray(), function(childLayer) {
                 me.addLayerNode(folderNode, childLayer);
-            });
+            }, me, true);
         } else {
             layer.text = layer.get(me.getTextProperty());
             node.appendChild(layer);
@@ -104,9 +104,9 @@ Ext.define('GeoExt.data.store.Tree', {
                 var collection = me.layerGroup.getLayers();
                 collection.once('remove', me.onLayerCollectionChanged, me);
                 collection.once('add', me.onLayerCollectionChanged, me);
-                collection.forEach(function(layer){
+                Ext.each(collection.getArray(), function(layer) {
                     me.addLayerNode(node, layer);
-                });
+                }, me, true);
             }
         }
     },
@@ -146,9 +146,9 @@ Ext.define('GeoExt.data.store.Tree', {
             var collection = me.getLayerGroup().getLayers();
             collection.once('remove', me.onLayerCollectionChanged, me);
             collection.once('add', me.onLayerCollectionChanged, me);
-            collection.forEach(function(layer){
+            Ext.each(collection.getArray(), function(layer) {
                 me.addLayerNode(me.getRootNode(), layer);
-            });
+            }, me, true);
         }
     }
 });

--- a/src/data/store/Tree.js
+++ b/src/data/store/Tree.js
@@ -46,6 +46,14 @@ Ext.define('GeoExt.data.store.Tree', {
     showLayerGroupNode: false,
 
     /**
+     * Defines if the order of the layers added to the store will be
+     * reversed. The default behaviour and what most users expect is
+     * that mapLayers on top are also on top in the tree.
+     * @property {boolean}
+     */
+    inverseLayerOrder: true,
+
+    /**
      * @cfg
      * @inheritdoc Ext.data.TreeStore
      */
@@ -81,7 +89,7 @@ Ext.define('GeoExt.data.store.Tree', {
             var folderNode = node.appendChild(layer);
             Ext.each(layer.getLayers().getArray(), function(childLayer) {
                 me.addLayerNode(folderNode, childLayer);
-            }, me, true);
+            }, me, me.inverseLayerOrder);
         } else {
             layer.text = layer.get(me.getTextProperty());
             node.appendChild(layer);
@@ -106,7 +114,7 @@ Ext.define('GeoExt.data.store.Tree', {
                 collection.once('add', me.onLayerCollectionChanged, me);
                 Ext.each(collection.getArray(), function(layer) {
                     me.addLayerNode(node, layer);
-                }, me, true);
+                }, me, me.inverseLayerOrder);
             }
         }
     },
@@ -148,7 +156,7 @@ Ext.define('GeoExt.data.store.Tree', {
             collection.once('add', me.onLayerCollectionChanged, me);
             Ext.each(collection.getArray(), function(layer) {
                 me.addLayerNode(me.getRootNode(), layer);
-            }, me, true);
+            }, me, me.inverseLayerOrder);
         }
     }
 });

--- a/test/spec/GeoExt/data/TreeStore.test.js
+++ b/test/spec/GeoExt/data/TreeStore.test.js
@@ -149,7 +149,7 @@ describe('GeoExt.data.store.Tree', function() {
             });
             mapComponent.addLayer(layer2);
 
-            var treeNode = treeStore.getRootNode().getChildAt(1);
+            var treeNode = treeStore.getRootNode().getChildAt(0);
             expect(treeNode.get('text')).to.be(layer2.get('name'));
 
             mapComponent.removeLayer(layer);
@@ -180,7 +180,7 @@ describe('GeoExt.data.store.Tree', function() {
                 });
             mapComponent.addLayer(layer2);
 
-            var treeNode = treeStore.getRootNode().getChildAt(0).getChildAt(1);
+            var treeNode = treeStore.getRootNode().getChildAt(0).getChildAt(0);
             expect(treeNode.get('text')).to.be(layer2.get('name'));
 
             mapComponent.removeLayer(layer);


### PR DESCRIPTION
Ok, this PR needs a little explanation:
I reversed the order the layers get added in the treestore.
The background is the following: The ol3-layer-collection contains the layers in the order they have been added.
If you add a layer at runtime to the map, it will get appended to the end of the collection / array.
In order to show this newly added layer on top in a layertree, you will need to reverse the collection.
I solved this by using 'Ext.each' with the 'reverse' flag set to true, so the code does the same as before but just in the reversed order.
This way the layertree shows the first / oldest added layers at the bottom, the newly or later added laters get shown on top.

Have a look at the layertree example to see the current problem:
http://rawgit.com/geoext/geoext3/master/examples/tree/panel.html

The layer at the bottom gets shown on top of the map.
I suspect this is exactly the wrong behaviour and this fix addresses this issue.