### PR TITLE
Introduce a SymbolizerColumn class

### DIFF
--- a/examples/features/grid.js
+++ b/examples/features/grid.js
@@ -3,7 +3,8 @@ Ext.require([
     'Ext.panel.Panel',
     'Ext.grid.Panel',
     'GeoExt.component.Map',
-    'GeoExt.data.store.Features'
+    'GeoExt.data.store.Features',
+    'GeoExt.grid.column.Symbolizer'
 ]);
 
 var olMap, gridWest, gridEast, featStore1, featStore2;
@@ -239,6 +240,7 @@ Ext.application({
             region: 'west',
             store: featStore1,
             columns: [
+                {xtype: 'gx_symbolizercolumn', width: 40},
                 {text: 'Name', dataIndex: 'city', flex: 1},
                 {
                     text: 'Population',
@@ -258,7 +260,8 @@ Ext.application({
             region: 'east',
             store: featStore2,
             columns: [
-                { text: 'Name', dataIndex: 'city', flex: 2}
+                {xtype: 'gx_symbolizercolumn', width: 40},
+                {text: 'Name', dataIndex: 'city', flex: 2}
             ],
             width: 250,
             listeners: {

--- a/src/grid/column/Symbolizer.js
+++ b/src/grid/column/Symbolizer.js
@@ -1,0 +1,60 @@
+/**
+ * An Ext.grid.column.Column pre-configured with a GeoExt.FeatureRenderer.
+ * This can be used to display the rendering style of a vector feature in a
+ * grid column.
+ */
+Ext.define('GeoExt.grid.column.Symbolizer', {
+    extend: 'Ext.grid.column.Column',
+    alternateClassName: 'GeoExt.grid.SymbolizerColumn',
+    alias: ['widget.gx_symbolizercolumn'],
+    requires: ['GeoExt.component.FeatureRenderer'],
+
+    /**
+     * The default renderer method for ol.Feature objects.
+     */
+    defaultRenderer: function(value, meta, record) {
+        var me = this,
+            id = Ext.id();
+        if (record) {
+            var feature = record.olObject,
+                symbolType = "Line",
+                geometry = feature.getGeometry();
+            if (geometry instanceof ol.geom.Point ||
+                    geometry instanceof ol.geom.MultiPoint) {
+                symbolType = "Point";
+            }
+            else if (geometry instanceof ol.geom.Polygon ||
+                        geometry instanceof ol.geom.MultiPolygon) {
+                symbolType = "Polygon";
+            }
+
+            var task = new Ext.util.DelayedTask(function() {
+                var ct = Ext.get(id);
+                // ct for old field may not exist any more during a grid update
+                if (ct) {
+                  Ext.create('GeoExt.component.FeatureRenderer', {
+                      renderTo: ct,
+                      symbolizers: me.determineStyle(record),
+                      symbolType: symbolType
+                  });
+                }
+            });
+            task.delay(0);
+        }
+        meta.css = "gx-grid-symbolizercol";
+        return Ext.String.format('<div id="{0}"></div>', id);
+    },
+
+    /**
+     * Determines the style for the given feature record.
+     *
+     * @private
+     * @param  {GeoExt.data.model.Feature} record A feature record to get the styler for
+     * @return {ol.style.Style[]|ol.style.Style} the style(s) applied to the given feature record
+     */
+    determineStyle: function(record) {
+        var feature = record.olObject;
+        return feature.getStyle() || feature.getStyleFunction() ||
+            (record.store ? record.store.layer.getStyle() : null);
+    }
+});

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -14,6 +14,7 @@
             'GeoExt/data/store/Tree.test.js',
             'GeoExt/data/LayerStore.test.js',
             'GeoExt/data/MapfishPrintProvider.test.js',
+            'GeoExt/grid/column/Symbolizer.test.js',
             'GeoExt/panel/Popup.test.js',
             'GeoExt/tree/Panel.test.js'
         ],

--- a/test/spec/GeoExt/grid/column/Symbolizer.test.js
+++ b/test/spec/GeoExt/grid/column/Symbolizer.test.js
@@ -1,0 +1,18 @@
+Ext.Loader.syncRequire(['GeoExt.grid.column.Symbolizer']);
+
+describe('GeoExt.grid.column.Symbolizer', function() {
+
+    describe('basics', function() {
+        it('GeoExt.grid.column.Symbolizer is defined', function() {
+            expect(GeoExt.grid.column.Symbolizer).not.to.be(undefined);
+        });
+
+        describe('constructor', function(){
+            it('can be called without arguments', function(){
+                var inst = Ext.create('GeoExt.grid.column.Symbolizer');
+                expect(inst).to.be.an(GeoExt.grid.column.Symbolizer);
+            });
+        });
+    });
+
+});

--- a/test/spec/GeoExt/grid/column/Symbolizer.test.js
+++ b/test/spec/GeoExt/grid/column/Symbolizer.test.js
@@ -3,16 +3,94 @@ Ext.Loader.syncRequire(['GeoExt.grid.column.Symbolizer']);
 describe('GeoExt.grid.column.Symbolizer', function() {
 
     describe('basics', function() {
+
         it('GeoExt.grid.column.Symbolizer is defined', function() {
             expect(GeoExt.grid.column.Symbolizer).not.to.be(undefined);
         });
 
-        describe('constructor', function(){
+        describe('constructor', function() {
+            var column;
+            afterEach(function() {
+                column.destroy();
+            });
             it('can be called without arguments', function(){
-                var inst = Ext.create('GeoExt.grid.column.Symbolizer');
-                expect(inst).to.be.an(GeoExt.grid.column.Symbolizer);
+                column = Ext.create('GeoExt.grid.column.Symbolizer');
+                expect(column).to.be.an(GeoExt.grid.column.Symbolizer);
             });
         });
     });
 
+
+    describe('column', function() {
+        var meta = {},
+            column;
+
+        beforeEach(function(){
+            column = Ext.create('GeoExt.grid.column.Symbolizer');
+        });
+        afterEach(function(){
+            column.destroy();
+        });
+
+        it('has the correct CSS class', function() {
+            column.renderer(null, meta);
+            expect(meta.css).equal("gx-grid-symbolizercol");
+        });
+        it('has the correct amount of symbolizer instances', function() {
+            expect(Ext.ComponentQuery.query('gx_symbolizercolumn').length).to.be(1);
+        });
+
+    });
+
+    describe('feature style', function() {
+        var column, detectedStyle, feat, rec,
+            style = new ol.style.Style({
+                fill: new ol.style.Fill({color: 'red'})
+            });
+        beforeEach(function() {
+            feat = new ol.Feature();
+            column = Ext.create('GeoExt.grid.column.Symbolizer');
+            rec = Ext.create('GeoExt.data.model.Feature', feat);
+        });
+        afterEach(function() {
+            column.destroy();
+            rec = null;
+            feat = null;
+            detectedStyle = null;
+        });
+
+        it('is detected correctly from a feature (by style object)', function() {
+            feat.setStyle(style);
+
+            detectedStyle = column.determineStyle(rec);
+            expect(detectedStyle).to.be(style);
+        });
+
+        it('is detected correctly from a feature (by style function)', function() {
+            var styleFn = function() {
+                return style;
+            };
+            feat.setStyle(styleFn);
+
+            detectedStyle = column.determineStyle(rec);
+            expect(detectedStyle).to.be(styleFn);
+        });
+
+        it('is detected correctly from an underlying layer', function() {
+            var vectorLayer = new ol.layer.Vector({
+                source: new ol.source.Vector({
+                    features: [feat]
+                }),
+                style: style
+            });
+            // create feature store by passing a vector layer
+            var featStore = Ext.create('GeoExt.data.store.Features', {
+                layer: vectorLayer
+            });
+            // overwrite predefined record
+            rec = featStore.first();
+            detectedStyle = column.determineStyle(rec);
+            expect(detectedStyle).to.be(style);
+        });
+    });
 });


### PR DESCRIPTION
This adds a class providing a SymbolizerColumn in order to visualize the map style of vector features in a grid column.
The example for FeatureGrids is adapted to show such SymbolizerColumns.
Basic tests are also added with by this PR.