### PR TITLE
Update form example

### DIFF
--- a/examples/mapviewform/mapviewform.html
+++ b/examples/mapviewform/mapviewform.html
@@ -14,8 +14,6 @@
             This example shows how to wrap OpenLayers classes as GeoExt.data.model.OlObjects. Changes on the Ext.data.Model are forwarded to the OpenLayers object and vice versa.
         </p>
         <p>
-            More layer settings like saturation and hue are available if WebGL is supported by your browser.</p>
-        <p>
             Have a look at <a href="mapviewform.js">mapviewform.js</a> to see how this is done.
         </p>
     </div>


### PR DESCRIPTION
This removes features from the example that depended on some experimental and rejected features of ol3 (hue, saturation as props of the layer). 

To make up for this I added a different demo of binding a boolean ol.Object  property to a checkbox. I found that to be at least a little bit interesting.. now that this example is much less colorful. :rainbow: :cry: 