### PR TITLE
Fixed recursion on treenodes to avoid layerloss on nodecollapse

### DIFF
--- a/src/data/store/LayersTree.js
+++ b/src/data/store/LayersTree.js
@@ -346,7 +346,7 @@ Ext.define('GeoExt.data.store.LayersTree', {
      */
     onBeforeGroupNodeCollapse: function(node){
         var keyRemoveOptOut = this.self.KEY_COLLAPSE_REMOVE_OPT_OUT;
-        node.eachChild(function(child){
+        node.cascadeBy(function(child){
             child[keyRemoveOptOut] = true;
         });
     },


### PR DESCRIPTION
In ExtJs collapsing of a node in the layertree leads to a loss of children in the store. In GeoExt there is a fix for this, but it only saves the first childnodes. With this fix, all children are safe!