### PR TITLE
Add empty projection String to satisfy ol.proj.Projection

### DIFF
--- a/src/component/FeatureRenderer.js
+++ b/src/component/FeatureRenderer.js
@@ -273,6 +273,7 @@ Ext.define('GeoExt.component.FeatureRenderer', {
             minResolution: resolution,
             maxResolution: resolution,
             projection: new ol.proj.Projection({
+                code: '',
                 units: 'pixels'
             })
         }));


### PR DESCRIPTION
When using proj4js together with ol3, instanciation of an ol.proj.Projection without the `code` proerpty will fail.
I will open up a Pull Request in ol3 shortly.
