### PR TITLE
Add support for printing vector layers

### DIFF
--- a/examples/data/SanFranciscoPublicSchools-Points.kml
+++ b/examples/data/SanFranciscoPublicSchools-Points.kml
@@ -1,0 +1,6566 @@
+<?xml version="1.0" encoding="UTF-8"?><kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
+   <Document xmlns:atom="http://purl.org/atom/ns#">
+      <name>geo_sert-rabb:geo_sert-rabb-1</name>
+      <LookAt>
+         <longitude>-122.38068968182785</longitude>
+         <latitude>37.5651386576078</latitude>
+         <altitude>76509.92853176431</altitude>
+         <range>61824.03532721263</range>
+         <tilt>0.0</tilt>
+         <heading>0.0</heading>
+         <altitudeMode>clampToGround</altitudeMode>
+      </LookAt>
+      <Placemark id="geo_sert-rabb-1.1">
+         <name><![CDATA[geo_sert-rabb-1.1]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003185</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Ulloa Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">s595-e3zf</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.49938854722026</longitude>
+            <latitude>37.73733034742629</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.49938854722028,37.73733034742629</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.2">
+         <name><![CDATA[geo_sert-rabb-1.2]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003094</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">FRANCISCO MIDDLE SCHOOL</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">iqr9-ufku</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41102161796286</longitude>
+            <latitude>37.804360261072674</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41102161796286,37.80436026107267</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.3">
+         <name><![CDATA[geo_sert-rabb-1.3]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003095</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Yick Wo Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">tpn9-ybn8</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4165965358292</longitude>
+            <latitude>37.80189958668411</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41659653582923,37.8018995866841</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.4">
+         <name><![CDATA[geo_sert-rabb-1.4]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003096</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Garfield Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">nutx-s4a7</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40653202333962</longitude>
+            <latitude>37.80193503567227</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40653202333962,37.80193503567227</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.5">
+         <name><![CDATA[geo_sert-rabb-1.5]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003102</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Parker, Jean Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">68v6-2nd3</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41105311939842</longitude>
+            <latitude>37.79764323111606</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41105311939843,37.79764323111606</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.6">
+         <name><![CDATA[geo_sert-rabb-1.6]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003104</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Spring Valley Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">wjgm-mujd</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41880011993192</longitude>
+            <latitude>37.79402002042987</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4188001199319,37.79402002042987</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.7">
+         <name><![CDATA[geo_sert-rabb-1.7]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003106</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Chinese Education Center Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ge83-xd72</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40405779333304</longitude>
+            <latitude>37.794768243377945</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40405779333304,37.794768243377945</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.8">
+         <name><![CDATA[geo_sert-rabb-1.8]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003112</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Marina Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">jxp8-h93b</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43604686599329</longitude>
+            <latitude>37.801679934198056</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43604686599329,37.801679934198056</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.9">
+         <name><![CDATA[geo_sert-rabb-1.9]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003113</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Tule Elk Park Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">up85-a9wb</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43456148192368</longitude>
+            <latitude>37.7993632700955</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43456148192364,37.79936327009549</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.10">
+         <name><![CDATA[geo_sert-rabb-1.10]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003115</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Sherman Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">fa97-rkbh</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42611796687393</longitude>
+            <latitude>37.79780159273537</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42611796687397,37.797801592735375</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.11">
+         <name><![CDATA[geo_sert-rabb-1.11]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003119</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Redding Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">k4wc-xshu</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4192433913725</longitude>
+            <latitude>37.78957754756699</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4192433913725,37.78957754756699</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.12">
+         <name><![CDATA[geo_sert-rabb-1.12]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003122</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Gateway High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">qs75-qjva</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43749698138359</longitude>
+            <latitude>37.78315100615974</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43749698138359,37.78315100615974</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.13">
+         <name><![CDATA[geo_sert-rabb-1.13]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003125</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">HARVEY MILK CHILDREN CENTER</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">hfxd-uhcv</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42004011316641</longitude>
+            <latitude>37.78368758851105</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42004011316642,37.783687588511064</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.14">
+         <name><![CDATA[geo_sert-rabb-1.14]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003126</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Creative Arts Charter School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">6au6-96jg</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43592717931011</longitude>
+            <latitude>37.77934657215253</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43592717931011,37.779346572152534</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.15">
+         <name><![CDATA[geo_sert-rabb-1.15]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003127</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">LAGUNA GOLDEN GATE CHILD CARE CENTER,  PRE-K SCHOOL</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">w4dz-3e89</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42731505935473</longitude>
+            <latitude>37.78062766204833</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42731505935474,37.78062766204833</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.16">
+         <name><![CDATA[geo_sert-rabb-1.16]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003131</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Muir, John Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">aicf-w2ty</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42878722381735</longitude>
+            <latitude>37.77372369539073</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42878722381737,37.77372369539072</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.17">
+         <name><![CDATA[geo_sert-rabb-1.17]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003137</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Cobb, Dr. William L. Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">kccf-spdy</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43962657598027</longitude>
+            <latitude>37.78770183533918</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43962657598024,37.787701835339185</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.18">
+         <name><![CDATA[geo_sert-rabb-1.18]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003138</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Roosevelt, Theodore Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">76qk-c65p</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.45835614854641</longitude>
+            <latitude>37.782285287395666</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.45835614854641,37.782285287395666</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.19">
+         <name><![CDATA[geo_sert-rabb-1.19]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003140</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Wallenberg, Raoul High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">rxbi-i6fb</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44675749042742</longitude>
+            <latitude>37.77984810681141</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44675749042747,37.77984810681141</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.20">
+         <name><![CDATA[geo_sert-rabb-1.20]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003141</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">New Traditions Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ykeg-zxrn</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.45026689817226</longitude>
+            <latitude>37.773885426970566</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4502668981723,37.773885426970566</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.21">
+         <name><![CDATA[geo_sert-rabb-1.21]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003146</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Grattan Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ygdk-ba74</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.45044870085826</longitude>
+            <latitude>37.76369766516642</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.45044870085829,37.76369766516642</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.22">
+         <name><![CDATA[geo_sert-rabb-1.22]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003149</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Alamo Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">xhfn-amm6</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.48226338624593</longitude>
+            <latitude>37.783000780585326</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.48226338624598,37.783000780585326</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.23">
+         <name><![CDATA[geo_sert-rabb-1.23]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003151</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Sutro Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">223a-2z8t</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.47145160709903</longitude>
+            <latitude>37.78360344047314</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.47145160709904,37.783603440473144</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.24">
+         <name><![CDATA[geo_sert-rabb-1.24]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003152</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Peabody, George Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">j4yb-zz47</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.46502461269273</longitude>
+            <latitude>37.783854466422916</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4650246126928,37.783854466422916</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.25">
+         <name><![CDATA[geo_sert-rabb-1.25]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003155</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Presidio Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">te2x-rrkr</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.48962711141604</longitude>
+            <latitude>37.78086473615904</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.48962711141606,37.78086473615904</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.26">
+         <name><![CDATA[geo_sert-rabb-1.26]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003157</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Washington, George High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">37eq-wp46</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.49102297327713</longitude>
+            <latitude>37.77787767897118</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.49102297327717,37.77787767897118</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.27">
+         <name><![CDATA[geo_sert-rabb-1.27]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003158</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Lafayette Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">xtk5-cm7u</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.49687607657032</longitude>
+            <latitude>37.77705609428389</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.49687607657035,37.777056094283886</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.28">
+         <name><![CDATA[geo_sert-rabb-1.28]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003161</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">S.F. County Special Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">County School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ru69-3ige</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.48386809911307</longitude>
+            <latitude>37.77552384773862</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4838680991131,37.77552384773862</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.29">
+         <name><![CDATA[geo_sert-rabb-1.29]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003162</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Argonne Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">p2sk-un7r</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.47632885555782</longitude>
+            <latitude>37.7753369704147</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.47632885555785,37.77533697041469</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.30">
+         <name><![CDATA[geo_sert-rabb-1.30]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003163</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">McCoppin, Frank Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">zym7-yh7d</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.46423203379567</longitude>
+            <latitude>37.77630467718355</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.46423203379568,37.776304677183546</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.31">
+         <name><![CDATA[geo_sert-rabb-1.31]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003164</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Argonne Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">h2md-a48i</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.47405696318486</longitude>
+            <latitude>37.773969509585314</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.47405696318486,37.773969509585314</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.32">
+         <name><![CDATA[geo_sert-rabb-1.32]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003165</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">PCC/Big Picture San Francisco</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">County School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">4e5h-ky3m</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.46385164103827</longitude>
+            <latitude>37.76321881597233</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.46385164103825,37.76321881597232</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.33">
+         <name><![CDATA[geo_sert-rabb-1.33]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003166</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Jefferson Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">vbjd-9zqj</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.47681453890723</longitude>
+            <latitude>37.763293928911295</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.47681453890726,37.763293928911295</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.34">
+         <name><![CDATA[geo_sert-rabb-1.34]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003167</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Jefferson Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">i3vy-6b82</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.48316724805193</longitude>
+            <latitude>37.762319941786814</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.48316724805196,37.76231994178681</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.35">
+         <name><![CDATA[geo_sert-rabb-1.35]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003169</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Walden House</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">County School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">pa8x-tqp5</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.50223226161299</longitude>
+            <latitude>37.7613856004922</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.50223226161295,37.7613856004922</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.36">
+         <name><![CDATA[geo_sert-rabb-1.36]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003171</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Lawton Alternative School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">cfu3-ttzh</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.48909824255088</longitude>
+            <latitude>37.75805076265725</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4890982425509,37.75805076265725</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.37">
+         <name><![CDATA[geo_sert-rabb-1.37]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003172</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Key, Francis Scott Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">2nka-arx3</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.50199953070589</longitude>
+            <latitude>37.75809770510133</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.50199953070589,37.75809770510132</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.38">
+         <name><![CDATA[geo_sert-rabb-1.38]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003176</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Giannini, A. P. Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">u9z2-4yyb</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.49721420190315</longitude>
+            <latitude>37.75061591584131</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.49721420190313,37.750615915841315</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.39">
+         <name><![CDATA[geo_sert-rabb-1.39]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003177</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Stevenson, Robert Louis Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ku8j-cdq9</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.49275608860418</longitude>
+            <latitude>37.748844413249884</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4927560886042,37.7488444132499</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.40">
+         <name><![CDATA[geo_sert-rabb-1.40]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003180</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Hoover, Herbert Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">5f3z-acx7</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.46882601849899</longitude>
+            <latitude>37.74574385053875</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.46882601849903,37.745743850538744</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.41">
+         <name><![CDATA[geo_sert-rabb-1.41]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003184</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Feinstein, Dianne Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">48ws-xrj9</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.48136639938772</longitude>
+            <latitude>37.73968584421931</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.48136639938777,37.73968584421931</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.42">
+         <name><![CDATA[geo_sert-rabb-1.42]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003188</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">McKinley Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">j5q5-jf77</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43645485360662</longitude>
+            <latitude>37.76697184293124</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43645485360662,37.76697184293124</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.43">
+         <name><![CDATA[geo_sert-rabb-1.43]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003194</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Alvarado Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">vnfm-ivuh</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43816176513852</longitude>
+            <latitude>37.753714731455936</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43816176513853,37.753714731455936</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.44">
+         <name><![CDATA[geo_sert-rabb-1.44]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003198</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Miraloma Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">icit-z8yq</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.45013700207764</longitude>
+            <latitude>37.73912570075076</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.45013700207767,37.73912570075077</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.45">
+         <name><![CDATA[geo_sert-rabb-1.45]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003199</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">West Portal Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">8muu-8sdp</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.46438898225719</longitude>
+            <latitude>37.74281606298224</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.46438898225723,37.74281606298224</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.46">
+         <name><![CDATA[geo_sert-rabb-1.46]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003200</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Sunnyside Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">9f8x-ctx9</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44823362614457</longitude>
+            <latitude>37.73028783823091</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44823362614459,37.7302878382309</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.47">
+         <name><![CDATA[geo_sert-rabb-1.47]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003202</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Sloat, Commodore Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">mqpu-3sr4</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.47056914005498</longitude>
+            <latitude>37.73167034224845</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.47056914005498,37.731670342248464</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.48">
+         <name><![CDATA[geo_sert-rabb-1.48]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003207</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Marshall Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">7zj8-mruf</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4190074727191</longitude>
+            <latitude>37.76645522979639</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41900747271912,37.76645522979639</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.49">
+         <name><![CDATA[geo_sert-rabb-1.49]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003209</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Sanchez Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ausj-hurn</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43050002737141</longitude>
+            <latitude>37.76346007252924</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43050002737141,37.76346007252924</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.50">
+         <name><![CDATA[geo_sert-rabb-1.50]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003210</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Everett Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">3zke-sdf5</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42897732452428</longitude>
+            <latitude>37.76361310020383</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42897732452431,37.76361310020383</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.51">
+         <name><![CDATA[geo_sert-rabb-1.51]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000001042</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Log Cabin Ranch County School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">County School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">6j7k-s7f4</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.25685830942209</longitude>
+            <latitude>37.30485102316952</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.25685830942209,37.30485102316952</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.52">
+         <name><![CDATA[geo_sert-rabb-1.52]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003213</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Mission High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">r8qy-ssb2</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42711267589416</longitude>
+            <latitude>37.761774297643086</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4271126758942,37.761774297643086</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.53">
+         <name><![CDATA[geo_sert-rabb-1.53]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003218</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Edison Charter K-8</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">eebu-gtfx</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42626571008753</longitude>
+            <latitude>37.75443624145558</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42626571008753,37.754436241455586</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.54">
+         <name><![CDATA[geo_sert-rabb-1.54]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003221</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Buena Vista/Horace Mann</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">nmx8-y26t</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42029704911684</longitude>
+            <latitude>37.75307285012619</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42029704911687,37.75307285012619</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.55">
+         <name><![CDATA[geo_sert-rabb-1.55]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003224</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Carmichael, Bessie (6-8 Campus)</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">e5f6-66mi</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40047916018969</longitude>
+            <latitude>37.78055488251819</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40047916018973,37.7805548825182</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.56">
+         <name><![CDATA[geo_sert-rabb-1.56]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000001831</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Carmichael, Bessie (K-5 Campus)</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">7hv6-uqtg</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40668800279198</longitude>
+            <latitude>37.776104575101506</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.406688002792,37.77610457510151</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.57">
+         <name><![CDATA[geo_sert-rabb-1.57]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003230</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Downtown High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">xwfi-z7es</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40387545434214</longitude>
+            <latitude>37.76136330418212</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40387545434216,37.76136330418212</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.58">
+         <name><![CDATA[geo_sert-rabb-1.58]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003232</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Webster, Daniel Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">da6q-3zyg</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.39597285796927</longitude>
+            <latitude>37.76057845396794</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.39597285796923,37.76057845396794</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.59">
+         <name><![CDATA[geo_sert-rabb-1.59]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003234</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Bryant Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">aqwe-tz72</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40481955125517</longitude>
+            <latitude>37.751580554876156</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40481955125517,37.751580554876156</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.60">
+         <name><![CDATA[geo_sert-rabb-1.60]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003235</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Starr King Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">rzdm-vrch</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.39921113574172</longitude>
+            <latitude>37.753238518653035</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.39921113574175,37.753238518653035</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.61">
+         <name><![CDATA[geo_sert-rabb-1.61]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003237</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Bryant Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">dg9h-ia8u</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40470068233938</longitude>
+            <latitude>37.75163100131541</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40470068233942,37.75163100131541</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.62">
+         <name><![CDATA[geo_sert-rabb-1.62]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003238</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">POTRERO NURSERY</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">kqpw-vjs9</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.39599816588498</longitude>
+            <latitude>37.75204253437714</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.39599816588496,37.75204253437714</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.63">
+         <name><![CDATA[geo_sert-rabb-1.63]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003245</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Harte, Bret Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">jcen-i33j</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.38889380041726</longitude>
+            <latitude>37.71828275813805</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.38889380041726,37.71828275813806</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.64">
+         <name><![CDATA[geo_sert-rabb-1.64]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060162</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Havard, Leola M. Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ygmn-wen6</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.3888156648955</longitude>
+            <latitude>37.73405013967621</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.38881566489552,37.734050139676214</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.65">
+         <name><![CDATA[geo_sert-rabb-1.65]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003250</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Marshall, Thurgood High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">uwm9-efaw</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40146508984839</longitude>
+            <latitude>37.7357315337404</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40146508984839,37.7357315337404</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.66">
+         <name><![CDATA[geo_sert-rabb-1.66]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003251</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Drew, Dr. Charles R. Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">h4ss-nd9r</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.39399537822979</longitude>
+            <latitude>37.7313220713989</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.39399537822982,37.73132207139891</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.67">
+         <name><![CDATA[geo_sert-rabb-1.67]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003256</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Revere, Paul School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">negs-bmfh</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41315842392737</longitude>
+            <latitude>37.73726298262514</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41315842392734,37.73726298262513</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.68">
+         <name><![CDATA[geo_sert-rabb-1.68]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003257</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Serra, Junipero Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">vqru-8ajp</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42149816256645</longitude>
+            <latitude>37.73698452270293</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42149816256648,37.73698452270293</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.69">
+         <name><![CDATA[geo_sert-rabb-1.69]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003259</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Hillcrest Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">qscp-vqqb</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41886225608164</longitude>
+            <latitude>37.728822310526844</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41886225608167,37.72882231052683</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.70">
+         <name><![CDATA[geo_sert-rabb-1.70]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003260</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">King, Dr. Martin Luther, Jr. Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">x2sw-8tuc</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40546776176515</longitude>
+            <latitude>37.72770298739694</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40546776176517,37.72770298739695</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.71">
+         <name><![CDATA[geo_sert-rabb-1.71]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003261</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Taylor, E. R. Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">z7yn-s7ww</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40746582403327</longitude>
+            <latitude>37.72767974789922</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4074658240333,37.72767974789922</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.72">
+         <name><![CDATA[geo_sert-rabb-1.72]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003262</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Excelsior Monroe Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">p8pe-74sg</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43047649543249</longitude>
+            <latitude>37.72564248891783</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43047649543247,37.72564248891782</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.73">
+         <name><![CDATA[geo_sert-rabb-1.73]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003263</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">S.F. COMMUNITY SCHOOL</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">eue3-vpdx</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4321335976571</longitude>
+            <latitude>37.72610456553669</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43213359765714,37.72610456553669</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.74">
+         <name><![CDATA[geo_sert-rabb-1.74]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003265</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Jordan, June High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ntq8-9i7w</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42525276207155</longitude>
+            <latitude>37.719240498444194</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42525276207158,37.71924049844418</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.75">
+         <name><![CDATA[geo_sert-rabb-1.75]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003266</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Cleveland Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ia6r-tw72</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4288800849537</longitude>
+            <latitude>37.72063016505053</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42888008495375,37.72063016505053</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.76">
+         <name><![CDATA[geo_sert-rabb-1.76]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003267</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Burton, Phillip and Sala High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">fzcj-7zmm</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40655226568984</longitude>
+            <latitude>37.72154527677192</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4065522656898,37.72154527677192</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.77">
+         <name><![CDATA[geo_sert-rabb-1.77]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003268</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">El Dorado Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">gnk9-fgvc</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40729607349937</longitude>
+            <latitude>37.7184219817455</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40729607349938,37.7184219817455</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.78">
+         <name><![CDATA[geo_sert-rabb-1.78]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003270</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Visitacion Valley Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">jx95-thcu</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4124077660482</longitude>
+            <latitude>37.71565156367177</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41240776604823,37.71565156367177</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.79">
+         <name><![CDATA[geo_sert-rabb-1.79]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003273</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Visitacion Valley Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">bmrz-h826</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41027497651027</longitude>
+            <latitude>37.712525000572796</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41027497651027,37.712525000572796</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.80">
+         <name><![CDATA[geo_sert-rabb-1.80]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003274</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">McLaren, John Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">8n68-rz9d</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42318559787518</longitude>
+            <latitude>37.71365110999242</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42318559787519,37.71365110999242</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.81">
+         <name><![CDATA[geo_sert-rabb-1.81]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003275</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Excelsior Guadalupe Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">zm99-7668</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43449972503291</longitude>
+            <latitude>37.71013456082104</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43449972503291,37.71013456082104</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.82">
+         <name><![CDATA[geo_sert-rabb-1.82]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003276</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Longfellow Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">mrst-cyy8</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44712616376339</longitude>
+            <latitude>37.71023481606431</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44712616376343,37.71023481606431</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.83">
+         <name><![CDATA[geo_sert-rabb-1.83]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003277</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Rodriguez, Zaida T. Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">n3hx-5x3i</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41917118003266</longitude>
+            <latitude>37.75014826665419</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41917118003268,37.75014826665421</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.84">
+         <name><![CDATA[geo_sert-rabb-1.84]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003278</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Lick, James Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">9ttx-4t53</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4321552513529</longitude>
+            <latitude>37.74954430347409</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43215525135294,37.74954430347409</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.85">
+         <name><![CDATA[geo_sert-rabb-1.85]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003279</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Mission Education Center Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">96b2-z9a4</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4314358423037</longitude>
+            <latitude>37.74220409860887</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43143584230373,37.74220409860887</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.86">
+         <name><![CDATA[geo_sert-rabb-1.86]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003280</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Fairmount Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">jjrs-g4yd</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42500898855397</longitude>
+            <latitude>37.74045957474419</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42500898855398,37.74045957474419</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.87">
+         <name><![CDATA[geo_sert-rabb-1.87]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003282</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Glen Park Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">6cp4-qcdt</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4357865882148</longitude>
+            <latitude>37.73309656160837</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43578658821481,37.73309656160836</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.88">
+         <name><![CDATA[geo_sert-rabb-1.88]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003283</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Balboa High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">kq75-suk7</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44080036349507</longitude>
+            <latitude>37.72217071460237</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44080036349509,37.72217071460237</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.89">
+         <name><![CDATA[geo_sert-rabb-1.89]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003284</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Denman, James Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">g2rb-7q84</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44287337450473</longitude>
+            <latitude>37.72153782059353</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44287337450477,37.72153782059353</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.90">
+         <name><![CDATA[geo_sert-rabb-1.90]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003285</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">San Miguel Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">7ren-mezi</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44485801690121</longitude>
+            <latitude>37.72149133271748</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44485801690122,37.72149133271748</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.91">
+         <name><![CDATA[geo_sert-rabb-1.91]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003286</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Ortega, Jose Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">fy7k-mrzg</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.46629406175035</longitude>
+            <latitude>37.71637898956342</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.46629406175036,37.71637898956341</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.92">
+         <name><![CDATA[geo_sert-rabb-1.92]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003287</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Sheridan Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">w4rf-mgrn</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.45962941485456</longitude>
+            <latitude>37.714475985799005</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.45962941485456,37.714475985799005</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.93">
+         <name><![CDATA[geo_sert-rabb-1.93]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003293</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Lakeshore Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">x4w4-kta8</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4860085741268</longitude>
+            <latitude>37.7300506930693</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.48600857412687,37.73005069306931</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.94">
+         <name><![CDATA[geo_sert-rabb-1.94]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003294</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">LOWELL HIGH SCHOOL</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">qegb-dqzs</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.48340200748032</longitude>
+            <latitude>37.730623528358315</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.48340200748034,37.73062352835832</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.95">
+         <name><![CDATA[geo_sert-rabb-1.95]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003236</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Hilltop Special Services Center</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">County School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">nmq3-d4tm</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40939655386441</longitude>
+            <latitude>37.75043248296697</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40939655386441,37.75043248296698</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.96">
+         <name><![CDATA[geo_sert-rabb-1.96]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003116</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Gateway Middle School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">d9vi-yipk</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43343825560643</longitude>
+            <latitude>37.79280501868586</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43343825560648,37.79280501868586</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.97">
+         <name><![CDATA[geo_sert-rabb-1.97]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003134</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Lilienthal, Claire (3-8 Winfield Scott Campus)</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">g6kx-8pdp</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44319755748464</longitude>
+            <latitude>37.803218930711644</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44319755748468,37.80321893071165</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.98">
+         <name><![CDATA[geo_sert-rabb-1.98]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003129</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Wells, Ida B. High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">gwf7-fdud</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43403688047647</longitude>
+            <latitude>37.77498638515989</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43403688047648,37.77498638515989</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.99">
+         <name><![CDATA[geo_sert-rabb-1.99]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003144</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Chinese Immersion School at DeAvila</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">jm3s-uxf5</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44434848135376</longitude>
+            <latitude>37.76973397063847</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44434848135376,37.76973397063847</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.100">
+         <name><![CDATA[geo_sert-rabb-1.100]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003203</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">APTOS MIDDLE SCHOOL</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Middle School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">8fsy-47vy</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.46601819420795</longitude>
+            <latitude>37.72969431045029</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.46601819420798,37.72969431045029</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.101">
+         <name><![CDATA[geo_sert-rabb-1.101]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000010186</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Lincoln, Abraham High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">uavv-wptr</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.48029535111235</longitude>
+            <latitude>37.74655970267749</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.48029535111237,37.746559702677494</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.102">
+         <name><![CDATA[geo_sert-rabb-1.102]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003533</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">SUNSET ELEMENTARY SCHOOL</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">vzws-mif6</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.49952278493254</longitude>
+            <latitude>37.75059317221159</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.49952278493261,37.75059317221158</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.103">
+         <name><![CDATA[geo_sert-rabb-1.103]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003100</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Chin, John Yehall Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ttxy-mqxp</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40321747699792</longitude>
+            <latitude>37.798610992611344</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40321747699795,37.79861099261134</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.104">
+         <name><![CDATA[geo_sert-rabb-1.104]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003105</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Stockton, Commodore Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">2gcf-xtsw</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40908641441399</longitude>
+            <latitude>37.79504527997475</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40908641441398,37.79504527997475</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.105">
+         <name><![CDATA[geo_sert-rabb-1.105]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003107</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Lau, Gordon J. Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">v5jc-eecd</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4089250764427</longitude>
+            <latitude>37.79407853651157</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40892507644271,37.79407853651157</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.106">
+         <name><![CDATA[geo_sert-rabb-1.106]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003110</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Galileo High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">f46h-7xz9</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42447926890833</longitude>
+            <latitude>37.80374834529723</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42447926890836,37.80374834529723</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.107">
+         <name><![CDATA[geo_sert-rabb-1.107]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003123</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Parks, Rosa Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">biui-p8zk</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43001153983695</longitude>
+            <latitude>37.78349340241511</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43001153983698,37.78349340241512</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.108">
+         <name><![CDATA[geo_sert-rabb-1.108]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003128</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Civic Center Secondary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">County School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">pne4-3drt</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4228778578721</longitude>
+            <latitude>37.78031378935084</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42287785787212,37.780313789350835</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.109">
+         <name><![CDATA[geo_sert-rabb-1.109]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003136</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Lilienthal, Claire (K-2 Madison Campus)</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">bjnc-nqai</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.45806740393718</longitude>
+            <latitude>37.78722555145973</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.45806740393722,37.78722555145972</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.110">
+         <name><![CDATA[geo_sert-rabb-1.110]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003170</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Yu, Alice Fong Alternative School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ek2s-gmm3</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.46971143337834</longitude>
+            <latitude>37.758910482438885</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.46971143337834,37.758910482438885</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.111">
+         <name><![CDATA[geo_sert-rabb-1.111]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003173</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Noriega Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">y2bw-a75f</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.50365891957364</longitude>
+            <latitude>37.75384963172111</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.50365891957362,37.75384963172111</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.112">
+         <name><![CDATA[geo_sert-rabb-1.112]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003182</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Independence High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">drdg-qwa7</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.49989695111557</longitude>
+            <latitude>37.743402256295894</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.49989695111555,37.74340225629589</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.113">
+         <name><![CDATA[geo_sert-rabb-1.113]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003189</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Clarendon Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">as98-7yxm</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.456323215348</longitude>
+            <latitude>37.75375731508062</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.45632321534801,37.75375731508062</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.114">
+         <name><![CDATA[geo_sert-rabb-1.114]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003190</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">HARVEY MILK CIVIL RIGHTS ACADEMY</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">8t4d-pbzk</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43645512148404</longitude>
+            <latitude>37.7589796759005</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.436455121484,37.75897967590051</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.115">
+         <name><![CDATA[geo_sert-rabb-1.115]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003191</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Rooftop (5-8 Mayeda Campus)</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">uv94-ybg4</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4444896297351</longitude>
+            <latitude>37.75740830319434</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4444896297351,37.75740830319433</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.116">
+         <name><![CDATA[geo_sert-rabb-1.116]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003193</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Rooftop (K-4 Burnett Campus)</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">uis5-ja9a</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4439169238259</longitude>
+            <latitude>37.75499520889745</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44391692382592,37.75499520889745</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.117">
+         <name><![CDATA[geo_sert-rabb-1.117]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003216</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Moscone, George Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">y9i5-3sg6</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41256222867102</longitude>
+            <latitude>37.75699935641083</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41256222867102,37.75699935641083</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.118">
+         <name><![CDATA[geo_sert-rabb-1.118]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003217</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Mahler, Theresa S. Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">jtyu-wjeq</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42809663616998</longitude>
+            <latitude>37.75527352848398</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42809663617,37.75527352848398</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.119">
+         <name><![CDATA[geo_sert-rabb-1.119]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003220</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Chavez, Cesar Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">6up7-8ic3</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.415092067633</longitude>
+            <latitude>37.754898979129386</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.415092067633,37.754898979129386</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.120">
+         <name><![CDATA[geo_sert-rabb-1.120]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003231</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">International Studies Academy</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">z8i6-29pd</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40080497145223</longitude>
+            <latitude>37.76182549992223</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40080497145223,37.76182549992223</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.121">
+         <name><![CDATA[geo_sert-rabb-1.121]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003242</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Malcolm X Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ab66-prqi</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.38110191071559</longitude>
+            <latitude>37.73420564431136</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.38110191071564,37.734205644311345</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.122">
+         <name><![CDATA[geo_sert-rabb-1.122]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003244</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Metropolitan Arts and Tech</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ipyh-jj54</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.38224144103515</longitude>
+            <latitude>37.73212188329177</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.38224144103516,37.73212188329178</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.123">
+         <name><![CDATA[geo_sert-rabb-1.123]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003254</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Flynn, Leonard Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">wzqw-scq2</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41196533192402</longitude>
+            <latitude>37.7477375909706</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4119653319241,37.74773759097061</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.124">
+         <name><![CDATA[geo_sert-rabb-1.124]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000003296</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Asawa, Ruth - San Francisco School of the Arts (SOTA)</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">pgud-knqy</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44866679763894</longitude>
+            <latitude>37.745431363449065</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44866679763891,37.745431363449065</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.125">
+         <name><![CDATA[geo_sert-rabb-1.125]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000010187</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Carver, Dr. George Washington Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">7snn-8jga</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.38557041991393</longitude>
+            <latitude>37.73184270862928</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.38557041991396,37.73184270862928</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.126">
+         <name><![CDATA[geo_sert-rabb-1.126]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060081</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Five Keys Charter</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">x7zf-v2u2</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4021800530486</longitude>
+            <latitude>37.7771531874609</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40218005304861,37.7771531874609</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.127">
+         <name><![CDATA[geo_sert-rabb-1.127]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060086</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Tenderloin Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">hxni-up5i</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41995051829818</longitude>
+            <latitude>37.78185450311691</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41995051829815,37.78185450311692</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.128">
+         <name><![CDATA[geo_sert-rabb-1.128]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060087</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">O'Connell, John High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">nfz4-r2kh</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41421483879932</longitude>
+            <latitude>37.75951718666005</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41421483879935,37.75951718666005</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.129">
+         <name><![CDATA[geo_sert-rabb-1.129]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060127</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Academy of Arts and Sciences</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">xwgk-38zk</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44948465562646</longitude>
+            <latitude>37.74515847593578</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44948465562649,37.74515847593578</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.130">
+         <name><![CDATA[geo_sert-rabb-1.130]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060128</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">S. F. International High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">High School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">69kq-s8hr</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40863966358671</longitude>
+            <latitude>37.75524584034381</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40863966358671,37.75524584034381</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.131">
+         <name><![CDATA[geo_sert-rabb-1.131]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060129</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Carmichael, Bessie Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">vagx-wpn5</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40678677845611</longitude>
+            <latitude>37.77657340880496</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40678677845615,37.77657340880495</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.132">
+         <name><![CDATA[geo_sert-rabb-1.132]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060130</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Chavez, Cesar Preschool</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">25z5-ic54</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41508304389939</longitude>
+            <latitude>37.75476252430071</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41508304389943,37.75476252430071</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.133">
+         <name><![CDATA[geo_sert-rabb-1.133]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060131</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Cobb, Dr. William Preschool</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">mhse-iwmq</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43915377416658</longitude>
+            <latitude>37.787992115639874</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43915377416666,37.787992115639874</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.134">
+         <name><![CDATA[geo_sert-rabb-1.134]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060132</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Drew, Dr. Charles Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">t3e5-vg8v</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.39388016101032</longitude>
+            <latitude>37.731767599969515</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.39388016101034,37.731767599969515</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.135">
+         <name><![CDATA[geo_sert-rabb-1.135]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060133</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Sanchez Preschool</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">mpf5-d4dn</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43049899573276</longitude>
+            <latitude>37.763167672839685</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43049899573279,37.76316767283968</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.136">
+         <name><![CDATA[geo_sert-rabb-1.136]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060135</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Flynn, Leonard Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">n2hx-axfr</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41194677167329</longitude>
+            <latitude>37.74804342282933</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41194677167327,37.748043422829326</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.137">
+         <name><![CDATA[geo_sert-rabb-1.137]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060136</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Garfield Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">6ezy-ygu4</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40679714221505</longitude>
+            <latitude>37.801902062841776</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40679714221504,37.80190206284178</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.138">
+         <name><![CDATA[geo_sert-rabb-1.138]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060137</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Grattan Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">8esw-wvr4</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4503970544726</longitude>
+            <latitude>37.76349811162416</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.45039705447263,37.763498111624166</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.139">
+         <name><![CDATA[geo_sert-rabb-1.139]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060138</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Guadalupe Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">hm8q-6iyp</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43411655373549</longitude>
+            <latitude>37.71031462695382</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43411655373549,37.71031462695382</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.140">
+         <name><![CDATA[geo_sert-rabb-1.140]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060139</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Harte, Bret Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">zz73-hyqm</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.38980366877882</longitude>
+            <latitude>37.71819686269234</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.38980366877885,37.71819686269234</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.141">
+         <name><![CDATA[geo_sert-rabb-1.141]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060140</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Key, Francis Scott Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">c79x-zsch</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.50227342567263</longitude>
+            <latitude>37.75783478842693</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.50227342567266,37.75783478842693</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.142">
+         <name><![CDATA[geo_sert-rabb-1.142]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060141</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Taylor, E.R. Preschool</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">kzit-7wv8</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40735999833714</longitude>
+            <latitude>37.72741283667987</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40735999833717,37.727412836679875</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.143">
+         <name><![CDATA[geo_sert-rabb-1.143]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060142</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Las Americas Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">5wvw-ecef</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41324751646917</longitude>
+            <latitude>37.75712245853309</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41324751646917,37.7571224585331</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.144">
+         <name><![CDATA[geo_sert-rabb-1.144]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060143</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Lau, Gordon J. Preschool</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">9c5s-3rhq</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.40858959637472</longitude>
+            <latitude>37.79415328917249</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.40858959637477,37.79415328917249</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.145">
+         <name><![CDATA[geo_sert-rabb-1.145]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060144</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">McCoppin, Frank Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">7263-zwra</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.46423818581974</longitude>
+            <latitude>37.77644177102199</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.46423818581974,37.77644177102199</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.146">
+         <name><![CDATA[geo_sert-rabb-1.146]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060145</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Monroe Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">sb8g-ky8a</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43028941722028</longitude>
+            <latitude>37.725512565729275</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43028941722024,37.72551256572926</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.147">
+         <name><![CDATA[geo_sert-rabb-1.147]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060146</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Muir, John Preschool</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">26ci-vi9q</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42877414027305</longitude>
+            <latitude>37.77360964565918</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42877414027308,37.77360964565918</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.148">
+         <name><![CDATA[geo_sert-rabb-1.148]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060147</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Parker, Jean Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">e8p6-snzj</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41120119912247</longitude>
+            <latitude>37.79751749136542</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41120119912249,37.79751749136542</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.149">
+         <name><![CDATA[geo_sert-rabb-1.149]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060148</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Redding Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">huy6-ut48</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41939595036953</longitude>
+            <latitude>37.789491415252996</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41939595036953,37.789491415253</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.150">
+         <name><![CDATA[geo_sert-rabb-1.150]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060150</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">S. F. Montessori Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">7jgu-fe98</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43363582742376</longitude>
+            <latitude>37.79277553188706</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43363582742379,37.79277553188706</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.151">
+         <name><![CDATA[geo_sert-rabb-1.151]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060151</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">S. F. Public Montessori Elementary School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">uh8j-5wr6</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.4339349695438</longitude>
+            <latitude>37.7927357065079</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.43393496954383,37.7927357065079</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.152">
+         <name><![CDATA[geo_sert-rabb-1.152]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060152</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Serra, Junipero Early Education School (1)</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">47d6-w3ti</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42151153739988</longitude>
+            <latitude>37.73684052787618</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42151153739984,37.73684052787618</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.153">
+         <name><![CDATA[geo_sert-rabb-1.153]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060153</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Serra, Junipero Early Education School (2)</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">uvsx-yzub</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42259917013124</longitude>
+            <latitude>37.73845825686219</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42259917013124,37.73845825686219</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.154">
+         <name><![CDATA[geo_sert-rabb-1.154]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060155</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Spring Valley Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ywh9-xdkc</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.41887325621889</longitude>
+            <latitude>37.793901169581886</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41887325621889,37.79390116958189</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.155">
+         <name><![CDATA[geo_sert-rabb-1.155]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060156</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Starr King Preschool</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">svjm-bjqx</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.39915492378057</longitude>
+            <latitude>37.7530428943751</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.39915492378059,37.753042894375106</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.156">
+         <name><![CDATA[geo_sert-rabb-1.156]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060157</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Sutro Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">5652-9msy</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.47140120581369</longitude>
+            <latitude>37.783481294695456</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.47140120581372,37.783481294695456</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.157">
+         <name><![CDATA[geo_sert-rabb-1.157]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060158</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Tenderloin Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">j76e-nv82</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42001362736536</longitude>
+            <latitude>37.78171735655589</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42001362736538,37.78171735655587</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.158">
+         <name><![CDATA[geo_sert-rabb-1.158]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060159</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Webster, Daniel Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">gy56-trkg</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.39597659171773</longitude>
+            <latitude>37.760393789928585</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.39597659171775,37.76039378992858</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.159">
+         <name><![CDATA[geo_sert-rabb-1.159]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060160</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Weill, Raphael Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">f36v-xm4e</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42977293647104</longitude>
+            <latitude>37.7832825866128</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42977293647107,37.7832825866128</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.160">
+         <name><![CDATA[geo_sert-rabb-1.160]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060161</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Woodside Learning Center</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">County School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ndv7-au4y</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.45250513331408</longitude>
+            <latitude>37.745926539880905</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.45250513331405,37.74592653988092</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.161">
+         <name><![CDATA[geo_sert-rabb-1.161]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060163</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Jefferson Out Of School (OST) Program</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Elementary</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">5rz9-fshn</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.3962022207707</longitude>
+            <latitude>37.762478823004024</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.39620222077073,37.762478823004024</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.162">
+         <name><![CDATA[geo_sert-rabb-1.162]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060164</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">KIPP Bayview Academy</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">qktr-y427</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.39636283554196</longitude>
+            <latitude>37.719342808779125</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.39636283554199,37.71934280877911</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.163">
+         <name><![CDATA[geo_sert-rabb-1.163]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060165</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">KIPP SF Bay Academy</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">kex9-2887</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.43746647931579</longitude>
+            <latitude>37.78299854792037</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.4374664793158,37.782998547920364</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.164">
+         <name><![CDATA[geo_sert-rabb-1.164]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060166</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Larkin Street Youth Services</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">County School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">gyax-qtu5</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.419201343569</longitude>
+            <latitude>37.788023259357075</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.41920134356903,37.788023259357075</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.165">
+         <name><![CDATA[geo_sert-rabb-1.165]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060167</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Leadership Charter High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ugfn-zuxy</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.44326237028051</longitude>
+            <latitude>37.721438846984654</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.44326237028055,37.721438846984654</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.166">
+         <name><![CDATA[geo_sert-rabb-1.166]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060168</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Life Learning Academy Charter School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">mr4e-q845</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.36792911279932</longitude>
+            <latitude>37.82529785748185</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.36792911279929,37.82529785748185</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.167">
+         <name><![CDATA[geo_sert-rabb-1.167]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060169</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">Presidio Early Education School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Early Education</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">nimq-mj6e</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.46093330617364</longitude>
+            <latitude>37.79781654837335</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.46093330617366,37.79781654837335</coordinates>
+         </Point>
+      </Placemark>
+      <Placemark id="geo_sert-rabb-1.168">
+         <name><![CDATA[geo_sert-rabb-1.168]]></name>
+         <description><![CDATA[<h4>geo_sert-rabb-1</h4>
+
+<ul class="textattributes">
+  
+  <li><strong><span class="atr-name">FACILITY_I</span>:</strong> <span class="atr-value">0000060170</span></li>
+  <li><strong><span class="atr-name">FACILITY_N</span>:</strong> <span class="atr-value">City Arts and Tech High School</span></li>
+  <li><strong><span class="atr-name">DEPTNAME</span>:</strong> <span class="atr-value">SF Unified School District (SFUSD)</span></li>
+  <li><strong><span class="atr-name">DEPT</span>:</strong> <span class="atr-value">7</span></li>
+  <li><strong><span class="atr-name">SCHOOL_TYP</span>:</strong> <span class="atr-value">Charter School</span></li>
+  <li><strong><span class="atr-name">_SocrataID</span>:</strong> <span class="atr-value">ieju-28ip</span></li>
+</ul>
+]]></description>
+         <LookAt>
+            <longitude>-122.42510757291552</longitude>
+            <latitude>37.718885864683344</latitude>
+            <altitude>0.0</altitude>
+            <range>0.0</range>
+            <tilt>0.0</tilt>
+            <heading>0.0</heading>
+            <altitudeMode>clampToGround</altitudeMode>
+         </LookAt>
+         <Style>
+            <IconStyle>
+               <color>b20033cc</color>
+               <colorMode>normal</colorMode>
+               <Icon>
+                  <href>http://maps.google.com/mapfiles/kml/pal4/icon25.png</href>
+               </Icon>
+            </IconStyle>
+            <LabelStyle>
+               <color>00ffffff</color>
+            </LabelStyle>
+         </Style>
+         <Point>
+            <coordinates>-122.42510757291554,37.718885864683344</coordinates>
+         </Point>
+      </Placemark>
+   </Document>
+</kml>

--- a/examples/print/basic-mapfish.html
+++ b/examples/print/basic-mapfish.html
@@ -11,12 +11,12 @@
 
     <div id='description'>
         <p>
-            This example shows how to use the 
+            This example shows how to use the
             <code>GeoExt.data.MapfishPrintProvider</code> class to talk to a
             Mapfish Print Server (v3.x).
         </p>
         <p>
-            Afterwards we have all information to create a valid POST to the 
+            Afterwards we have all information to create a valid POST to the
             servlet. The printed extent is highlighte as vector layer. If you
             move around or change the zoom, the extent will adjust accordingly.
         </p>

--- a/src/data/MapfishPrintProvider.js
+++ b/src/data/MapfishPrintProvider.js
@@ -177,9 +177,17 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
          *
          * @static
          */
-        getSerializedLayers: function(layers){
+        getSerializedLayers: function(mapComponent, filterFn, filterScope){
+            var layers = mapComponent.getLayers();
+            var viewRes = mapComponent.getView().getResolution();
             var serializedLayers = [];
             var inputLayers = this.getLayerArray(layers);
+
+            if (Ext.isDefined(filterFn)) {
+                inputLayers = Ext.Array.filter(
+                    inputLayers, filterFn, filterScope
+                );
+            }
 
             Ext.each(inputLayers, function(layer){
                 var source = layer.getSource();
@@ -187,7 +195,7 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
 
                 var serializer = this.findSerializerBySource(source);
                 if (serializer) {
-                    serialized = serializer.serialize(layer, source);
+                    serialized = serializer.serialize(layer, source, viewRes);
                     serializedLayers.push(serialized);
                 }
             }, this);

--- a/src/data/serializer/Base.js
+++ b/src/data/serializer/Base.js
@@ -35,6 +35,7 @@
          * @param {ol.layer.Layer} layer The layer to serialize.
          * @param {ol.source.Source} source The source of the layer to
          *    serialize.
+         * @param {Number} viewRes The resolution of the mapview.
          * @return {Object} a serialized representation of source and layer.
          */
         serialize: function() {

--- a/src/data/serializer/Vector.js
+++ b/src/data/serializer/Vector.js
@@ -1,0 +1,554 @@
+/* Copyright (c) 2015 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * A serializer for layers that have a `ol.source.Vector` source.
+ *
+ * This class is heavily inspired by the excellent `ngeo` Print service class:
+ * [camptocamp/ngeo](https://github.com/camptocamp/ngeo/blob/master/src/services/print.js).
+ *
+ * Additionally some utility methods were borrowed from the color class of the
+ * [google/closure-library](https://github.com/google/closure-library/blob/master/closure/goog/color/color.js).
+ */
+Ext.define('GeoExt.data.serializer.Vector', {
+    extend: 'GeoExt.data.serializer.Base',
+    inheritableStatics: {
+        /**
+         * The types of styles that mapfish supports.
+         *
+         * @private
+         */
+        PRINTSTYLE_TYPES: {
+            POINT: 'Point',
+            LINE_STRING: 'LineString',
+            POLYGON: 'Polygon'
+        },
+
+        /**
+         * An object that maps an ol.geom.GeometryType to a printstyle type.
+         *
+         * @private
+         */
+        GEOMETRY_TYPE_TO_PRINTSTYLE_TYPE: {}, // filled once class is defined
+
+        /**
+         * A fallback serialization of a vector layer that will be used if
+         * the given source e.g. doesn't have any features.
+         *
+         * @private
+         */
+        FALLBACK_SERIALIZATION: {
+            geoJson: {
+                type: "FeatureCollection",
+                features: []
+            },
+            opacity: 1,
+            style: {
+                 version: "2",
+                 "*": {
+                     symbolizers: [{
+                         type: "point",
+                         strokeColor: "white",
+                         strokeOpacity: 1,
+                         strokeWidth: 4,
+                         strokeDashstyle: "solid",
+                         fillColor: "red"
+                     }]
+                 }
+            },
+            type: "geojson"
+        },
+
+        /**
+         * The prefix we will give to the generated styles. Every feature will
+         * -- once it is serialized -- have a property constructed with
+         * the #FEAT_STYLE_PREFIX and a counter. For every unique combination
+         * of #FEAT_STYLE_PREFIX  + i with the value style uid (see #getUid
+         * and #GX_UID_PROPERTY), the layer serialization will also have a
+         * CQL entry with a matching symbolizer:
+         *
+         *     {
+         *          // …
+         *          style: {
+         *              "[_gx3_style_0='ext-46']": {
+         *                  symbolizer: {
+         *                      // …
+         *                  }
+         *              }
+         *          },
+         *          geoJson: {
+         *              // …
+         *              features: [
+         *                  {
+         *                      // …
+         *                      properties: {
+         *                          '_gx3_style_0': 'ext-46'
+         *                          // …
+         *                      }
+         *                  }
+         *              ]
+         *          }
+         *          // …
+         *     }
+         *
+         * @private
+         */
+        FEAT_STYLE_PREFIX: '_gx3_style_',
+
+        /**
+         * The name / identifier for the uid property that is assigned and read
+         * out in #getUid
+         *
+         * @private
+         */
+        GX_UID_PROPERTY: '__gx_uid__',
+
+        /**
+         * A shareable instance of ol.format.GeoJSON to serialize the features.
+         *
+         * @private
+         */
+        format: new ol.format.GeoJSON(),
+
+        /**
+         * @inheritdoc
+         */
+        sourceCls: ol.source.Vector,
+
+        /**
+         * @inheritdoc
+         */
+        serialize: function(layer, source, viewRes) {
+            var staticMe = this;
+            staticMe.validateSource(source);
+            var features = source.getFeatures();
+            var format = staticMe.format;
+            var geoJsonFeatures = [];
+            var mapfishStyleObject = {
+                version: 2
+            };
+
+            Ext.each(features, function(feature) {
+                var geometry = feature.getGeometry();
+                if (Ext.isEmpty(geometry)) {
+                    // no need to encode features with no geometry
+                    return;
+                }
+                var geometryType = geometry.getType();
+                var geojsonFeature = format.writeFeatureObject(feature);
+
+                var styles = null;
+                var styleFunction = feature.getStyleFunction();
+                if (Ext.isDefined(styleFunction)) {
+                    styles = styleFunction.call(feature, viewRes);
+                } else {
+                    styleFunction = layer.getStyleFunction();
+                    if (Ext.isDefined(styleFunction)) {
+                        styles = styleFunction.call(layer, feature, viewRes);
+                    }
+                }
+                if (styles !== null && styles.length > 0) {
+                    geoJsonFeatures.push(geojsonFeature);
+                    if (Ext.isEmpty(geojsonFeature.properties)) {
+                        geojsonFeature.properties = {};
+                    }
+                    Ext.each(styles, function(style, j){
+                        var styleId = staticMe.getUid(style);
+                        var featureStyleProp = staticMe.FEAT_STYLE_PREFIX + j;
+                        staticMe.encodeVectorStyle(
+                            mapfishStyleObject,
+                            geometryType,
+                            style,
+                            styleId,
+                            featureStyleProp
+                        );
+                        geojsonFeature.properties[featureStyleProp] = styleId;
+                    });
+                }
+            });
+
+            var serialized;
+
+            // MapFish Print fails if there are no style rules, even if there
+            // are no features either. To work around this, we add a basic
+            // style in the else clause array of GeoJSON features is empty.
+            if (geoJsonFeatures.length > 0) {
+                var geojsonFeatureCollection = {
+                    type: 'FeatureCollection',
+                    features: geoJsonFeatures
+                };
+                serialized = {
+                    geoJson: geojsonFeatureCollection,
+                    opacity: layer.getOpacity(),
+                    style: mapfishStyleObject,
+                    type: 'geojson'
+                };
+            } else {
+                serialized = this.FALLBACK_SERIALIZATION;
+            }
+
+            return serialized;
+        },
+
+        /**
+         * Encodes an ol.style.Style into the passed MapFish style object.
+         *
+         * @param {Object} object The MapFish style object.
+         * @param {ol.geom.GeometryType} geometryType The type of the GeoJSON
+         *    geometry
+         * @param {ol.style.Style} style The style to encode.
+         * @param {String} styleId The id of the style.
+         * @param {String} featureStyleProp Feature style property name.
+         * @private
+         */
+        encodeVectorStyle: function(object, geometryType, style, styleId, featureStyleProp) {
+            var staticMe = this;
+            var printTypes = staticMe.PRINTSTYLE_TYPES;
+            var printStyleLookup = staticMe.GEOMETRY_TYPE_TO_PRINTSTYLE_TYPE;
+            if (!Ext.isDefined(printStyleLookup[geometryType])) {
+                // unsupported geometry type
+                return;
+            }
+            var styleType = printStyleLookup[geometryType];
+            var key = '[' + featureStyleProp + ' = \'' + styleId + '\']';
+            if (Ext.isDefined(object[key])) {
+                // do nothing if we already have a style object for this CQL
+                // rule
+                return;
+            }
+            var styleObject = {
+                symbolizers: []
+            };
+
+            object[key] = styleObject;
+
+            var fillStyle = style.getFill();
+            var imageStyle = style.getImage();
+            var strokeStyle = style.getStroke();
+            var textStyle = style.getText();
+
+            var hasFillStyle = !Ext.isEmpty(fillStyle);
+            var hasImageStyle = !Ext.isEmpty(imageStyle);
+            var hasStrokeStyle = !Ext.isEmpty(strokeStyle);
+            var hasTextStyle = !Ext.isEmpty(textStyle);
+
+            if (styleType === printTypes.POLYGON && hasFillStyle) {
+                staticMe.encodeVectorStylePolygon(
+                    styleObject.symbolizers, fillStyle, strokeStyle
+                );
+            } else if (styleType === printTypes.LINE_STRING && hasStrokeStyle) {
+                staticMe.encodeVectorStyleLine(
+                    styleObject.symbolizers, strokeStyle
+                );
+            } else if (styleType === printTypes.POINT && hasImageStyle) {
+                staticMe.encodeVectorStylePoint(
+                    styleObject.symbolizers, imageStyle
+                );
+            }
+            // this can be there regardless of type
+            if (hasTextStyle) {
+                staticMe.encodeTextStyle(styleObject.symbolizers, textStyle);
+            }
+        },
+
+        /**
+         * Encodes an ol.style.Fill and an optional ol.style.Stroke and adds it
+         * to the passed symbolizers array.
+         *
+         * @param {Object[]} symbolizers Array of MapFish Print symbolizers.
+         * @param {ol.style.Fill} fillStyle Fill style.
+         * @param {ol.style.Stroke} strokeStyle Stroke style. May be null.
+         * @private
+         */
+        encodeVectorStylePolygon: function(symbolizers, fillStyle, strokeStyle){
+            var symbolizer = {
+                type: 'polygon'
+            };
+            this.encodeVectorStyleFill(symbolizer, fillStyle);
+            if (strokeStyle !== null) {
+                this.encodeVectorStyleStroke(symbolizer, strokeStyle);
+            }
+            symbolizers.push(symbolizer);
+        },
+
+        /**
+         * Encodes an ol.style.Stroke and adds it to the passed symbolizers
+         * array.
+         *
+         * @param {Object[]} symbolizers Array of MapFish Print symbolizers.
+         * @param {ol.style.Stroke} strokeStyle Stroke style.
+         * @private
+         */
+        encodeVectorStyleLine: function(symbolizers, strokeStyle){
+            var symbolizer = {
+                type: 'line'
+            };
+            this.encodeVectorStyleStroke(symbolizer, strokeStyle);
+            symbolizers.push(symbolizer);
+        },
+
+        /**
+         * Encodes an ol.style.Image and adds it to the passed symbolizers
+         * array.
+         *
+         * @param {Object[]} symbolizers Array of MapFish Print symbolizers.
+         * @param {ol.style.Image} imageStyle Image style.
+         * @private
+         */
+        encodeVectorStylePoint: function(symbolizers, imageStyle){
+            var symbolizer;
+            if (imageStyle instanceof ol.style.Circle) {
+                symbolizer = {
+                  type: 'point'
+                };
+                symbolizer.pointRadius = imageStyle.getRadius();
+                var fillStyle = imageStyle.getFill();
+                if (fillStyle !== null) {
+                    this.encodeVectorStyleFill(symbolizer, fillStyle);
+                }
+                var strokeStyle = imageStyle.getStroke();
+                if (strokeStyle !== null) {
+                    this.encodeVectorStyleStroke(symbolizer, strokeStyle);
+                }
+            } else if (imageStyle instanceof ol.style.Icon) {
+                var src = imageStyle.getSrc();
+                if (Ext.isDefined(src)) {
+                    symbolizer = {
+                        type: 'point',
+                        externalGraphic: src
+                    };
+                    var rotation = imageStyle.getRotation();
+                    if (rotation !== 0) {
+                        var degreesRotation = rotation * 180 / Math.PI;
+                        symbolizer.rotation = degreesRotation;
+                    }
+                 }
+            }
+            if (Ext.isDefined(symbolizer)) {
+                symbolizers.push(symbolizer);
+            }
+        },
+
+        /**
+         * Encodes an ol.style.Text and adds it to the passed symbolizers
+         * array.
+         *
+         * @param {Object[]} symbolizers Array of MapFish Print symbolizers.
+         * @param {ol.style.Text} textStyle Text style.
+         * @private
+         */
+        encodeTextStyle: function(symbolizers, textStyle) {
+            var symbolizer = {
+                type: 'Text'
+            };
+            var label = textStyle.getText();
+            if (!Ext.isDefined(label)) {
+                // do not encode undefined labels
+                return;
+            }
+
+            symbolizer.label = label;
+
+            var labelAlign = textStyle.getTextAlign();
+            if (Ext.isDefined(labelAlign)) {
+                symbolizer.labelAlign = labelAlign;
+            }
+
+            var labelRotation = textStyle.getRotation();
+            if (Ext.isDefined(labelRotation)) {
+                // Mapfish Print expects a string to rotate text
+                var strRotationDeg = (labelRotation * 180 / Math.PI) + '';
+                symbolizer.labelRotation = strRotationDeg;
+            }
+
+            var fontStyle = textStyle.getFont();
+            if (Ext.isDefined(fontStyle)) {
+                var font = fontStyle.split(' ');
+                if (font.length >= 3) {
+                    symbolizer.fontWeight = font[0];
+                    symbolizer.fontSize = font[1];
+                    symbolizer.fontFamily = font.splice(2).join(' ');
+                }
+            }
+
+            var strokeStyle = textStyle.getStroke();
+            if (strokeStyle !== null) {
+                var strokeColor = strokeStyle.getColor();
+                var strokeColorRgba = ol.color.asArray(strokeColor);
+                symbolizer.haloColor = this.rgbArrayToHex(strokeColorRgba);
+                symbolizer.haloOpacity = strokeColorRgba[3];
+                var width = strokeStyle.getWidth();
+                if (Ext.isDefined(width)) {
+                    symbolizer.haloRadius = width;
+                }
+            }
+
+            var fillStyle = textStyle.getFill();
+            if (fillStyle !== null) {
+                var fillColorRgba = ol.color.asArray(fillStyle.getColor());
+                symbolizer.fontColor = this.rgbArrayToHex(fillColorRgba);
+            }
+
+            // Mapfish Print allows offset only if labelAlign is defined.
+            if (Ext.isDefined(symbolizer.labelAlign)) {
+                symbolizer.labelXOffset = textStyle.getOffsetX();
+                // Mapfish uses the opposite direction of OpenLayers for y
+                // axis, so the minus sign is required for the y offset to
+                // be identical.
+                symbolizer.labelYOffset = -textStyle.getOffsetY();
+            }
+
+            symbolizers.push(symbolizer);
+        },
+
+        /**
+         * Encode the passed ol.style.Fill into the passed symbolizer.
+         *
+         * @param {Object} symbolizer MapFish Print symbolizer.
+         * @param {ol.style.Fill} fillStyle Fill style.
+         * @private
+         */
+        encodeVectorStyleFill: function(symbolizer, fillStyle) {
+            var fillColor = fillStyle.getColor();
+            if (fillColor !== null) {
+                var fillColorRgba = ol.color.asArray(fillColor);
+                symbolizer.fillColor = this.rgbArrayToHex(fillColorRgba);
+                symbolizer.fillOpacity = fillColorRgba[3];
+            }
+        },
+
+        /**
+         * Encode the passed ol.style.Stroke into the passed symbolizer.
+         *
+         * @param {Object} symbolizer MapFish Print symbolizer.
+         * @param {ol.style.Stroke} strokeStyle Stroke style.
+         * @private
+         */
+        encodeVectorStyleStroke: function(symbolizer, strokeStyle){
+            var strokeColor = strokeStyle.getColor();
+            if (strokeColor !== null) {
+                var strokeColorRgba = ol.color.asArray(strokeColor);
+                symbolizer.strokeColor = this.rgbArrayToHex(strokeColorRgba);
+                symbolizer.strokeOpacity = strokeColorRgba[3];
+            }
+            var strokeWidth = strokeStyle.getWidth();
+            if (Ext.isDefined(strokeWidth)) {
+                symbolizer.strokeWidth = strokeWidth;
+            }
+        },
+
+        /**
+         * Takes a hex value and prepends a zero if it's a single digit.
+         * From https://github.com/google/closure-library/blob/master/closure/goog/color/color.js
+         * It is called `prependZeroIfNecessaryHelper` there.
+         *
+         * @param {string} hex Hex value to prepend if single digit.
+         * @return {string} hex value prepended with zero if it was single digit,
+         *     otherwise the same value that was passed in.
+         * @private
+         */
+        padHexValue: function(hex){
+            return hex.length === 1 ? '0' + hex : hex;
+        },
+
+        /**
+         * Converts a color from RGB to hex representation.
+         * Taken from https://github.com/google/closure-library/blob/master/closure/goog/color/color.js
+         *
+         * @param {number} r Amount of red, int between 0 and 255.
+         * @param {number} g Amount of green, int between 0 and 255.
+         * @param {number} b Amount of blue, int between 0 and 255.
+         * @return {String} The passed color in hex representation.
+         * @private
+         */
+        rgbToHex: function(r, g, b){
+            r = Number(r);
+            g = Number(g);
+            b = Number(b);
+            if (isNaN(r) || r < 0 || r > 255 ||
+                isNaN(g) || g < 0 || g > 255 ||
+                isNaN(b) || b < 0 || b > 255) {
+                Ext.raise('"(' + r + ',' + g + ',' + b + '") is not a valid ' +
+                    ' RGB color');
+            }
+            var hexR = this.padHexValue(r.toString(16));
+            var hexG = this.padHexValue(g.toString(16));
+            var hexB = this.padHexValue(b.toString(16));
+            return '#' + hexR + hexG + hexB;
+        },
+        /**
+         * Converts a color from RGB to hex representation.
+         * Taken from https://github.com/google/closure-library/blob/master/closure/goog/color/color.js
+         *
+         * @param {Number[]} rgbArr An array with three numbers representing
+         *    red, green and blue.
+         * @return {String} The passed color in hex representation.
+         * @private
+         */
+        rgbArrayToHex: function(rgbArr){
+            return this.rgbToHex(rgbArr[0], rgbArr[1], rgbArr[2]);
+        },
+
+        /**
+         * Returns a unique id for this object. The object is assigned a new
+         * property #GX_UID_PROPERTY and modified in place if this hasn't
+         * happened in a previous call.
+         *
+         * @param {Object} The object to get the uid of.
+         * @return {String} The uid of the object.
+         * @private
+         */
+        getUid: function(obj) {
+            if (!Ext.isObject(obj)) {
+                Ext.raise('Cannot get uid of non-object.');
+            }
+            var key = this.GX_UID_PROPERTY;
+            if (!Ext.isDefined(obj[key])) {
+                obj[key] = Ext.id();
+            }
+            return obj[key];
+        }
+    }
+}, function(cls) {
+    // This is ol.geom.GeometryType, from https://github.com/openlayers/ol3/blob/master/src/ol/geom/geometry.js
+    var olGeomTypes = {
+        POINT: 'Point',
+        LINE_STRING: 'LineString',
+        LINEAR_RING: 'LinearRing',
+        POLYGON: 'Polygon',
+        MULTI_POINT: 'MultiPoint',
+        MULTI_LINE_STRING: 'MultiLineString',
+        MULTI_POLYGON: 'MultiPolygon',
+        GEOMETRY_COLLECTION: 'GeometryCollection',
+        CIRCLE: 'Circle'
+    };
+    // The supported types for the print
+    var printStyleTypes = cls.PRINTSTYLE_TYPES;
+
+    // a map that connect ol geometry types to their mapfish equivalent;
+    // Please note that not all ol geometry types can be serialized.
+    var geom2print = {};
+    geom2print[olGeomTypes.POINT] = printStyleTypes.POINT;
+    geom2print[olGeomTypes.MULTI_POINT] = printStyleTypes.POINT;
+    geom2print[olGeomTypes.LINE_STRING] = printStyleTypes.LINE_STRING;
+    geom2print[olGeomTypes.MULTI_LINE_STRING] = printStyleTypes.LINE_STRING;
+    geom2print[olGeomTypes.POLYGON] = printStyleTypes.POLYGON;
+    geom2print[olGeomTypes.MULTI_POLYGON] = printStyleTypes.POLYGON;
+
+    cls.GEOMETRY_TYPE_TO_PRINTSTYLE_TYPE = geom2print;
+
+    // Register this serializer via the inherited method `register`.
+    cls.register(cls);
+});

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -12,6 +12,7 @@
             'GeoExt/data/serializer/Base.test.js',
             'GeoExt/data/serializer/ImageWMS.test.js',
             'GeoExt/data/serializer/TileWMS.test.js',
+            'GeoExt/data/serializer/Vector.test.js',
             'GeoExt/data/store/Collection.test.js',
             'GeoExt/data/store/Features.test.js',
             'GeoExt/data/store/Tree.test.js',

--- a/test/spec/GeoExt/data/MapfishPrintProvider.test.js
+++ b/test/spec/GeoExt/data/MapfishPrintProvider.test.js
@@ -276,7 +276,7 @@ describe('GeoExt.data.MapfishPrintProvider', function() {
 
         it('getSerializedLayers returns the serialized Layers', function(){
             expect(GeoExt.data.MapfishPrintProvider.getSerializedLayers).to.be.a('function');
-            var serializedLayers = GeoExt.data.MapfishPrintProvider.getSerializedLayers(mapComponent.getStore());
+            var serializedLayers = GeoExt.data.MapfishPrintProvider.getSerializedLayers(mapComponent);
             var serializedLayer = serializedLayers[0];
 
             expect(serializedLayers).to.be.an('array');

--- a/test/spec/GeoExt/data/serializer/ImageWMS.test.js
+++ b/test/spec/GeoExt/data/serializer/ImageWMS.test.js
@@ -13,6 +13,7 @@ describe('GeoExt.data.serializer.ImageWMS', function() {
     describe('serializing behaviour', function() {
         var source = null;
         var layer = null;
+        var viewResolution = 38.21851414258813;
 
         beforeEach(function(){
             source = new ol.source.ImageWMS({
@@ -32,7 +33,9 @@ describe('GeoExt.data.serializer.ImageWMS', function() {
 
         it('doesn\'t throw on expected source', function(){
             expect(function(){
-                GeoExt.data.serializer.ImageWMS.serialize(layer, source);
+                GeoExt.data.serializer.ImageWMS.serialize(
+                    layer, source, viewResolution
+                );
             }).to.not.throwException();
         });
 
@@ -44,13 +47,15 @@ describe('GeoExt.data.serializer.ImageWMS', function() {
                 crossOrigin: ''
             });
             expect(function(){
-                GeoExt.data.serializer.ImageWMS.serialize(layer, wrongSource);
+                GeoExt.data.serializer.ImageWMS.serialize(
+                    layer, wrongSource, viewResolution
+                );
             }).to.throwException();
         });
 
         it('serializes as expected', function(){
             var serialized = GeoExt.data.serializer.ImageWMS.serialize(
-                layer, source
+                layer, source, viewResolution
             );
             var expected = {
                 baseURL: 'http://demo.boundlessgeo.com/geoserver/wms',

--- a/test/spec/GeoExt/data/serializer/TileWMS.test.js
+++ b/test/spec/GeoExt/data/serializer/TileWMS.test.js
@@ -13,6 +13,7 @@ describe('GeoExt.data.serializer.TileWMS', function() {
     describe('serializing behaviour', function() {
         var source = null;
         var layer = null;
+        var viewResolution = 38.21851414258813;
 
         beforeEach(function(){
             source = new ol.source.TileWMS({
@@ -32,7 +33,9 @@ describe('GeoExt.data.serializer.TileWMS', function() {
 
         it('doesn\'t throw on expected source', function(){
             expect(function(){
-                GeoExt.data.serializer.TileWMS.serialize(layer, source);
+                GeoExt.data.serializer.TileWMS.serialize(
+                    layer, source, viewResolution
+                );
             }).to.not.throwException();
         });
 
@@ -44,13 +47,15 @@ describe('GeoExt.data.serializer.TileWMS', function() {
                 crossOrigin: ''
             });
             expect(function(){
-                GeoExt.data.serializer.TileWMS.serialize(layer, wrongSource);
+                GeoExt.data.serializer.TileWMS.serialize(
+                    layer, wrongSource, viewResolution
+                );
             }).to.throwException();
         });
 
         it('serializes as expected', function(){
             var serialized = GeoExt.data.serializer.TileWMS.serialize(
-                layer, source
+                layer, source, viewResolution
             );
             var expected = {
                 baseURL: 'http://demo.boundlessgeo.com/geoserver/wms',

--- a/test/spec/GeoExt/data/serializer/Vector.test.js
+++ b/test/spec/GeoExt/data/serializer/Vector.test.js
@@ -1,0 +1,447 @@
+Ext.Loader.syncRequire(['GeoExt.data.serializer.Vector']);
+
+describe('GeoExt.data.serializer.Vector', function() {
+
+    describe('basics', function(){
+
+        it('is defined', function(){
+            expect(GeoExt.data.serializer.Vector).not.to.be(undefined);
+        });
+
+    });
+
+    describe('static methods and properties', function(){
+
+        describe('#GEOMETRY_TYPE_TO_PRINTSTYLE_TYPE', function() {
+
+            it('assigns a valid printstyle-type for 6 geometry types', function(){
+                var olGeomTypes = [
+                    'Point', 'LineString', 'Polygon',
+                    'MultiPoint', 'MultiLineString', 'MultiPolygon'
+                ];
+                var possiblePrintStyles = Ext.Object.getValues(
+                        GeoExt.data.serializer.Vector.PRINTSTYLE_TYPES
+                    );
+                var lookUp = GeoExt.data.serializer.Vector.GEOMETRY_TYPE_TO_PRINTSTYLE_TYPE
+                Ext.each(olGeomTypes, function(olGeomType){
+                    var printstyle = lookUp[olGeomType];
+                    expect(printstyle).to.not.be(undefined);
+                    expect(Ext.Array.contains(possiblePrintStyles, printstyle)).to.be(true);
+                });
+            });
+
+        });
+
+        describe('#getUid', function(){
+
+            it('throws when called on a non-object', function() {
+                expect(function(){
+                    GeoExt.data.serializer.Vector.getUid(null);
+                }).to.throwException();
+                expect(function(){
+                    GeoExt.data.serializer.Vector.getUid(undefined);
+                }).to.throwException();
+                expect(function(){
+                    GeoExt.data.serializer.Vector.getUid(-1);
+                }).to.throwException();
+                expect(function(){
+                    GeoExt.data.serializer.Vector.getUid(12.345);
+                }).to.throwException();
+                expect(function(){
+                    GeoExt.data.serializer.Vector.getUid('Humpty');
+                }).to.throwException();
+                expect(function(){
+                    GeoExt.data.serializer.Vector.getUid(/abc/);
+                }).to.throwException();
+                expect(function(){
+                    GeoExt.data.serializer.Vector.getUid([]);
+                }).to.throwException();
+                expect(function(){
+                    GeoExt.data.serializer.Vector.getUid(function(){});
+                }).to.throwException();
+                expect(function(){
+                    GeoExt.data.serializer.Vector.getUid(true);
+                }).to.throwException();
+            });
+
+            it('assigns once, reads out for subsequent calls', function(){
+                var obj = {};
+                var got = GeoExt.data.serializer.Vector.getUid(obj);
+                expect(got).to.not.be(undefined);
+                var got2 = GeoExt.data.serializer.Vector.getUid(obj);
+                var got3 = GeoExt.data.serializer.Vector.getUid(obj);
+                expect(got).to.be(got2);
+                expect(got).to.be(got3);
+            });
+
+            it('assigns a new property to the passed object', function(){
+                var obj = {};
+                var got = GeoExt.data.serializer.Vector.getUid(obj);
+                var key = GeoExt.data.serializer.Vector.GX_UID_PROPERTY;
+                expect(Ext.Object.getSize(obj)).to.be(1);
+                expect(obj[key]).to.not.be(undefined);
+            });
+
+        });
+
+    });
+
+    describe('serializing behaviour', function() {
+        var source = null;
+        var layer = null;
+        var viewResolution = 38.21851414258813;
+        var style0 = style1 = style2 = style3 = style4 = null;
+
+        beforeEach(function(){
+            var feature0 = new ol.Feature({
+                geometry: new ol.geom.Point([0, 0]),
+                foo: '0'
+            });
+
+            var feature1 = new ol.Feature({
+                geometry: new ol.geom.LineString([[0, 0], [1, 1]]),
+                foo: '1'
+            });
+
+            var feature2 = new ol.Feature({
+                geometry: new ol.geom.Polygon([[[0, 0], [1, 1], [1, 0], [0, 0]]]),
+                foo: '2'
+            });
+
+            var feature3 = new ol.Feature({
+                geometry: new ol.geom.Point([0, 0]),
+                foo: '3'
+            });
+
+            style0 = new ol.style.Style({
+                fill: new ol.style.Fill({
+                    color: [1, 1, 1, 0.1]
+                }),
+                image: new ol.style.Circle({
+                    radius: 1,
+                    stroke: new ol.style.Stroke({
+                        width: 1,
+                        color: [1, 1, 1, 0.1]
+                    })
+                }),
+                stroke: new ol.style.Stroke({
+                    width: 1,
+                    color: [1, 1, 1, 0.1]
+                })
+            });
+
+            // styles for feature0
+            var styles0 = [style0];
+
+            style1 = new ol.style.Style({
+                stroke: new ol.style.Stroke({
+                    width: 2,
+                    color: [2, 2, 2, 0.2]
+                })
+            });
+
+            // styles for feature1
+            var styles1 = [style0, style1];
+
+            style2 = new ol.style.Style({
+                fill: new ol.style.Fill({
+                    color: [3, 3, 3, 0.3]
+                }),
+                stroke: new ol.style.Stroke({
+                    width: 3,
+                    color: [3, 3, 3, 0.3]
+                })
+            });
+
+            // styles for features2
+            var styles2 = [style2];
+
+            style3 = new ol.style.Style({
+                text: new ol.style.Text({
+                    font: 'normal 16px "sans serif"',
+                    text: 'GeoExt3',
+                    textAlign: 'left',
+                    offsetX: 42,
+                    offsetY: -42
+                })
+            });
+
+            // Here to check that no offset are present if textAlign is not there.
+            style4 = new ol.style.Style({
+                text: new ol.style.Text({
+                    font: 'normal 16px "sans serif"',
+                    text: 'Ngeo',
+                    offsetX: 42,
+                    offsetY: -42
+                })
+            });
+
+            // styles for features3
+            var styles3 = [style3, style4];
+
+            var styleFunction = function(feature, resolution) {
+                var v = feature.get('foo');
+                if (v == '0') {
+                    return styles0;
+                } else if (v == '1') {
+                    return styles1;
+                } else if (v == '2') {
+                    return styles2;
+                } else if (v == '3') {
+                    return styles3;
+                }
+            };
+
+            source = new ol.source.Vector({
+                features: [
+                    feature0,
+                    feature1,
+                    feature2,
+                    feature3
+                ]
+            });
+            layer = new ol.layer.Vector({
+                opacity: 0.8,
+                source: source,
+                style: styleFunction
+            });
+        });
+
+        afterEach(function(){
+            source = null;
+            layer = null;
+            style0 = style1 = style2 = style3 = style4 = null
+        });
+
+        it('doesn\'t throw on expected source', function(){
+            expect(function(){
+                GeoExt.data.serializer.Vector.serialize(
+                    layer, source, viewResolution
+                );
+            }).to.not.throwException();
+        });
+
+        it('correctly throws on unexpected source', function(){
+            var wrongSource = new ol.source.ImageWMS({
+                url: 'http://demo.boundlessgeo.com/geoserver/wms',
+                params: {'LAYERS': 'ne:ne'},
+                serverType: 'geoserver',
+                crossOrigin: ''
+            });
+            expect(function(){
+                GeoExt.data.serializer.Vector.serialize(
+                    layer, wrongSource, viewResolution
+                );
+            }).to.throwException();
+        });
+
+        // This test is more or less a copy of the test
+        // that is used in camptocamp/ngeo
+        // see e.g. https://github.com/camptocamp/ngeo/blob/master/test/spec/services/print.spec.js
+        it('serializes as expected', function(){
+            var vecSerializer = GeoExt.data.serializer.Vector;
+
+            var styleId0 = vecSerializer.getUid(style0);
+            var styleId1 = vecSerializer.getUid(style1);
+            var styleId2 = vecSerializer.getUid(style2);
+            var styleId3 = vecSerializer.getUid(style3);
+            var styleId4 = vecSerializer.getUid(style4);
+
+            var expectedStyle = {
+                version: 2
+            };
+            expectedStyle['[_gx3_style_0 = \'' + styleId0 + '\']'] = {
+                symbolizers: [{
+                    type: 'point',
+                    pointRadius: 1,
+                    strokeColor: '#010101',
+                    strokeOpacity: 0.1,
+                    strokeWidth: 1
+                }]
+            };
+            expectedStyle['[_gx3_style_1 = \'' + styleId1 + '\']'] = {
+                symbolizers: [{
+                    type: 'line',
+                    strokeColor: '#020202',
+                    strokeOpacity: 0.2,
+                    strokeWidth: 2
+                }]
+            };
+            expectedStyle['[_gx3_style_0 = \'' + styleId2 + '\']'] = {
+                symbolizers: [{
+                    type: 'polygon',
+                    fillColor: '#030303',
+                    fillOpacity: 0.3,
+                    strokeColor: '#030303',
+                    strokeOpacity: 0.3,
+                    strokeWidth: 3
+                }]
+            };
+            expectedStyle['[_gx3_style_0 = \'' + styleId3 + '\']'] = {
+                symbolizers: [{
+                    type: 'Text',
+                    fontWeight: 'normal',
+                    fontSize: '16px',
+                    fontFamily: '"sans serif"',
+                    label: 'GeoExt3',
+                    labelAlign: 'left',
+                    labelXOffset: 42,
+                    labelYOffset: 42
+                }]
+            };
+            expectedStyle['[_gx3_style_1 = \'' + styleId4 + '\']'] = {
+                symbolizers: [{
+                    type: 'Text',
+                    fontWeight: 'normal',
+                    fontSize: '16px',
+                    fontFamily: '"sans serif"',
+                    label: 'Ngeo'
+                }]
+            };
+
+            // the expected properties of feature0
+            var properties0 = {
+                foo: '0',
+                '_gx3_style_0': styleId0
+            };
+
+            // the expected properties of feature1
+            var properties1 = {
+                foo: '1',
+                '_gx3_style_0': styleId0,
+                '_gx3_style_1': styleId1
+            };
+
+            // the expected properties of feature2
+            var properties2 = {
+                foo: '2',
+                '_gx3_style_0': styleId2
+            };
+
+            // the expected properties of feature3
+            var properties3 = {
+                foo: '3',
+                '_gx3_style_0': styleId3,
+                '_gx3_style_1': styleId4
+            };
+
+            // construct the final expected layer serialisation
+            var expected = {
+                geoJson: {
+                    type: 'FeatureCollection',
+                    features: [{
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Point',
+                            coordinates: [0, 0]
+                        },
+                        properties: properties0
+                    }, {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'LineString',
+                            coordinates: [[0, 0], [1, 1]]
+                        },
+                        properties: properties1
+                    }, {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Polygon',
+                            coordinates: [[[0, 0], [1, 1], [1, 0], [0, 0]]]
+                        },
+                        properties: properties2
+                    }, {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Point',
+                            coordinates: [0, 0]
+                        },
+                        properties: properties3
+                    }]
+                },
+                opacity: 0.8,
+                style: expectedStyle,
+                type: 'geojson'
+            };
+
+            var serialized = GeoExt.data.serializer.Vector.serialize(
+                layer, source, viewResolution
+            );
+            expect(serialized).to.eql(expected);
+        });
+
+        it('serializes an empty source with the fallback serialization', function(){
+            layer = new ol.layer.Vector({
+                source: new ol.source.Vector()
+            });
+            var serialized = GeoExt.data.serializer.Vector.serialize(
+                layer, layer.getSource(), viewResolution
+            );
+            expect(serialized).to.eql(
+                GeoExt.data.serializer.Vector.FALLBACK_SERIALIZATION
+            );
+        });
+
+        it('skips features without geometry', function(){
+            layer = new ol.layer.Vector({
+                source: new ol.source.Vector({
+                    features: [
+                        new ol.Feature(),
+                        new ol.Feature({
+                            geometry: null
+                        }),
+                        new ol.Feature({
+                            geometry: new ol.geom.Point([0, 0])
+                        })
+                    ]
+                })
+            });
+            var serialized = GeoExt.data.serializer.Vector.serialize(
+                layer, layer.getSource(), viewResolution
+            );
+            expect(serialized.geoJson.features.length).to.be(1);
+        });
+
+        it('uses a features style function', function() {
+            var feat = new ol.Feature({
+                geometry: new ol.geom.Point([0, 0])
+            });
+            var style = new ol.style.Style({
+                image: new ol.style.Circle({
+                    radius: 84,
+                    stroke: new ol.style.Stroke({
+                        width: 42,
+                        color: [255, 0, 0, 0.5]
+                    })
+                })
+            });
+            var styleUid = GeoExt.data.serializer.Vector.getUid(style);
+            feat.setStyle(function(res) {
+                return [ style ];
+            });
+
+            layer = new ol.layer.Vector({
+                source: new ol.source.Vector({
+                    features: [ feat ]
+                })
+            });
+
+            var serialized = GeoExt.data.serializer.Vector.serialize(
+                layer, layer.getSource(), viewResolution
+            );
+
+            var cql = "[_gx3_style_0 = '" + styleUid + "']";
+            var symbolizer = serialized.style[cql].symbolizers[0];
+
+            expect(symbolizer).to.eql({
+                pointRadius: 84,
+                strokeColor: "#ff0000",
+                strokeOpacity: 0.5,
+                strokeWidth: 42,
+                type: "point"
+            })
+        });
+
+    });
+
+});


### PR DESCRIPTION
This PR adds support for printing vector layers by introducing a new serializer for vectors.

What is included:

* The print example now shows a vector layer (Schools in San Franscisco from a KML file, see http://data.sfgov.org)
* The signature of `MapfishPrintProvider.getSerializedLayers` is changed from `function(layers)` to `function(mapComponent, filterFn, filterScope){`
  * One now needs to pass the mapComponent isntead of the layer store, so we have a chance of getting the view resolution
  * the layers to be serialized can be filterd with the two new optional arguments for a function and the scope the function is being called on
* A new serializer class
  * The main class `GeoExt.data.serializer.Vector` is **heavily** inspired by the great implementation in camptocamp/ngeo (specifically the file src/services/print.js @ camptocamp/ngeo@3dc2a63c37b423ada2e654d80d669f0b420ec84e)
  * As that implementation uses some google closure library methods, these have been ported over as well
  * The tests of that class are also inspired by the one in the ngeo-project.
  * Thanks a lot to the work of @elemoine and @Jenselme

Please review.