### PR TITLE
Use an existing tileset from mapbox in tests

### DIFF
--- a/test/spec/GeoExt/data/MapfishPrintProvider.test.js
+++ b/test/spec/GeoExt/data/MapfishPrintProvider.test.js
@@ -417,7 +417,7 @@ describe('GeoExt.data.MapfishPrintProvider', function() {
                     url: "http://webmapcenter.de/print-servlet-3.1.2/" +
                         "print/geoext/capabilities.json",
                     listeners: {
-                        'ready': function(){
+                        ready: function(){
                             var formats = this.capabilityRec.get('formats');
                             expect(formats).to.be.an(Array);
                             expect(formats.length).to.be(6);
@@ -436,7 +436,7 @@ describe('GeoExt.data.MapfishPrintProvider', function() {
                     url: "http://webmapcenter.de/print-servlet-3.1.2/" +
                         "print/geoext/capabilities.json",
                     listeners: {
-                        'ready': function(){
+                        ready: function(){
                             var layoutStore = this.capabilityRec.layouts();
                             var firstLayout = layoutStore.getAt(0);
                             var attributesStore = firstLayout.attributes();

--- a/test/spec/GeoExt/data/store/LayersTree.test.js
+++ b/test/spec/GeoExt/data/store/LayersTree.test.js
@@ -225,11 +225,10 @@ describe('GeoExt.data.store.LayersTree', function() {
                 layers: [
                     new ol.layer.Tile({
                         visible: false,
-                        name: 'LAYERFOOD',
+                        name: 'LAYERGEOGRAPHYCLASS',
                         source: new ol.source.TileJSON({
                             url: 'http://api.tiles.mapbox.com/v3/'+
-                                'mapbox.20110804-hoa-foodinsecurity-'+
-                                '3month.jsonp',
+                                'mapbox.geography-class.jsonp',
                             crossOrigin: 'anonymous'
                         })
                     }),


### PR DESCRIPTION
This removes the annoying (no actual errors) when testing:

```
Error loading resource http://b.tiles.mapbox.com/v3/mapbox.20110804-hoa-
foodinsecurity-3month/2/1/2.png (203).
Details: Error downloading http://b.tiles.mapbox.com/v3/mapbox.20110804-hoa-
foodinsecurity-3month/2/1/2.png - server replied: Not Found
```

Cheers for any review.