### PR TITLE
Move eslint config for tests to test/ folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "test": "phantomjs --ssl-protocol=any --ignore-ssl-errors=true ./node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee test/index.html",
     "test:watch": "watch 'npm test' src/ test/",
-    "lint-js": "eslint src/ examples/ && eslint -c .test.eslintrc test/spec/",
+    "lint-js": "eslint src/ examples/ && eslint -c test/.eslintrc test/spec/",
     "livereload": "live-reload --port 9091 src/ examples/ test/",
     "save-coverage": "phantomjs --ssl-protocol=any --ignore-ssl-errors=true ./node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee test/index.html spec '{\"hooks\": \"../../../test/phantom_hooks.js\"}'",
     "clean-coverage": "rm -rf src_instrumented src_old coverage",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -7,7 +7,7 @@
         "expect": false,
         "it": false,
         "sinon": false,
-        
+
         "Ext": false,
         "GeoExt": false,
         "ol": false
@@ -18,4 +18,3 @@
         "strict": "never"
     }
 }
-

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -1,6 +1,6 @@
 /*global document*/
 /*jshint camelcase:true, curly:true, eqeqeq:true, latedef:true, newcap:true, noarg:true, undef:true, trailing:true, maxlen:80 */
-;(function(doc, global){
+(function(doc, global){
     var specPath = './spec/',
         dependencies = [
             'GeoExt/component/FeatureRenderer.test.js',


### PR DESCRIPTION
This doesn't change the functionality, but helps editors (namely atom)
pick up the specific 0eslint configuration when editing files in the
test folder.