### PR TITLE
Add missing require for serializer

### DIFF
--- a/examples/print/basic-mapfish.js
+++ b/examples/print/basic-mapfish.js
@@ -1,6 +1,7 @@
 Ext.require([
+    'GeoExt.component.Map',
     'GeoExt.data.MapfishPrintProvider',
-    'GeoExt.component.Map'
+    'GeoExt.data.serializer.TileWMS'
 ]);
 
 var olMap,


### PR DESCRIPTION
This adds another require so that the layer in the print example can be serialized. This should have been part #47.

Please review.

Fixes #52.