### PR TITLE
FeatureStore enhancements

### DIFF
--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -146,6 +146,9 @@ Ext.define('GeoExt.data.store.Features', {
      */
     destroy: function() {
         var me = this;
+
+        me.unbindLayerEvents();
+
         if (me.map && me.layerCreated === true) {
             me.map.removeLayer(me.layer);
         }
@@ -189,6 +192,20 @@ Ext.define('GeoExt.data.store.Features', {
             // bind feature add / remove events of the layer
             me.layer.getSource().on('addfeature', me.onFeaturesAdded, me);
             me.layer.getSource().on('removefeature', me.onFeaturesRemoved, me);
+        }
+    },
+
+    /**
+     * Unbind the 'addfeature' and 'removefeature' events of the #layer.
+     *
+     *  @private
+     */
+    unbindLayerEvents: function () {
+        var me = this;
+        if(me.layer && me.layer.getSource() instanceof ol.source.Vector) {
+            // unbind feature add / remove events of the layer
+            me.layer.getSource().un('addfeature', me.onFeaturesAdded, me);
+            me.layer.getSource().un('removefeature', me.onFeaturesRemoved, me);
         }
     },
 

--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -111,6 +111,8 @@ Ext.define('GeoExt.data.store.Features', {
         if (me.createLayer === true && !me.layer) {
             me.drawFeaturesOnMap();
         }
+
+        me.bindLayerEvents();
     },
 
     /**
@@ -173,6 +175,49 @@ Ext.define('GeoExt.data.store.Features', {
         }
 
         me.layerCreated = true;
+    },
+
+    /**
+     * Bind the 'addfeature' and 'removefeature' events to sync the features
+     * in #layer with this store.
+     *
+     *  @private
+     */
+    bindLayerEvents: function () {
+        var me = this;
+        if(me.layer && me.layer.getSource() instanceof ol.source.Vector) {
+            // bind feature add / remove events of the layer
+            me.layer.getSource().on('addfeature', me.onFeaturesAdded, me);
+            me.layer.getSource().on('removefeature', me.onFeaturesRemoved, me);
+        }
+    },
+
+    /**
+     * Handler for #layer 'addfeature' event
+     *
+     * @param  {Object} evt the event object of OpenLayers
+     * @private
+     */
+    onFeaturesAdded: function (evt) {
+        this.add(evt.feature);
+    },
+
+    /**
+     * Handler for #layer 'removefeature' event
+     *
+     * @param  {Object} evt the event object of OpenLayers
+     * @private
+     */
+    onFeaturesRemoved: function (evt) {
+        var me = this;
+        if (!me._removing) {
+            var record = me.getByFeature(evt.feature);
+            if (record) {
+                me._removing = true;
+                me.remove(record);
+                delete me._removing;
+            }
+        }
     }
 
 });

--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -124,6 +124,18 @@ Ext.define('GeoExt.data.store.Features', {
     },
 
     /**
+     * Returns the record corresponding to a feature.
+     *
+     * @param  {ol.Feature} feature An ol.Feature object to get the record for
+     * @return {Ext.data.Model} The model instance corresponding to the feature
+     */
+    getByFeature: function(feature) {
+        return this.getAt(this.findBy(function(record) {
+            return record.getFeature() === feature;
+        }));
+    },
+
+    /**
      * @protected
      *
      * Overwrites the destroy function to ensure the #layer is removed from

--- a/test/spec/GeoExt/data/store/Features.test.js
+++ b/test/spec/GeoExt/data/store/Features.test.js
@@ -101,6 +101,30 @@ describe('GeoExt.data.store.Features', function() {
         });
     });
 
+    describe('#getByFeature', function() {
+        var coll,
+            store,
+            feature;
+        beforeEach(function() {
+            feature = new ol.Feature();
+            coll = new ol.Collection();
+            coll.push(feature);
+            store = Ext.create('GeoExt.data.store.Features', {features: coll});
+        });
+        afterEach(function() {
+            store = null;
+            coll = null;
+            feature = null;
+        });
+
+        it('is defined', function() {
+            expect(store.getByFeature).not.to.be(undefined);
+        });
+        it('returns the right feature record', function() {
+            expect(store.getByFeature(feature).getFeature()).to.be.equal(feature);
+        });
+    });
+
     describe('config option "createLayer" without a map', function() {
         var coll,
             store,
@@ -186,4 +210,5 @@ describe('GeoExt.data.store.Features', function() {
             expect(store.getLayer()).to.be(map.getLayers().item(1));
         });
     });
+
 });

--- a/test/spec/GeoExt/data/store/Features.test.js
+++ b/test/spec/GeoExt/data/store/Features.test.js
@@ -123,6 +123,9 @@ describe('GeoExt.data.store.Features', function() {
         it('returns the right feature record', function() {
             expect(store.getByFeature(feature).getFeature()).to.be.equal(feature);
         });
+        it('returns null in case of passing a non-managed feature', function() {
+            expect(store.getByFeature(new ol.Feature())).to.be(null);
+        });
     });
 
     describe('config option "createLayer" without a map', function() {

--- a/test/spec/GeoExt/data/store/Features.test.js
+++ b/test/spec/GeoExt/data/store/Features.test.js
@@ -245,4 +245,40 @@ describe('GeoExt.data.store.Features', function() {
         });
     });
 
+    describe('Unbinding events on vector layer', function() {
+        var layer,
+            store;
+        beforeEach(function() {
+            layer = new ol.layer.Vector({
+                source: new ol.source.Vector({
+                    features: [new ol.Feature()]
+                })
+            });
+            store = Ext.create('GeoExt.data.store.Features', {
+                layer: layer
+            });
+        });
+        afterEach(function() {
+            store = null;
+            layer = null;
+        });
+
+        it('is done correctly by function "unbindLayerEvents"', function() {
+            store.unbindLayerEvents();
+            layer.getSource().addFeatures([new ol.Feature()]);
+            expect(store.getCount()).to.be(1);
+            layer.getSource().removeFeature(layer.getSource().getFeatures()[0]);
+            expect(store.getCount()).to.be(1);
+        });
+        it('function "unbindLayerEvents" is called before store is destroyed', function() {
+            var i = 0;
+            // overwrite to see if the function is called on store destruction
+            store.unbindLayerEvents = function () {
+                i++;
+            };
+            store.destroy();
+            expect(i).to.be.equal(1);
+        });
+    });
+
 });

--- a/test/spec/GeoExt/data/store/Features.test.js
+++ b/test/spec/GeoExt/data/store/Features.test.js
@@ -211,4 +211,35 @@ describe('GeoExt.data.store.Features', function() {
         });
     });
 
+    describe('Event binding on vector layer', function() {
+        var layer,
+            store,
+            feature;
+        beforeEach(function() {
+            feature = new ol.Feature({id: 'foo'});
+            layer = new ol.layer.Vector({
+                source: new ol.source.Vector({
+                    features: [feature]
+                })
+            });
+            store = Ext.create('GeoExt.data.store.Features', {
+                layer: layer
+            });
+        });
+        afterEach(function() {
+            store = null;
+            layer = null;
+            feature = null;
+        });
+
+        it('is done correctly for "addfeature"', function() {
+            layer.getSource().addFeatures([new ol.Feature()]);
+            expect(store.getCount()).to.be(layer.getSource().getFeatures().length);
+        });
+        it('is done correctly for "removefeature"', function() {
+            layer.getSource().removeFeature(layer.getSource().getFeatures()[0]);
+            expect(store.getCount()).to.be(layer.getSource().getFeatures().length);
+        });
+    });
+
 });


### PR DESCRIPTION
This PR does two major things (both related to the ``GeoExt.data.store.Features`` class):

  - Add a new function ``getByFeature``, which returns the corresponding record for the given feature
  - Bind the store to the ``addfeature`` and ``removefeature`` events of the (possibly) underlying OpenLayers vector layer

Tests are also included. 

Please Review.