### PR TITLE
Register mouseover instead of mouseenter event on the map

### DIFF
--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -286,9 +286,9 @@ Ext.define("GeoExt.component.Map", {
 
         if (!me.rendered) {
             // make sure we do not fire any if the pointer left the component
-            me.on('afterrender', me.bindOverLeaveListeners, me);
+            me.on('afterrender', me.bindOverOutListeners, me);
         } else {
-            me.bindOverLeaveListeners();
+            me.bindOverOutListeners();
         }
 
     },
@@ -299,13 +299,13 @@ Ext.define("GeoExt.component.Map", {
      *
      * @private
      */
-    bindOverLeaveListeners: function() {
+    bindOverOutListeners: function() {
         var me = this;
         var mapEl = me.getEl();
         if (mapEl) {
             mapEl.on({
                 mouseover: me.onMouseOver,
-                mouseleave: me.onMouseLeave,
+                mouseout: me.onMouseOut,
                 scope: me
             });
         }
@@ -317,13 +317,13 @@ Ext.define("GeoExt.component.Map", {
      *
      * @private
      */
-    unbindOverLeaveListeners: function() {
+    unbindOverOutListeners: function() {
         var me = this;
         var mapEl = me.getTargetEl ? me.getTargetEl() : me.element;
         if (mapEl) {
             mapEl.un({
                 mouseover: me.onMouseOver,
-                mouseleave: me.onMouseLeave,
+                mouseout: me.onMouseOut,
                 scope: me
             });
         }
@@ -343,17 +343,17 @@ Ext.define("GeoExt.component.Map", {
      *
      * @private
      */
-    onMouseLeave: function() {
+    onMouseOut: function() {
         this.isMouseOverMapEl = false;
     },
 
     /**
      * Unregisters the #bufferedPointerMove event listener and unbinds the
-     * over- and leave-listeners.
+     * over- and out-listeners.
      */
     unregisterPointerRestEvents: function(){
         var map = this.getMap();
-        this.unbindOverLeaveListeners();
+        this.unbindOverOutListeners();
         if (map) {
             map.un('pointermove', this.bufferedPointerMove);
         }

--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -286,9 +286,9 @@ Ext.define("GeoExt.component.Map", {
 
         if (!me.rendered) {
             // make sure we do not fire any if the pointer left the component
-            me.on('afterrender', me.bindEnterLeaveListeners, me);
+            me.on('afterrender', me.bindOverLeaveListeners, me);
         } else {
-            me.bindEnterLeaveListeners();
+            me.bindOverLeaveListeners();
         }
 
     },
@@ -299,12 +299,12 @@ Ext.define("GeoExt.component.Map", {
      *
      * @private
      */
-    bindEnterLeaveListeners: function() {
+    bindOverLeaveListeners: function() {
         var me = this;
         var mapEl = me.getEl();
         if (mapEl) {
             mapEl.on({
-                mouseenter: me.onMouseEnter,
+                mouseover: me.onMouseOver,
                 mouseleave: me.onMouseLeave,
                 scope: me
             });
@@ -317,12 +317,12 @@ Ext.define("GeoExt.component.Map", {
      *
      * @private
      */
-    unbindEnterLeaveListeners: function() {
+    unbindOverLeaveListeners: function() {
         var me = this;
         var mapEl = me.getTargetEl ? me.getTargetEl() : me.element;
         if (mapEl) {
             mapEl.un({
-                mouseenter: me.onMouseEnter,
+                mouseover: me.onMouseOver,
                 mouseleave: me.onMouseLeave,
                 scope: me
             });
@@ -334,7 +334,7 @@ Ext.define("GeoExt.component.Map", {
      *
      * @private
      */
-    onMouseEnter: function() {
+    onMouseOver: function() {
         this.isMouseOverMapEl = true;
     },
 
@@ -349,11 +349,11 @@ Ext.define("GeoExt.component.Map", {
 
     /**
      * Unregisters the #bufferedPointerMove event listener and unbinds the
-     * enter- and leave-listeners.
+     * over- and leave-listeners.
      */
     unregisterPointerRestEvents: function(){
         var map = this.getMap();
-        this.unbindEnterLeaveListeners();
+        this.unbindOverLeaveListeners();
         if (map) {
             map.un('pointermove', this.bufferedPointerMove);
         }


### PR DESCRIPTION
This PR suggests to replace the `mouseenter` with the `mouseover` event to ensure the map's `pointerrest` event is fired as expected in IE11.

IE11 fires the `mouseenter` event if the user moves the mouse pointer inside the boundaries of the object (here the `GeoExt.component.Map`) only. If the pointer is already inside the boundaries, it wont get fired and the user has to move the pointer outside the element and back in the origin to get this event fired (see [here](https://msdn.microsoft.com/en-us/library/ms536945(v=vs.85).aspx) for further details).

The problem: Under circumstances where the pointer is moved outside the map (`mouseleave`), e.g. by a hover popup/window created just under the pointer, the user would have to move the pointer outside the map and back in to get the hover functionality working again.