### PR TITLE
Refactor symbol check class to a mixin

### DIFF
--- a/src/component/FeatureRenderer.js
+++ b/src/component/FeatureRenderer.js
@@ -21,9 +21,10 @@
 Ext.define('GeoExt.component.FeatureRenderer', {
     extend: 'Ext.Component',
     alias: 'widget.gx_renderer',
-    requires: [
-        'GeoExt.util.Symbol'
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
+
     // <debug>
     symbols: [
         'ol.extent.getCenter',
@@ -377,8 +378,4 @@ Ext.define('GeoExt.component.FeatureRenderer', {
             this.setSymbolizers(options.symbolizers);
         }
     }
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -40,11 +40,13 @@ Ext.define("GeoExt.component.Map", {
         "widget.gx_map",
         "widget.gx_component_map"
     ],
-
     requires: [
-        'GeoExt.data.store.Layer',
-        'GeoExt.util.Symbol'
+        'GeoExt.data.store.Layer'
     ],
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
+    ],
+
     // <debug>
     symbols: [
         'ol.layer.Base',
@@ -464,8 +466,4 @@ Ext.define("GeoExt.component.Map", {
     setView: function(view){
         this.getMap().setView(view);
     }
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -63,8 +63,8 @@ Ext.define("GeoExt.component.OverviewMap", {
         'widget.gx_overviewmap',
         'widget.gx_component_overviewmap'
     ],
-    requires: [
-        'GeoExt.util.Symbol'
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -486,8 +486,4 @@ Ext.define("GeoExt.component.OverviewMap", {
         this.boxFeature.setStyle(style);
         return style;
     }
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/MapfishPrintProvider.js
+++ b/src/data/MapfishPrintProvider.js
@@ -19,10 +19,12 @@
  */
 Ext.define('GeoExt.data.MapfishPrintProvider', {
     extend: 'Ext.Base',
-    mixins: ['Ext.mixin.Observable'],
+    mixins: [
+        'Ext.mixin.Observable',
+        'GeoExt.mixin.SymbolCheck'
+    ],
     requires: [
         'GeoExt.data.model.print.Capability',
-        'GeoExt.util.Symbol',
         'Ext.data.JsonStore'
     ],
     // <debug>
@@ -303,8 +305,4 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
             });
         }
     }
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/model/Layer.js
+++ b/src/data/model/Layer.js
@@ -20,8 +20,8 @@
  */
 Ext.define('GeoExt.data.model.Layer', {
     extend: 'GeoExt.data.model.Base',
-    requires: [
-        'GeoExt.util.Symbol'
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -123,8 +123,4 @@ Ext.define('GeoExt.data.model.Layer', {
             return this.data;
         }
     }
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/model/LayerTreeNode.js
+++ b/src/data/model/LayerTreeNode.js
@@ -21,9 +21,13 @@
 Ext.define('GeoExt.data.model.LayerTreeNode', {
     extend: 'GeoExt.data.model.Layer',
     requires: [
-        'Ext.data.NodeInterface',
-        'GeoExt.util.Symbol'
+        'Ext.data.NodeInterface'
     ],
+    mixins: [
+        'Ext.mixin.Queryable',
+        'GeoExt.mixin.SymbolCheck'
+    ],
+
     // <debug>
     symbols: [
         'ol.layer.Base',
@@ -31,10 +35,6 @@ Ext.define('GeoExt.data.model.LayerTreeNode', {
         'ol.Object#set'
     ],
     // </debug>
-
-    mixins: [
-        'Ext.mixin.Queryable'
-    ],
 
     fields: [
         {
@@ -185,10 +185,7 @@ Ext.define('GeoExt.data.model.LayerTreeNode', {
         return this.parentNode;
     }
 
-}, function (cls) {
+}, function () {
     // make this an Ext.data.TreeModel
     Ext.data.NodeInterface.decorate(this);
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/model/Object.js
+++ b/src/data/model/Object.js
@@ -18,8 +18,8 @@
  */
 Ext.define('GeoExt.data.model.Object', {
     extend: 'GeoExt.data.model.Base',
-    requires: [
-        'GeoExt.util.Symbol'
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -161,8 +161,4 @@ Ext.define('GeoExt.data.model.Object', {
 
         this.callParent(arguments);
     }
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/serializer/Base.js
+++ b/src/data/serializer/Base.js
@@ -19,8 +19,10 @@
 Ext.define('GeoExt.data.serializer.Base', {
     extend: 'Ext.Base',
     requires: [
-        'GeoExt.data.MapfishPrintProvider',
-        'GeoExt.util.Symbol'
+        'GeoExt.data.MapfishPrintProvider'
+    ],
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -82,8 +84,4 @@ Ext.define('GeoExt.data.serializer.Base', {
             }
         }
     }
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/serializer/ImageWMS.js
+++ b/src/data/serializer/ImageWMS.js
@@ -18,9 +18,8 @@
  */
 Ext.define('GeoExt.data.serializer.ImageWMS', {
     extend: 'GeoExt.data.serializer.Base',
-
-    requires: [
-        'GeoExt.util.Symbol'
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -59,7 +58,4 @@ Ext.define('GeoExt.data.serializer.ImageWMS', {
 }, function(cls) {
     // Register this serializer via the inherited method `register`.
     cls.register(cls);
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/serializer/TileWMS.js
+++ b/src/data/serializer/TileWMS.js
@@ -18,9 +18,8 @@
  */
 Ext.define('GeoExt.data.serializer.TileWMS', {
     extend: 'GeoExt.data.serializer.Base',
-
-    requires: [
-        'GeoExt.util.Symbol'
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -59,7 +58,4 @@ Ext.define('GeoExt.data.serializer.TileWMS', {
 }, function(cls) {
     // Register this serializer via the inherited method `register`.
     cls.register(cls);
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/serializer/Vector.js
+++ b/src/data/serializer/Vector.js
@@ -24,9 +24,8 @@
  */
 Ext.define('GeoExt.data.serializer.Vector', {
     extend: 'GeoExt.data.serializer.Base',
-
-    requires: [
-        'GeoExt.util.Symbol'
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -607,7 +606,4 @@ Ext.define('GeoExt.data.serializer.Vector', {
 
     // Register this serializer via the inherited method `register`.
     cls.register(cls);
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/serializer/WMTS.js
+++ b/src/data/serializer/WMTS.js
@@ -22,9 +22,8 @@
  */
 Ext.define('GeoExt.data.serializer.WMTS', {
     extend: 'GeoExt.data.serializer.Base',
-
-    requires: [
-        'GeoExt.util.Symbol'
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -101,7 +100,4 @@ Ext.define('GeoExt.data.serializer.WMTS', {
 }, function(cls) {
     // Register this serializer via the inherited method `register`.
     cls.register(cls);
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/serializer/XYZ.js
+++ b/src/data/serializer/XYZ.js
@@ -18,6 +18,20 @@
   */
 Ext.define('GeoExt.data.serializer.XYZ', {
     extend: 'GeoExt.data.serializer.Base',
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
+    ],
+
+    symbols: [
+        'ol.layer.Base#getOpacity',
+        'ol.size.toSize',
+        'ol.source.XYZ',
+        'ol.source.XYZ#getTileGrid',
+        'ol.source.XYZ#getUrls',
+        'ol.tilegrid.TileGrid#getResolutions',
+        'ol.tilegrid.TileGrid#getTileSize'
+    ],
+
     inheritableStatics: {
         /**
          * @inheritdoc

--- a/src/data/store/Collection.js
+++ b/src/data/store/Collection.js
@@ -19,8 +19,11 @@
 Ext.define('GeoExt.data.store.Collection', {
     extend: 'Ext.data.Store',
     requires: [
-        'GeoExt.data.model.Object',
-        'GeoExt.util.Symbol'
+        'GeoExt.data.model.Object'
+    ],
+
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -149,8 +152,4 @@ Ext.define('GeoExt.data.store.Collection', {
 
         this.callParent(arguments);
     }
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -20,8 +20,8 @@
  */
 Ext.define('GeoExt.data.store.Features', {
     extend: 'GeoExt.data.store.Collection',
-    requires: [
-        'GeoExt.util.Symbol'
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -265,8 +265,4 @@ Ext.define('GeoExt.data.store.Features', {
         }
     }
 
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/store/Layer.js
+++ b/src/data/store/Layer.js
@@ -23,8 +23,11 @@ Ext.define('GeoExt.data.store.Layer', {
     extend: 'Ext.data.Store',
     alternateClassName: ['GeoExt.data.LayerStore'],
     requires: [
-        'GeoExt.data.model.Layer',
-        'GeoExt.util.Symbol'
+        'GeoExt.data.model.Layer'
+    ],
+
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -397,8 +400,4 @@ Ext.define('GeoExt.data.store.Layer', {
         }
     }
 
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/data/store/Tree.js
+++ b/src/data/store/Tree.js
@@ -23,8 +23,8 @@ Ext.define('GeoExt.data.store.Tree', {
 
     alternateClassName: ['GeoExt.data.TreeStore'],
 
-    requires: [
-        'GeoExt.util.Symbol'
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
@@ -269,8 +269,4 @@ Ext.define('GeoExt.data.store.Tree', {
     resumeCollectionEvents: function(){
         this.collectionEventsSuspended = false;
     }
-}, function(cls) {
-    // <debug>
-    GeoExt.util.Symbol.check(cls);
-    // </debug>
 });

--- a/src/mixin/SymbolCheck.js
+++ b/src/mixin/SymbolCheck.js
@@ -17,11 +17,11 @@
  * A utility class providing methods to check for symbols of OpenLayers we
  * depend upon.
  *
- * This class can be used to check if the dependencies to external symbols are
- * fulfilled. An example:
+ * This class can be mixed into classes to check if the dependencies to external
+ * symbols are fulfilled. An example:
  *
  *     Ext.define('MyNewClass.DependingOnOpenLayersClasses', {
- *         requires: ['GeoExt.util.Symbol'],
+ *         mixins: ['GeoExt.mixin.SymbolCheck'],
  *         // the contents of the `symbols` property will be checked
  *         symbols: [
  *             'ol.Map', // checking a class
@@ -31,29 +31,21 @@
  *             'ol.color::asString' // other way to reference a static method
  *         ]
  *         // … your configuration and methods …
- *     }, function(cls) {
- *         // actually call `check` with the just defined class:
- *         GeoExt.util.Symbol.check(cls);
  *     });
  *
  * Since this sort of checking usually only makes sense in debug mode, you can
- * additionally wrap the `symbols`-configuration and the call to `check` in
- * these &lt;debug&gt;-line comments:
+ * additionally wrap the `symbols`-configuration in these &lt;debug&gt;-line
+ * comments:
  *
  *     Ext.define('MyNewClass.DependingOnOpenLayersClasses', {
- *         requires: ['GeoExt.util.Symbol'],
+ *         mixins: ['GeoExt.mixin.SymbolCheck'],
  *         // <debug>
  *         symbols: []
  *         // </debug>
- *     }, function(cls) {
- *         // <debug>
- *         GeoExt.util.Symbol.check(cls);
- *         // </debug>
  *     });
  *
- * This means that the array of symbols and the check itself will not happen in
- * production builds as the wrapped lines are simply removed from the final
- * JavaScript.
+ * This means that the array of symbols is not defined in production builds
+ * as the wrapped lines are simply removed from the final JavaScript.
  *
  * If one of the symbols cannot be found, a warning will be printed to the
  * developer console (via `Ext.log.warn`, which will only print in a debug
@@ -62,11 +54,12 @@
  *     [W] The class "MyNewClass.DependingOnOpenLayersClasses" depends on the
  *     external symbol "ol.color.notExisting", which does not seem to exist.
  *
- * @class GeoExt.util.Symbol
+ * @class GeoExt.mixin.SymbolCheck
  */
-Ext.define('GeoExt.util.Symbol', {
-    extend: 'Ext.Base',
+Ext.define('GeoExt.mixin.SymbolCheck', {
+    extend: 'Ext.Mixin',
     statics: {
+        // <debug>
         /**
          * An object that we will use to store already looked up references in.
          *
@@ -85,7 +78,7 @@ Ext.define('GeoExt.util.Symbol', {
          * in the global context. Will log to the console if a symbol cannot be
          * found.
          *
-         * @param {Ext.Base} An ext class defining a property `symbols` that
+         * @param {Ext.Base} cls An ext class defining a property `symbols` that
          *     that this method will check.
          */
         check: function(cls) {
@@ -190,5 +183,25 @@ Ext.define('GeoExt.util.Symbol', {
             checkedCache[symbolStr] = isDefined;
             return isDefined;
         }
+        // </debug>
+    },
+
+    /**
+     * @property {String[]} symbols The symbols to check.
+     */
+
+    // <debug>
+
+    /**
+     * Whenever a class mixes in GeoExt.mixin.SymbolCheck, this method will be
+     * called and it actually runs the checks for all the defined #symbols.
+     *
+     * @param {Ext.Class} cls The class that this mixin is mixed into.
+     * @private
+     */
+    onClassMixedIn: function(cls) {
+        GeoExt.mixin.SymbolCheck.check(cls);
     }
+
+    // </debug>
 });

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -21,9 +21,9 @@
             'GeoExt/data/LayerStore.test.js',
             'GeoExt/data/MapfishPrintProvider.test.js',
             'GeoExt/grid/column/Symbolizer.test.js',
+            'GeoExt/mixin/SymbolCheck.test.js',
             'GeoExt/panel/Popup.test.js',
-            'GeoExt/tree/Panel.test.js',
-            'GeoExt/util/Symbol.test.js'
+            'GeoExt/tree/Panel.test.js'
         ],
         getScriptTag = global.TestUtil.getExternalScriptTag,
         dependencyCnt = dependencies.length,

--- a/test/spec/GeoExt/mixin/SymbolCheck.test.js
+++ b/test/spec/GeoExt/mixin/SymbolCheck.test.js
@@ -1,10 +1,10 @@
-Ext.Loader.syncRequire(['GeoExt.util.Symbol']);
+Ext.Loader.syncRequire(['GeoExt.mixin.SymbolCheck']);
 
-describe('GeoExt.util.Symbol', function() {
+describe('GeoExt.mixin.SymbolCheck', function() {
 
     describe('Basics', function(){
         it('is defined', function(){
-            expect(GeoExt.util.Symbol).not.to.be(undefined);
+            expect(GeoExt.mixin.SymbolCheck).not.to.be(undefined);
         });
     });
 
@@ -21,11 +21,12 @@ describe('GeoExt.util.Symbol', function() {
 
     beforeEach(function() {
         // reset the local cache for each test
-        GeoExt.util.Symbol._checked = {};
+        GeoExt.mixin.SymbolCheck._checked = {};
         // set up the spy to be examined in the TestClass
         warnLoggerSpy = sinon.spy(Ext.log, 'warn');
         className = 'TestClass' + (+new Date());
         Ext.define(className, {
+            mixins: ['GeoExt.mixin.SymbolCheck'],
             symbols: [
                 // An existing class
                 'ol.layer.Base',
@@ -38,10 +39,8 @@ describe('GeoExt.util.Symbol', function() {
                 // A instance method using the shortcut
                 'ol.layer.Base#setVisible',
                 // A static method using the shortcut
-                'GeoExt.util.Symbol::check'
+                'GeoExt.mixin.SymbolCheck::check'
             ]
-        }, function(cls){
-            GeoExt.util.Symbol.check(cls);
         });
     });
     afterEach(function(){
@@ -60,7 +59,7 @@ describe('GeoExt.util.Symbol', function() {
             });
 
             it('filled the cache (direct requires)', function() {
-                var cache = GeoExt.util.Symbol._checked;
+                var cache = GeoExt.mixin.SymbolCheck._checked;
 
                 expect(cache['ol.layer.Base']).to.not.be(undefined);
                 expect(cache['ol.layer.Base']).to.be(true);
@@ -81,12 +80,14 @@ describe('GeoExt.util.Symbol', function() {
                 );
                 expect(cache['ol.layer.Base.prototype.setVisible']).to.be(true);
 
-                expect(cache['GeoExt.util.Symbol.check']).to.not.be(undefined);
-                expect(cache['GeoExt.util.Symbol.check']).to.be(true);
+                expect(cache['GeoExt.mixin.SymbolCheck.check']).to.not.be(
+                    undefined
+                );
+                expect(cache['GeoExt.mixin.SymbolCheck.check']).to.be(true);
             });
 
             it('filled the cache (intermediate requires)', function() {
-                var cache = GeoExt.util.Symbol._checked;
+                var cache = GeoExt.mixin.SymbolCheck._checked;
 
                 expect(cache['ol']).to.not.be(undefined);
                 expect(cache['ol']).to.be(true);
@@ -103,49 +104,48 @@ describe('GeoExt.util.Symbol', function() {
                 expect(cache['GeoExt']).to.not.be(undefined);
                 expect(cache['GeoExt']).to.be(true);
 
-                expect(cache['GeoExt.util']).to.not.be(undefined);
-                expect(cache['GeoExt.util']).to.be(true);
+                expect(cache['GeoExt.mixin']).to.not.be(undefined);
+                expect(cache['GeoExt.mixin']).to.be(true);
 
-                expect(cache['GeoExt.util.Symbol']).to.not.be(undefined);
-                expect(cache['GeoExt.util.Symbol']).to.be(true);
+                expect(cache['GeoExt.mixin.SymbolCheck']).to.not.be(undefined);
+                expect(cache['GeoExt.mixin.SymbolCheck']).to.be(true);
             });
 
             it('takes a short way out if no "symbols"', function() {
                 var normalizeSymbolSpy = sinon.spy(
-                    GeoExt.util.Symbol, 'normalizeSymbol'
+                    GeoExt.mixin.SymbolCheck, 'normalizeSymbol'
                 );
                 var checkSymbolSpy = sinon.spy(
-                    GeoExt.util.Symbol, 'checkSymbol'
+                    GeoExt.mixin.SymbolCheck, 'checkSymbol'
                 );
                 var isDefinedSymbolSpy = sinon.spy(
-                    GeoExt.util.Symbol, 'isDefinedSymbol'
+                    GeoExt.mixin.SymbolCheck, 'isDefinedSymbol'
                 );
                 Ext.define('NoMember_symbols', {
-                }, function(cls){
-                    GeoExt.util.Symbol.check(cls);
+                    mixins: ['GeoExt.mixin.SymbolCheck']
                 });
                 expect(normalizeSymbolSpy.called).to.be(false);
                 expect(checkSymbolSpy.called).to.be(false);
                 expect(isDefinedSymbolSpy.called).to.be(false);
 
                 // cleanup
-                GeoExt.util.Symbol.normalizeSymbol.restore();
-                GeoExt.util.Symbol.checkSymbol.restore();
-                GeoExt.util.Symbol.isDefinedSymbol.restore();
+                GeoExt.mixin.SymbolCheck.normalizeSymbol.restore();
+                GeoExt.mixin.SymbolCheck.checkSymbol.restore();
+                GeoExt.mixin.SymbolCheck.isDefinedSymbol.restore();
                 cleanupTestClass('NoMember_symbols');
             });
 
             it('takes a shortcut for checked symbols', function(){
-                GeoExt.util.Symbol.isDefinedSymbol(
+                GeoExt.mixin.SymbolCheck.isDefinedSymbol(
                     'Shub.Niggurath.Lord.Of.The.Wood'
                 );
                 var extEachSpy = sinon.spy(Ext, 'each');
                 var extIsDefinedSpy = sinon.spy(Ext, 'isDefined');
-                GeoExt.util.Symbol.isDefinedSymbol(
+                GeoExt.mixin.SymbolCheck.isDefinedSymbol(
                     'Shub.Niggurath.Lord.Of.The.Wood'
                 );
 
-                var cache = GeoExt.util.Symbol._checked;
+                var cache = GeoExt.mixin.SymbolCheck._checked;
 
                 expect(extIsDefinedSpy.called).to.be(true);
                 expect(extIsDefinedSpy.callCount).to.be(1);


### PR DESCRIPTION
This PR suggests refactoring of the `GeoExt.util.Symbol`-class to a mixin. This gives us the opportunity to remove the explicit calls to `GeoExt.util.Symbol.check(cls)` as we can then use the `onClassMixedIn`-method, which will do this automatically.

Additionally a commit is included which tests the symbols of the recently introduced `GeoExt.data.serializer.XYZ`.

Please review.

See #59, fixes #71

/cc @chrismayer