### PR TITLE
Automatically check for required external symbols

### DIFF
--- a/src/component/FeatureRenderer.js
+++ b/src/component/FeatureRenderer.js
@@ -21,6 +21,35 @@
 Ext.define('GeoExt.component.FeatureRenderer', {
     extend: 'Ext.Component',
     alias: 'widget.gx_renderer',
+    requires: [
+        'GeoExt.util.Symbol'
+    ],
+    // <debug>
+    symbols: [
+        'ol.extent.getCenter',
+        'ol.extent.getWidth',
+        'ol.extent.getHeight',
+        'ol.Feature',
+        'ol.Feature#getGeometry',
+        'ol.Feature#setStyle',
+        'ol.geom.Geometry#getExtent',
+        'ol.geom.Point',
+        'ol.geom.LineString',
+        'ol.geom.Polygon',
+        'ol.layer.Vector',
+        'ol.layer.Vector#getSource',
+        'ol.Map#getSize',
+        'ol.Map#getView',
+        'ol.Map#setView',
+        'ol.Map#updateSize',
+        'ol.proj.Projection',
+        'ol.source.Vector',
+        'ol.source.Vector#addFeature',
+        'ol.View',
+        'ol.View#fit'
+    ],
+    // </debug>
+
     /**
      * Fires when the feature is clicked on.
      *
@@ -347,4 +376,8 @@ Ext.define('GeoExt.component.FeatureRenderer', {
             this.setSymbolizers(options.symbolizers);
         }
     }
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -42,8 +42,28 @@ Ext.define("GeoExt.component.Map", {
     ],
 
     requires: [
-        'GeoExt.data.store.Layer'
+        'GeoExt.data.store.Layer',
+        'GeoExt.util.Symbol'
     ],
+    // <debug>
+    symbols: [
+        'ol.layer.Base',
+        'ol.Map',
+        'ol.Map#addLayer',
+        'ol.Map#getLayers',
+        'ol.Map#getSize',
+        'ol.Map#getView',
+        'ol.Map#removeLayer',
+        'ol.Map#setTarget',
+        'ol.Map#setView',
+        'ol.Map#updateSize',
+        'ol.View',
+        'ol.View#calculateExtent',
+        'ol.View#fit',
+        'ol.View#getCenter',
+        'ol.View#setCenter'
+    ],
+    // </debug>
 
     /**
      * @event pointerrest
@@ -444,4 +464,8 @@ Ext.define("GeoExt.component.Map", {
     setView: function(view){
         this.getMap().setView(view);
     }
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -63,6 +63,49 @@ Ext.define("GeoExt.component.OverviewMap", {
         'widget.gx_overviewmap',
         'widget.gx_component_overviewmap'
     ],
+    requires: [
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol.animation.pan',
+        'ol.Collection',
+        'ol.Feature',
+        'ol.Feature#setGeometry',
+        'ol.Feature#setStyle',
+        'ol.geom.Point',
+        'ol.geom.Point#getCoordinates',
+        'ol.geom.Point#setCoordinates',
+        'ol.geom.Polygon',
+        'ol.geom.Polygon.fromExtent',
+        'ol.geom.Polygon#getCoordinates',
+        'ol.geom.Polygon#setCoordinates',
+        'ol.layer.Image', // we should get rid of this requirement
+        'ol.layer.Tile', // we should get rid of this requirement
+        'ol.layer.Vector',
+        'ol.layer.Vector#getSource',
+        'ol.Map',
+        'ol.Map#addLayer',
+        'ol.Map#beforeRender',
+        'ol.Map#getView',
+        'ol.Map#on',
+        'ol.Map#updateSize',
+        'ol.Map#un',
+        'ol.source.Vector',
+        'ol.source.Vector#addFeatures',
+        'ol.View',
+        'ol.View#calculateExtent',
+        'ol.View#getCenter',
+        'ol.View#getProjection',
+        'ol.View#getRotation',
+        'ol.View#getZoom',
+        'ol.View#on',
+        'ol.View#set',
+        'ol.View#setCenter',
+        'ol.View#un'
+    ],
+    // </debug>
 
     config: {
         /**
@@ -443,4 +486,8 @@ Ext.define("GeoExt.component.OverviewMap", {
         this.boxFeature.setStyle(style);
         return style;
     }
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/MapfishPrintProvider.js
+++ b/src/data/MapfishPrintProvider.js
@@ -22,8 +22,19 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
     mixins: ['Ext.mixin.Observable'],
     requires: [
         'GeoExt.data.model.print.Capability',
+        'GeoExt.util.Symbol',
         'Ext.data.JsonStore'
     ],
+    // <debug>
+    symbols: [
+        'ol.Collection',
+        'ol.geom.Polygon.fromExtent',
+        'ol.layer.Layer#getSource',
+        'ol.layer.Group',
+        'ol.source.Vector.prototype.addFeature',
+        'ol.View#calculateExtent'
+    ],
+    // </debug>
 
     /**
      * @event ready
@@ -292,4 +303,8 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
             });
         }
     }
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/model/Layer.js
+++ b/src/data/model/Layer.js
@@ -20,6 +20,17 @@
  */
 Ext.define('GeoExt.data.model.Layer', {
     extend: 'GeoExt.data.model.Base',
+    requires: [
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol.layer.Group',
+        'ol.layer.Base',
+        'ol.layer.Base#get'
+    ],
+    // </debug>
 
     statics: {
         /**
@@ -112,4 +123,8 @@ Ext.define('GeoExt.data.model.Layer', {
             return this.data;
         }
     }
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/model/LayerTreeNode.js
+++ b/src/data/model/LayerTreeNode.js
@@ -21,8 +21,16 @@
 Ext.define('GeoExt.data.model.LayerTreeNode', {
     extend: 'GeoExt.data.model.Layer',
     requires: [
-        'Ext.data.NodeInterface'
+        'Ext.data.NodeInterface',
+        'GeoExt.util.Symbol'
     ],
+    // <debug>
+    symbols: [
+        'ol.layer.Base',
+        'ol.Object#get',
+        'ol.Object#set'
+    ],
+    // </debug>
 
     mixins: [
         'Ext.mixin.Queryable'
@@ -177,7 +185,10 @@ Ext.define('GeoExt.data.model.LayerTreeNode', {
         return this.parentNode;
     }
 
-}, function () {
+}, function (cls) {
     // make this an Ext.data.TreeModel
     Ext.data.NodeInterface.decorate(this);
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/model/Object.js
+++ b/src/data/model/Object.js
@@ -18,6 +18,19 @@
  */
 Ext.define('GeoExt.data.model.Object', {
     extend: 'GeoExt.data.model.Base',
+    requires: [
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol',
+        'ol.Object',
+        'ol.Object#on',
+        'ol.Object#get',
+        'ol.Object#set'
+    ],
+    // </debug>
 
     statics: {
         /**
@@ -148,4 +161,8 @@ Ext.define('GeoExt.data.model.Object', {
 
         this.callParent(arguments);
     }
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/serializer/Base.js
+++ b/src/data/serializer/Base.js
@@ -18,7 +18,18 @@
  */
 Ext.define('GeoExt.data.serializer.Base', {
     extend: 'Ext.Base',
-    requires: 'GeoExt.data.MapfishPrintProvider',
+    requires: [
+        'GeoExt.data.MapfishPrintProvider',
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol.layer.Layer',
+        'ol.source.Source'
+    ],
+    // </debug>
+
     inheritableStatics: {
         /**
          * The ol.source.Source class that this serializer will serialize.
@@ -71,4 +82,8 @@ Ext.define('GeoExt.data.serializer.Base', {
             }
         }
     }
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/serializer/ImageWMS.js
+++ b/src/data/serializer/ImageWMS.js
@@ -18,6 +18,20 @@
  */
 Ext.define('GeoExt.data.serializer.ImageWMS', {
     extend: 'GeoExt.data.serializer.Base',
+
+    requires: [
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol.layer.Layer#getOpacity',
+        'ol.source.ImageWMS',
+        'ol.source.ImageWMS#getUrl',
+        'ol.source.ImageWMS#getParams'
+    ],
+    // </debug>
+
     inheritableStatics: {
         /**
          * @inheritdoc
@@ -45,4 +59,7 @@ Ext.define('GeoExt.data.serializer.ImageWMS', {
 }, function(cls) {
     // Register this serializer via the inherited method `register`.
     cls.register(cls);
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/serializer/TileWMS.js
+++ b/src/data/serializer/TileWMS.js
@@ -18,6 +18,20 @@
  */
 Ext.define('GeoExt.data.serializer.TileWMS', {
     extend: 'GeoExt.data.serializer.Base',
+
+    requires: [
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol.layer.Layer#getOpacity',
+        'ol.source.TileWMS',
+        'ol.source.TileWMS#getUrls',
+        'ol.source.TileWMS#getParams'
+    ],
+    // </debug>
+
     inheritableStatics: {
         /**
          * @inheritdoc
@@ -45,4 +59,7 @@ Ext.define('GeoExt.data.serializer.TileWMS', {
 }, function(cls) {
     // Register this serializer via the inherited method `register`.
     cls.register(cls);
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/serializer/Vector.js
+++ b/src/data/serializer/Vector.js
@@ -24,6 +24,56 @@
  */
 Ext.define('GeoExt.data.serializer.Vector', {
     extend: 'GeoExt.data.serializer.Base',
+
+    requires: [
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol.color.asArray',
+        'ol.Feature',
+        'ol.Feature#getGeometry',
+        'ol.Feature#getStyleFunction',
+        'ol.format.GeoJSON',
+        'ol.format.GeoJSON#writeFeatureObject',
+        'ol.geom.Geometry',
+        'ol.geom.LineString#getType',
+        'ol.geom.MultiLineString#getType',
+        'ol.geom.MultiPoint#getType',
+        'ol.geom.MultiPolygon#getType',
+        'ol.geom.Point#getType',
+        'ol.geom.Polygon#getType',
+        'ol.layer.Vector#getOpacity',
+        'ol.layer.Vector#getStyleFunction',
+        'ol.source.Vector',
+        'ol.source.Vector#getFeatures',
+        'ol.style.Circle',
+        'ol.style.Circle#getRadius',
+        'ol.style.Circle#getFill',
+        'ol.style.Fill',
+        'ol.style.Fill#getColor',
+        'ol.style.Icon',
+        'ol.style.Icon#getSrc',
+        'ol.style.Icon#getRotation',
+        'ol.style.Stroke',
+        'ol.style.Stroke#getColor',
+        'ol.style.Stroke#getWidth',
+        'ol.style.Style',
+        'ol.style.Style#getFill',
+        'ol.style.Style#getImage',
+        'ol.style.Style#getStroke',
+        'ol.style.Style#getText',
+        'ol.style.Text',
+        'ol.style.Text#getFont',
+        'ol.style.Text#getOffsetX',
+        'ol.style.Text#getOffsetY',
+        'ol.style.Text#getRotation',
+        'ol.style.Text#getText',
+        'ol.style.Text#getTextAlign'
+    ],
+    // </debug>
+
     inheritableStatics: {
         /**
          * The types of styles that mapfish supports.
@@ -557,4 +607,7 @@ Ext.define('GeoExt.data.serializer.Vector', {
 
     // Register this serializer via the inherited method `register`.
     cls.register(cls);
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/serializer/WMTS.js
+++ b/src/data/serializer/WMTS.js
@@ -22,6 +22,32 @@
  */
 Ext.define('GeoExt.data.serializer.WMTS', {
     extend: 'GeoExt.data.serializer.Base',
+
+    requires: [
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol.proj.Projection#getMetersPerUnit',
+        'ol.size.toSize',
+        'ol.source.WMTS',
+        'ol.source.WMTS#getDimensions',
+        'ol.source.WMTS#getFormat',
+        'ol.source.WMTS#getLayer',
+        'ol.source.WMTS#getMatrixSet',
+        'ol.source.WMTS#getProjection',
+        'ol.source.WMTS#getRequestEncoding',
+        'ol.source.WMTS#getStyle',
+        'ol.source.WMTS#getTileGrid',
+        'ol.source.WMTS#getUrls',
+        'ol.source.WMTS#getVersion',
+        'ol.tilegrid.WMTS#getMatrixIds',
+        'ol.tilegrid.WMTS#getOrigin',
+        'ol.tilegrid.WMTS#getResolution'
+    ],
+    // </debug>
+
     inheritableStatics: {
         /**
          * @inheritdoc
@@ -75,4 +101,7 @@ Ext.define('GeoExt.data.serializer.WMTS', {
 }, function(cls) {
     // Register this serializer via the inherited method `register`.
     cls.register(cls);
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/store/Collection.js
+++ b/src/data/store/Collection.js
@@ -19,8 +19,18 @@
 Ext.define('GeoExt.data.store.Collection', {
     extend: 'Ext.data.Store',
     requires: [
-        'GeoExt.data.model.Object'
+        'GeoExt.data.model.Object',
+        'GeoExt.util.Symbol'
     ],
+
+    // <debug>
+    symbols: [
+        'ol.Collection',
+        'ol.Collection#getArray',
+        'ol.Collection#insertAt',
+        'ol.Collection#removeAt'
+    ],
+    // </debug>
 
     /**
      * The ol collection this store syncs with.
@@ -139,4 +149,8 @@ Ext.define('GeoExt.data.store.Collection', {
 
         this.callParent(arguments);
     }
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -20,7 +20,27 @@
  */
 Ext.define('GeoExt.data.store.Features', {
     extend: 'GeoExt.data.store.Collection',
-    requires: [],
+    requires: [
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol.Collection',
+        'ol.layer.Vector',
+        'ol.Map',
+        'ol.Map#addLayer',
+        'ol.Map#removeLayer',
+        'ol.source.Vector',
+        'ol.source.Vector#getFeatures',
+        'ol.source.Vector#on',
+        'ol.source.Vector#un',
+        'ol.style.Circle',
+        'ol.style.Fill',
+        'ol.style.Stroke',
+        'ol.style.Style'
+    ],
+    // </debug>
 
     model: 'GeoExt.data.model.Feature',
 
@@ -245,4 +265,8 @@ Ext.define('GeoExt.data.store.Features', {
         }
     }
 
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/store/Layer.js
+++ b/src/data/store/Layer.js
@@ -21,8 +21,30 @@
  */
 Ext.define('GeoExt.data.store.Layer', {
     extend: 'Ext.data.Store',
-    requires: ['GeoExt.data.model.Layer'],
     alternateClassName: ['GeoExt.data.LayerStore'],
+    requires: [
+        'GeoExt.data.model.Layer',
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol.Collection#clear',
+        'ol.Collection#forEach',
+        'ol.Collection#getArray',
+        'ol.Collection#insertAt',
+        'ol.Collection#on',
+        'ol.Collection#push',
+        'ol.Collection#remove',
+        'ol.layer.Layer',
+        'ol.layer.Layer#get',
+        'ol.layer.Layer#on',
+        'ol.layer.Layer#set',
+        'ol.Map',
+        'ol.Map#getLayers'
+    ],
+    // </debug>
+
     model: 'GeoExt.data.model.Layer',
 
     config: {
@@ -375,4 +397,8 @@ Ext.define('GeoExt.data.store.Layer', {
         }
     }
 
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/data/store/Tree.js
+++ b/src/data/store/Tree.js
@@ -23,6 +23,24 @@ Ext.define('GeoExt.data.store.Tree', {
 
     alternateClassName: ['GeoExt.data.TreeStore'],
 
+    requires: [
+        'GeoExt.util.Symbol'
+    ],
+
+    // <debug>
+    symbols: [
+        'ol.Collection',
+        'ol.Collection#getArray',
+        'ol.Collection#once',
+        'ol.Collection#un',
+        'ol.layer.Base',
+        'ol.layer.Base#get',
+        'ol.layer.Group',
+        'ol.layer.Group#get',
+        'ol.layer.Group#getLayers'
+    ],
+    // </debug>
+
     model: 'GeoExt.data.model.LayerTreeNode',
 
     config: {
@@ -251,4 +269,8 @@ Ext.define('GeoExt.data.store.Tree', {
     resumeCollectionEvents: function(){
         this.collectionEventsSuspended = false;
     }
+}, function(cls) {
+    // <debug>
+    GeoExt.util.Symbol.check(cls);
+    // </debug>
 });

--- a/src/util/Symbol.js
+++ b/src/util/Symbol.js
@@ -1,0 +1,194 @@
+/* Copyright (c) 2015 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * A utility class providing methods to check for symbols of OpenLayers we
+ * depend upon.
+ *
+ * This class can be used to check if the dependencies to external symbols are
+ * fulfilled. An example:
+ *
+ *     Ext.define('MyNewClass.DependingOnOpenLayersClasses', {
+ *         requires: ['GeoExt.util.Symbol'],
+ *         // the contents of the `symbols` property will be checked
+ *         symbols: [
+ *             'ol.Map', // checking a class
+ *             'ol.View.prototype.constrainResolution', // an instance method
+ *             'ol.control.ScaleLine#getUnits', // other way for instance method
+ *             'ol.color.asArray', // one way to reference a static method
+ *             'ol.color::asString' // other way to reference a static method
+ *         ]
+ *         // … your configuration and methods …
+ *     }, function(cls) {
+ *         // actually call `check` with the just defined class:
+ *         GeoExt.util.Symbol.check(cls);
+ *     });
+ *
+ * Since this sort of checking usually only makes sense in debug mode, you can
+ * additionally wrap the `symbols`-configuration and the call to `check` in
+ * these &lt;debug&gt;-line comments:
+ *
+ *     Ext.define('MyNewClass.DependingOnOpenLayersClasses', {
+ *         requires: ['GeoExt.util.Symbol'],
+ *         // <debug>
+ *         symbols: []
+ *         // </debug>
+ *     }, function(cls) {
+ *         // <debug>
+ *         GeoExt.util.Symbol.check(cls);
+ *         // </debug>
+ *     });
+ *
+ * This means that the array of symbols and the check itself will not happen in
+ * production builds as the wrapped lines are simply removed from the final
+ * JavaScript.
+ *
+ * If one of the symbols cannot be found, a warning will be printed to the
+ * developer console (via `Ext.log.warn`, which will only print in a debug
+ * build):
+ *
+ *     [W] The class "MyNewClass.DependingOnOpenLayersClasses" depends on the
+ *     external symbol "ol.color.notExisting", which does not seem to exist.
+ *
+ * @class GeoExt.util.Symbol
+ */
+Ext.define('GeoExt.util.Symbol', {
+    extend: 'Ext.Base',
+    statics: {
+        /**
+         * An object that we will use to store already looked up references in.
+         *
+         * The key will be a symbol (after it has been normalized by the
+         * method #normalizeSymbol), and the value will be a boolean indicating
+         * if the symbol was found to be defined when it was checked.
+         *
+         * @private
+         */
+        _checked: {
+            // will be filled while we are checking stuff for existance
+        },
+
+        /**
+         * Checks whether the required symbols of the given class are defined
+         * in the global context. Will log to the console if a symbol cannot be
+         * found.
+         *
+         * @param {Ext.Base} An ext class defining a property `symbols` that
+         *     that this method will check.
+         */
+        check: function(cls) {
+            var staticMe = this;
+            var proto = cls.prototype;
+            var olSymbols = proto && proto.symbols;
+            var clsName = proto && proto['$className'];
+            if (!olSymbols) {
+                return;
+            }
+            Ext.each(olSymbols, function(olSymbol) {
+                olSymbol = staticMe.normalizeSymbol(olSymbol);
+                staticMe.checkSymbol(olSymbol, clsName);
+            });
+        },
+
+        /**
+         * Normalizes a short form of a symbol to a canonical one we use to
+         * store the results of the #isDefinedSymbol method. The following two
+         * normalizations take place:
+         *
+         * * A `#` in the symbol is being replaced with `.prototype.` so that
+         *   e.g. the symbol `'ol.Class#methodName'` turns into the symbol
+         *   `'ol.Class.prototype.methodName'`
+         * * A `::` in the symbol is being replaced with `.` so that
+         *   e.g. the symbol `'ol.Class::staticMethodName'` turns into the
+         *   symbol `'ol.Class.staticMethodName'`
+         *
+         * @param {String} symbolStr A string to normalize.
+         * @return {String} The normalized string.
+         * @private
+         */
+        normalizeSymbol: (function() {
+            var hashRegEx = /#/g;
+            var colonRegEx = /::/g;
+            var normalizeFunction = function(symbolStr){
+                if (hashRegEx.test(symbolStr)) {
+                    symbolStr = symbolStr.replace(hashRegEx, '.prototype.');
+                } else if (colonRegEx.test(symbolStr)) {
+                    symbolStr = symbolStr.replace(colonRegEx, '.');
+                }
+                return symbolStr;
+            };
+            return normalizeFunction;
+        }()),
+
+        /**
+         * Checks the passed symbolStr and raises a warning if it cannot be
+         * found.
+         *
+         * @param {String} symbolStr A string to check. Usually this string has
+         *     been {@link #normalizeSymbol normalized} already.
+         * @param {String} [clsName] The optional name of the class that
+         *     requires the passed openlayers symbol.
+         * @private
+         */
+        checkSymbol: function(symbolStr, clsName){
+            var isDefined = this.isDefinedSymbol(symbolStr);
+            if (!isDefined) {
+                Ext.log.warn(
+                    'The class "' + (clsName || 'unknown') + '" ' +
+                    'depends on the external symbol "' + symbolStr + '", ' +
+                    'which does not seem to exist.'
+                );
+            }
+        },
+
+        /**
+         * Checks if the passed symbolStr is defined.
+         *
+         * @param {String} symbolStr A string to check. Usually this string has
+         *     been {@link #normalizeSymbol normalized} already.
+         * @return {Boolean} Whether the symbol is defined or not.
+         * @private
+         */
+        isDefinedSymbol: function(symbolStr){
+            var checkedCache = this._checked;
+            if (Ext.isDefined(checkedCache[symbolStr])) {
+                return checkedCache[symbolStr];
+            }
+            var parts = symbolStr.split('.');
+            var lastIdx = parts.length - 1;
+            var curSymbol = Ext.getWin().dom;
+            var isDefined = false;
+            var intermediateSymb = '';
+            Ext.each(parts, function(part, idx){
+                if (intermediateSymb !== '') {
+                    intermediateSymb += '.';
+                }
+                intermediateSymb += part;
+                if(curSymbol[part]) {
+                    checkedCache[intermediateSymb] = true;
+                    curSymbol = curSymbol[part];
+                    if (lastIdx === idx) {
+                        isDefined = true;
+                    }
+                } else {
+                    checkedCache[intermediateSymb] = false;
+                    return false; // break early
+                }
+            });
+            checkedCache[symbolStr] = isDefined;
+            return isDefined;
+        }
+    }
+});

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -21,7 +21,8 @@
             'GeoExt/data/MapfishPrintProvider.test.js',
             'GeoExt/grid/column/Symbolizer.test.js',
             'GeoExt/panel/Popup.test.js',
-            'GeoExt/tree/Panel.test.js'
+            'GeoExt/tree/Panel.test.js',
+            'GeoExt/util/Symbol.test.js'
         ],
         getScriptTag = global.TestUtil.getExternalScriptTag,
         dependencyCnt = dependencies.length,

--- a/test/spec/GeoExt/util/Symbol.test.js
+++ b/test/spec/GeoExt/util/Symbol.test.js
@@ -1,0 +1,167 @@
+Ext.Loader.syncRequire(['GeoExt.util.Symbol']);
+
+describe('GeoExt.util.Symbol', function() {
+
+    describe('Basics', function(){
+        it('is defined', function(){
+            expect(GeoExt.util.Symbol).not.to.be(undefined);
+        });
+    });
+
+    function cleanupTestClass(className){
+        Ext.getWin().dom[className] = null;
+        delete Ext.getWin().dom[className];
+        delete Ext.ClassManager['$namespaceCache'][className];
+        delete Ext.ClassManager.classState[className];
+        delete Ext.ClassManager.classes[className];
+    }
+
+    var warnLoggerSpy;
+    var className;
+
+    beforeEach(function() {
+        // reset the local cache for each test
+        GeoExt.util.Symbol._checked = {};
+        // set up the spy to be examined in the TestClass
+        warnLoggerSpy = sinon.spy(Ext.log, 'warn');
+        className = 'TestClass' + (+new Date());
+        Ext.define(className, {
+            symbols: [
+                // An existing class
+                'ol.layer.Base',
+                // A non-existing class in an existing namespace
+                'ol.layer.NonExistingClass',
+                // A completely non-existing symbol
+                'non.existing.Symbol',
+                // A fully specified instance method
+                'ol.layer.Base.prototype.setOpacity',
+                // A instance method using the shortcut
+                'ol.layer.Base#setVisible',
+                // A static method using the shortcut
+                'GeoExt.util.Symbol::check'
+            ]
+        }, function(cls){
+            GeoExt.util.Symbol.check(cls);
+        });
+    });
+    afterEach(function(){
+        cleanupTestClass(className);
+        // restore the old method 'Ext.log.warn'
+        Ext.log.warn.restore();
+    });
+
+    describe('Static methods', function() {
+
+        describe('#check', function() {
+
+            it('only warned when the symbol was not defined', function() {
+                expect(warnLoggerSpy.called).to.be(true);
+                expect(warnLoggerSpy.callCount).to.be(2);
+            });
+
+            it('filled the cache (direct requires)', function() {
+                var cache = GeoExt.util.Symbol._checked;
+
+                expect(cache['ol.layer.Base']).to.not.be(undefined);
+                expect(cache['ol.layer.Base']).to.be(true);
+
+                expect(cache['ol.layer.NonExistingClass']).to.not.be(undefined);
+                expect(cache['ol.layer.NonExistingClass']).to.be(false);
+
+                expect(cache['non.existing.Symbol']).to.not.be(undefined);
+                expect(cache['non.existing.Symbol']).to.be(false);
+
+                expect(cache['ol.layer.Base.prototype.setOpacity']).to.not.be(
+                    undefined
+                );
+                expect(cache['ol.layer.Base.prototype.setOpacity']).to.be(true);
+
+                expect(cache['ol.layer.Base.prototype.setVisible']).to.not.be(
+                    undefined
+                );
+                expect(cache['ol.layer.Base.prototype.setVisible']).to.be(true);
+
+                expect(cache['GeoExt.util.Symbol.check']).to.not.be(undefined);
+                expect(cache['GeoExt.util.Symbol.check']).to.be(true);
+            });
+
+            it('filled the cache (intermediate requires)', function() {
+                var cache = GeoExt.util.Symbol._checked;
+
+                expect(cache['ol']).to.not.be(undefined);
+                expect(cache['ol']).to.be(true);
+
+                expect(cache['ol.layer']).to.not.be(undefined);
+                expect(cache['ol.layer']).to.be(true);
+
+                expect(cache['non']).to.not.be(undefined);
+                expect(cache['non']).to.be(false);
+
+                expect(cache['ol.layer.Base.prototype']).to.not.be(undefined);
+                expect(cache['ol.layer.Base.prototype']).to.be(true);
+
+                expect(cache['GeoExt']).to.not.be(undefined);
+                expect(cache['GeoExt']).to.be(true);
+
+                expect(cache['GeoExt.util']).to.not.be(undefined);
+                expect(cache['GeoExt.util']).to.be(true);
+
+                expect(cache['GeoExt.util.Symbol']).to.not.be(undefined);
+                expect(cache['GeoExt.util.Symbol']).to.be(true);
+            });
+
+            it('takes a short way out if no "symbols"', function() {
+                var normalizeSymbolSpy = sinon.spy(
+                    GeoExt.util.Symbol, 'normalizeSymbol'
+                );
+                var checkSymbolSpy = sinon.spy(
+                    GeoExt.util.Symbol, 'checkSymbol'
+                );
+                var isDefinedSymbolSpy = sinon.spy(
+                    GeoExt.util.Symbol, 'isDefinedSymbol'
+                );
+                Ext.define('NoMember_symbols', {
+                }, function(cls){
+                    GeoExt.util.Symbol.check(cls);
+                });
+                expect(normalizeSymbolSpy.called).to.be(false);
+                expect(checkSymbolSpy.called).to.be(false);
+                expect(isDefinedSymbolSpy.called).to.be(false);
+
+                // cleanup
+                GeoExt.util.Symbol.normalizeSymbol.restore();
+                GeoExt.util.Symbol.checkSymbol.restore();
+                GeoExt.util.Symbol.isDefinedSymbol.restore();
+                cleanupTestClass('NoMember_symbols');
+            });
+
+            it('takes a shortcut for checked symbols', function(){
+                GeoExt.util.Symbol.isDefinedSymbol(
+                    'Shub.Niggurath.Lord.Of.The.Wood'
+                );
+                var extEachSpy = sinon.spy(Ext, 'each');
+                var extIsDefinedSpy = sinon.spy(Ext, 'isDefined');
+                GeoExt.util.Symbol.isDefinedSymbol(
+                    'Shub.Niggurath.Lord.Of.The.Wood'
+                );
+
+                var cache = GeoExt.util.Symbol._checked;
+
+                expect(extIsDefinedSpy.called).to.be(true);
+                expect(extIsDefinedSpy.callCount).to.be(1);
+                expect(extIsDefinedSpy.calledWith(
+                    cache['Shub.Niggurath.Lord.Of.The.Wood']
+                )).to.be(true);
+
+                expect(extEachSpy.called).to.be(false);
+
+                // cleanup
+                Ext.isDefined.restore();
+                Ext.each.restore();
+            });
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
This PR adds an utility class providing methods to check for symbols of OpenLayers we depend upon.

This class can be used to check if the dependencies to external symbols are fulfilled. An example:

```javascript
Ext.define('MyNewClass.DependingOnOpenLayersClasses', {
    requires: ['GeoExt.util.Symbol'],
    // the contents of the `symbols` property will be checked
    symbols: [
        'ol.Map', // checking a class
        'ol.View.prototype.constrainResolution', // an instance method
        'ol.control.ScaleLine#getUnits', // other way for instance method
        'ol.color.asArray', // one way to reference a static method
        'ol.color::asString' // other way to reference a static method
    ]
    // … your configuration and methods …
}, function(cls) {
    // actually call `check` with the just defined class:
    GeoExt.util.Symbol.check(cls);
});
```

Since this sort of checking usually only makes sense in debug mode, you can additionally wrap the symbols-configuration and the call to check in these `<debug>`-line comments:

```javascript
Ext.define('MyNewClass.DependingOnOpenLayersClasses', {
    requires: ['GeoExt.util.Symbol'],
    // <debug>
    symbols: []
    // </debug>
}, function(cls) {
    // <debug>
    GeoExt.util.Symbol.check(cls);
    // </debug>
});
```

This means that the array of symbols and the check itseöf will not happen in production builds as the wrapped lines are simply removed from the final JavaScript.

If one of the symbols canot be found a warning will be printed to the developer console (via Ext.log.warn, which will only print in a debug build):

    [W] The class "MyNewClass.DependingOnOpenLayersClasses" depends on the
    external symbol "ol.color.notExisting", which does not seem to exist.

Additionally all current requirements are added to existing classes.