### PR TITLE
Enable building package with sencha cmd on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: node_js
 node_js: "0.12"
+before_install:
+  - ./ci/create-sencha-environment.sh
 install: npm install
 script:
   - npm run lint-js
   - npm test
+  - ./ci/create-sencha-package.sh
 after_success: npm run ci-coverage
 branches:
   only:
     - master
-
+cache:
+  directories:
+    - __download
+    - __install
+    - node_modules

--- a/ci/create-sencha-environment.sh
+++ b/ci/create-sencha-environment.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -ex
+
+# ------------------------------------------------------------------------------
+# This script is supposed to be called from Travis continuous integration server
+#
+# It sets up a sencha build environment (with a properly configured
+# workspace and the right sencha Cmd …) so that the accompanying script
+# `ci/create-sencha-package.sh` can actually build and add the GeoExt package.
+#
+# To configure this script (with regard to pathes etc.), edit the variables in
+# the script `ci/shared.sh`.
+# ------------------------------------------------------------------------------
+
+# Load variables and the 'running-on-travis'-check
+. $TRAVIS_BUILD_DIR/ci/shared.sh
+
+# create directories (if needed), will not fail if they are there already
+mkdir -p $DOWN_DIR
+mkdir -p $INSTALL_DIR
+
+# Many of the commands below check if a resource or directory already exists,
+# this is here because the relevant directories are cached by travis and may
+# already be there from a previous build.
+
+cd $DOWN_DIR
+
+# DOWNLOAD (if needed)
+# 1) Sencha cmd (v6.0.0.202)
+if [ ! -f "SenchaCmd-$SENCHA_CMD_VERSION-linux-amd64.sh.zip" ]; then
+    wget "http://cdn.sencha.com/cmd/$SENCHA_CMD_VERSION/no-jre/SenchaCmd-$SENCHA_CMD_VERSION-linux-amd64.sh.zip"
+fi
+
+# 2) Ext JS (v6.0.0.640)
+if [ ! -f "ext-$SENCHA_EXTJS_VERSION-gpl.zip" ]; then
+    wget "http://cdn.sencha.com/ext/gpl/ext-$SENCHA_EXTJS_VERSION-gpl.zip"
+fi
+
+# EXTRACT (if needed)
+# 1) Sencha cmd (v6.0.0.202)
+if [ ! -f "SenchaCmd-$SENCHA_CMD_VERSION-linux-amd64.sh" ]; then
+    unzip -q "SenchaCmd-$SENCHA_CMD_VERSION-linux-amd64.sh.zip"
+fi
+
+# 2) Ext JS (v6.0.0.640)
+if [ ! -d "ext-$SENCHA_EXTJS_VERSION" ]; then
+    unzip -q "ext-$SENCHA_EXTJS_VERSION-gpl.zip"
+fi
+
+# Install Sencha cmd
+if [ ! -f $SENCHA_CMD ]; then
+    ./SenchaCmd-$SENCHA_CMD_VERSION-linux-amd64.sh -q -dir $INSTALL_DIR
+fi
+
+# Create a sencha workspace using the downloaded ExtJS
+if [ ! -d $SENCHA_WS ]; then
+    $SENCHA_CMD -sdk $DOWN_DIR/ext-$SENCHA_EXTJS_VERSION generate workspace $SENCHA_WS
+fi
+
+# Create a folder for the GeoExt package
+if [ ! -d $GEOEXT_IN_SENCHA_WS_FOLDER ]; then
+    mkdir -p $GEOEXT_IN_SENCHA_WS_FOLDER
+fi
+
+# Initialize local repository
+$SENCHA_CMD package repo init -name "$GEOEXT_REPO_NAME" -email "$GEOEXT_REPO_EMAIL"
+
+# Back to the original working directory
+cd $TRAVIS_BUILD_DIR
+
+return 0

--- a/ci/create-sencha-package.sh
+++ b/ci/create-sencha-package.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -ex
+
+# ------------------------------------------------------------------------------
+# This script is supposed to be called from Travis continuous integration server
+#
+# It expects that a sencha build environment (with a properly configured
+# workspace and the right sencha Cmd …) has previously been set up. See the
+# accompanying script `ci/create-sencha-environment.sh`.
+#
+# To configure this script (with regard to pathes etc.), edit the variables in
+# the script `ci/shared.sh`.
+# ------------------------------------------------------------------------------
+
+# Load variables and the 'running-on-travis'-check
+. $TRAVIS_BUILD_DIR/ci/shared.sh
+
+# Cleanup (there shouldn't be anything left over, but let's make sure)
+rm -Rf $GEOEXT_IN_SENCHA_WS_FOLDER/*
+
+# copy the relevant resources instead of cloning the repo/PR again
+for COPY_RESOURCE in $COPY_RESOURCES
+do
+    cp -r $TRAVIS_BUILD_DIR/$COPY_RESOURCE $GEOEXT_IN_SENCHA_WS_FOLDER
+done
+
+# Switch to the now properly filled directory in the sencha workspace
+cd $GEOEXT_IN_SENCHA_WS_FOLDER
+
+# Remove GeoExt package (if any)
+$SENCHA_CMD package remove $GEOEXT_PACKAGE_NAME
+
+# Build the package
+$SENCHA_CMD package build
+
+# Add the package to the local repo
+$SENCHA_CMD package add $SENCHA_WS/build/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_NAME.pkg
+
+# TODO we could actually try to use the package now in an application that
+#      wants to use the GeoExt package
+# TODO It'd be nice if the result of that build process could be made available
+#      on the gh-pages repository, but this is a task for another day
+
+# We're done
+exit 0

--- a/ci/shared.sh
+++ b/ci/shared.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -ex
+
+# ------------------------------------------------------------------------------
+# This script is supposed to be called from Travis continuous integration server
+#
+# It contains a basic check that will abort if the script is executed elsewhere.
+#
+# Basically we set up shared variables here that are used in the main ci-scripts
+# `ci/create-sencha-environment.sh` and `ci/create-sencha-package`.
+# ------------------------------------------------------------------------------
+
+# Only do something on travis
+if [ "$TRAVIS" != "true" ]; then
+    echo "This script is supposed to be run inside the travis environment."
+    return 1
+fi
+
+# Where we will downloaded fils go? Cached between builds via travis
+DOWN_DIR="$TRAVIS_BUILD_DIR/__download"
+
+# Where we will we install the sencha cmd? Cached between builds via travis
+INSTALL_DIR="$TRAVIS_BUILD_DIR/__install"
+
+# The sencha workspace, won't be cached but be regenerated on every build
+SENCHA_WS="/tmp/sencha-workspace"
+
+# Where will the source of the GeoExt package live in the sencha workspace?
+GEOEXT_IN_SENCHA_WS_FOLDER="$SENCHA_WS/packages/geoext3"
+
+# This is the executable sencha command once it has been installed
+SENCHA_CMD="$INSTALL_DIR/sencha"
+
+# The version of sencha command to downlaod and install
+SENCHA_CMD_VERSION="6.0.0.202"
+
+# The version of ExtJS to download and configure the sencha workspace with
+SENCHA_EXTJS_VERSION="6.0.0"
+
+# The resource of GeoExt we copy over from the current PR or build over to
+# the $GEOEXT_IN_SENCHA_WS_FOLDER
+COPY_RESOURCES=".sencha resources sass src package.json build.xml LICENSE"
+
+# The name of the package
+GEOEXT_PACKAGE_NAME="GeoExt" # see the 'name'-prop of package.json
+
+# Properties to create a local package repository
+GEOEXT_REPO_NAME="GeoExt Contributors" # see the 'creator'-prop of package.json
+GEOEXT_REPO_EMAIL="dev@geoext.org"


### PR DESCRIPTION
This commit adds several shell scripts, which are used when running the continuous integration. They download and install all resources needed for a build using the sencha cmd. As part of the ci, we now
always try to build the GeoExt package.

Additionally the travis ci is configured to cache the contents of certain directories, which change only every now and then. This caching speeds up the following builds, where the dependencies for
Sencha or ExtJS have been resolved previously.

Please review.

/cc @weskamm, @chrismayer, @KaiVolland 