### PR TITLE
Use json in LayersTree test when using TileJSON

### DIFF
--- a/test/spec/GeoExt/data/store/LayersTree.test.js
+++ b/test/spec/GeoExt/data/store/LayersTree.test.js
@@ -228,7 +228,7 @@ describe('GeoExt.data.store.LayersTree', function() {
                         name: 'LAYERGEOGRAPHYCLASS',
                         source: new ol.source.TileJSON({
                             url: 'http://api.tiles.mapbox.com/v3/'+
-                                'mapbox.geography-class.jsonp',
+                                'mapbox.geography-class.json',
                             crossOrigin: 'anonymous'
                         })
                     }),
@@ -237,7 +237,7 @@ describe('GeoExt.data.store.LayersTree', function() {
                         name: 'LAYERLIGHT',
                         source: new ol.source.TileJSON({
                             url: 'http://api.tiles.mapbox.com/v3/'+
-                                'mapbox.world-borders-light.jsonp',
+                                'mapbox.world-borders-light.json',
                             crossOrigin: 'anonymous'
                         })
                     })


### PR DESCRIPTION
`ol.source.TileJSON` now uses XHR (see openlayers/ol3#4625) and we need to adjust our tests.

Please review.