### PR TITLE
Change GeoExt.component.Map initialisation to constructor method

### DIFF
--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -149,8 +149,11 @@ Ext.define("GeoExt.component.Map", {
     /**
      * @inheritdoc
      */
-    initComponent: function() {
+    constructor: function(config) {
         var me = this;
+
+        me.callParent([config]);
+
         if(!(me.getMap() instanceof ol.Map)){
             var olMap = new ol.Map({
                 view: new ol.View({
@@ -167,7 +170,6 @@ Ext.define("GeoExt.component.Map", {
         });
 
         me.on('resize', me.onResize, me);
-        me.callParent();
     },
 
     /**
@@ -177,7 +179,8 @@ Ext.define("GeoExt.component.Map", {
         // Get the corresponding view of the controller (the mapComponent).
         var me = this;
         if(!me.mapRendered){
-            me.getMap().setTarget(me.getTargetEl().dom);
+            var el = me.getTargetEl ? me.getTargetEl() : me.element;
+            me.getMap().setTarget(el.dom);
             me.mapRendered = true;
         } else {
             me.getMap().updateSize();
@@ -284,7 +287,7 @@ Ext.define("GeoExt.component.Map", {
      */
     unbindEnterLeaveListeners: function() {
         var me = this;
-        var mapEl = me.getEl();
+        var mapEl = me.getTargetEl ? me.getTargetEl() : me.element;
         if (mapEl) {
             mapEl.un({
                 mouseenter: me.onMouseEnter,


### PR DESCRIPTION
With these changes, the mapcomponent can be used and instanciated
in an universal app, which means it can be used with both toolkits
(classic and modern or ext and touch).

Both toolkits share the constructor method which should be preferred
if possible. The initComponent method will only be available in the
classic toolkit, while the initialize method is only available in
the modern toolkit...