### PR TITLE
Allow to init records from deeply nested property maps migrating print models

### DIFF
--- a/src/data/model/Base.js
+++ b/src/data/model/Base.js
@@ -21,9 +21,37 @@ Ext.define('GeoExt.data.model.Base', {
     requires: [
         'Ext.data.identifier.Uuid'
     ],
+
+    identifier: 'uuid',
+
     schema: {
         id: 'geoext-schema',
         namespace: 'GeoExt.data.model'
     },
-    identifier: 'uuid'
+
+    inheritableStatics: {
+        /**
+         * Loads a record from a provided data structure initializing the models
+         * associations. Simply calling Ext.create will not utilize the models
+         * configured reader and effectivly sidetrack associations configs.
+         * This static helper method makes sure associations are initialized
+         * properly and are available with the returned record.
+         *
+         * Be aware that the provided data may be modified by the models reader
+         * initializing associations.
+         *
+         * @param  {Object} data The data the record will be created with.
+         * @return {GeoExt.data.model.Base} The record.
+         */
+        loadRawData: function (data) {
+            var me = this,
+                result = me.getProxy().getReader().readRecords(data || {}),
+                records = result.getRecords(),
+                success = result.getSuccess();
+
+            if (success && records.length) {
+                return records[0];
+            }
+        }
+    }
 });

--- a/src/data/model/Layer.js
+++ b/src/data/model/Layer.js
@@ -32,20 +32,6 @@ Ext.define('GeoExt.data.model.Layer', {
     ],
     // </debug>
 
-    statics: {
-        /**
-         * Convenience function for creating new layer model instance object
-         * using a layer object.
-         *
-         * @param {ol.layer.Base} layer The layer to create the model instance
-         *     for.
-         * @return {GeoExt.data.model.Layer} The created model instance.
-         * @static
-         */
-        createFromLayer: function(layer) {
-            return this.getProxy().getReader().readRecords([layer]).records[0];
-        }
-    },
     fields: [
         {
             name: 'isLayerGroup',

--- a/src/data/model/print/Capability.js
+++ b/src/data/model/print/Capability.js
@@ -24,6 +24,14 @@ Ext.define('GeoExt.data.model.print.Capability', {
     requires: [
         'GeoExt.data.model.print.Layout'
     ],
+
+    /**
+     * @method layouts
+     * Returns an Ext.data.Store of referenced
+     * {@link GeoExt.data.model.print.Layout}s.
+     * @return {Ext.data.Store} The store
+     */
+
     fields: [
         { name: 'app', type: 'string' },
         { name: 'formats', type: 'auto', defaultValue: [] }

--- a/src/data/model/print/Capability.js
+++ b/src/data/model/print/Capability.js
@@ -32,12 +32,7 @@ Ext.define('GeoExt.data.model.print.Capability', {
         }
     ],
     fields: [
-        {
-            name: 'app',
-            type: 'string'
-        },
-        {
-            name: 'formats'
-        }
+        { name: 'app', type: 'string' },
+        { name: 'formats', type: 'auto', defaultValue: [] }
     ]
 });

--- a/src/data/model/print/Capability.js
+++ b/src/data/model/print/Capability.js
@@ -24,13 +24,6 @@ Ext.define('GeoExt.data.model.print.Capability', {
     requires: [
         'GeoExt.data.model.print.Layout'
     ],
-    hasMany: [
-        {
-            name: 'layouts',
-            associationKey: 'layouts',
-            model: 'print.Layout'
-        }
-    ],
     fields: [
         { name: 'app', type: 'string' },
         { name: 'formats', type: 'auto', defaultValue: [] }

--- a/src/data/model/print/Layout.js
+++ b/src/data/model/print/Layout.js
@@ -25,17 +25,14 @@ Ext.define('GeoExt.data.model.print.Layout', {
     requires: [
         'GeoExt.data.model.print.LayoutAttribute'
     ],
-    hasMany: [
-        {
-            name: 'attributes',
-            associationKey: 'attributes',
-            model: 'print.LayoutAttribute'
-        }
-    ],
     fields: [
+        { name: 'name', type: 'string' },
         {
-            name: 'name',
-            type: 'string'
+            name: 'capabilityId',
+            reference: {
+                type: 'print.Capability',
+                inverse: 'layouts'
+            }
         }
     ]
 });

--- a/src/data/model/print/Layout.js
+++ b/src/data/model/print/Layout.js
@@ -25,6 +25,21 @@ Ext.define('GeoExt.data.model.print.Layout', {
     requires: [
         'GeoExt.data.model.print.LayoutAttribute'
     ],
+
+    /**
+     * @method getCapability
+     * Returns the layouts parent print capabilities. May be null if Layout is
+     * instantiated directly.
+     * @return {GeoExt.data.model.print.Capability} The print capabilities
+     */
+
+    /**
+     * @method attributes
+     * Returns an Ext.data.Store of referenced
+     * {@link GeoExt.data.model.print.LayoutAttribute}s.
+     * @return {Ext.data.Store} The store
+     */
+
     fields: [
         { name: 'name', type: 'string' },
         {

--- a/src/data/model/print/LayoutAttribute.js
+++ b/src/data/model/print/LayoutAttribute.js
@@ -22,6 +22,14 @@
  */
 Ext.define('GeoExt.data.model.print.LayoutAttribute', {
     extend: 'GeoExt.data.model.Base',
+
+    /**
+     * @method getLayout
+     * Returns the attribute parent layout model. May be null if
+     * LayoutAttribute is instantiated directly.
+     * @return {GeoExt.data.model.print.Layout} The attributes layout
+     */
+
     fields: [
         { name: 'name', type: 'string' },
         { name: 'type', type: 'string' },

--- a/src/data/model/print/LayoutAttribute.js
+++ b/src/data/model/print/LayoutAttribute.js
@@ -23,17 +23,15 @@
 Ext.define('GeoExt.data.model.print.LayoutAttribute', {
     extend: 'GeoExt.data.model.Base',
     fields: [
+        { name: 'name', type: 'string' },
+        { name: 'type', type: 'string' },
+        { name: 'clientInfo', type: 'auto' },
         {
-            name: 'name',
-            type: 'string'
-        },
-        {
-            name: 'type',
-            type: 'string'
-        },
-        {
-            name: 'clientInfo',
-            type: 'auto'
+            name: 'layoutId',
+            reference: {
+                type: 'print.Layout',
+                inverse: 'attributes'
+            }
         }
     ]
 });

--- a/test/data/PrintCapabilities.json
+++ b/test/data/PrintCapabilities.json
@@ -1,0 +1,122 @@
+{
+    "app": "geoext",
+    "layouts": [
+        {
+            "name": "A4 portrait",
+            "attributes": [
+                {
+                    "name": "map",
+                    "type": "MapAttributeValues",
+                    "clientParams": {
+                        "center": {
+                            "type": "double",
+                            "isArray": true
+                        },
+                        "bbox": {
+                            "type": "double",
+                            "isArray": true
+                        },
+                        "layers": {
+                            "type": "array"
+                        },
+                        "dpi": {
+                            "type": "double"
+                        },
+                        "areaOfInterest": {
+                            "type": "AreaOfInterest",
+                            "embeddedType": {
+                                "area": {
+                                    "type": "String"
+                                },
+                                "renderAsSvg": {
+                                    "type": "boolean",
+                                    "default": null
+                                },
+                                "display": {
+                                    "type": "AoiDisplay",
+                                    "embeddedType": {},
+                                    "default": "RENDER"
+                                },
+                                "style": {
+                                    "type": "String",
+                                    "default": null
+                                }
+                            }
+                        },
+                        "scale": {
+                            "type": "double",
+                            "default": null
+                        },
+                        "rotation": {
+                            "type": "double",
+                            "default": null
+                        },
+                        "projection": {
+                            "type": "String",
+                            "default": null
+                        },
+                        "dpiSensitiveStyle": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "zoomToFeatures": {
+                            "type": "ZoomToFeatures",
+                            "embeddedType": {
+                                "zoomType": {
+                                    "type": "ZoomType",
+                                    "embeddedType": {},
+                                    "default": "EXTENT"
+                                },
+                                "minMargin": {
+                                    "type": "int",
+                                    "default": 10
+                                },
+                                "minScale": {
+                                    "type": "double",
+                                    "default": null
+                                },
+                                "layer": {
+                                    "type": "String",
+                                    "default": null
+                                }
+                            },
+                            "default": null
+                        },
+                        "useNearestScale": {
+                            "type": "boolean",
+                            "default": null
+                        },
+                        "longitudeFirst": {
+                            "type": "boolean",
+                            "default": null
+                        },
+                        "useAdjustBounds": {
+                            "type": "boolean",
+                            "default": null
+                        }
+                    },
+                    "clientInfo": {
+                        "height": 330,
+                        "width": 780,
+                        "dpiSuggestions": [
+                            72,
+                            120,
+                            200,
+                            254,
+                            300
+                        ],
+                        "maxDPI": 400
+                    }
+                }
+            ]
+        }
+    ],
+    "formats": [
+        "bmp",
+        "gif",
+        "pdf",
+        "png",
+        "tif",
+        "tiff"
+    ]
+}

--- a/test/index.html
+++ b/test/index.html
@@ -41,6 +41,9 @@
   <script src='spec/GeoExt/data/model/Feature.test.js'></script>
   <script src='spec/GeoExt/data/model/Layer.test.js'></script>
   <script src='spec/GeoExt/data/model/OlObject.test.js'></script>
+  <script src='spec/GeoExt/data/model/print/Capability.test.js'></script>
+  <script src='spec/GeoExt/data/model/print/Layout.test.js'></script>
+  <script src='spec/GeoExt/data/model/print/LayoutAttribute.test.js'></script>
   <script src='spec/GeoExt/data/serializer/Base.test.js'></script>
   <script src='spec/GeoExt/data/serializer/ImageWMS.test.js'></script>
   <script src='spec/GeoExt/data/serializer/TileWMS.test.js'></script>

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -18,6 +18,11 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
+            // test data
+            {
+                pattern: 'test/data/**',
+                included: false
+            },
             // CSS files
             'http://openlayers.org/en/master/css/ol.css',
             'https://cdnjs.cloudflare.com/ajax/libs/extjs/6.0.0/classic/'

--- a/test/spec/GeoExt/data/model/print/Capability.test.js
+++ b/test/spec/GeoExt/data/model/print/Capability.test.js
@@ -1,0 +1,166 @@
+describe("A GeoExt.data.model.print.Capability model", function() {
+
+    var dataBasePath = (typeof __karma__ === "undefined" ? "" : "base/test/"),
+        url = dataBasePath + "data/PrintCapabilities.json",
+        data;
+
+    function createFromRawData(props) {
+        return Ext.create('GeoExt.data.model.print.Capability', props);
+    }
+
+    function loadFromRawData(props) {
+        var recordProps = Ext.clone(props);
+        return GeoExt.data.model.print.Capability.loadRawData(recordProps);
+    }
+
+    before(function(done) {
+        Ext.syncRequire("GeoExt.data.model.print.Capability");
+        Ext.Ajax.request({
+            url: url,
+            success: function(response) {
+                data = Ext.decode(response.responseText);
+            },
+            failure: function(response) {
+                Ext.raise("Could not retrieve test data. Code "
+                    + response.status);
+            },
+            callback: function() {
+                done();
+            }
+        });
+    });
+
+    describe('can be initialized with Ext.create', function() {
+        var record;
+
+        it('from no properties at all', function() {
+            expect(createFromRawData).to.not.throwException();
+            record = createFromRawData();
+            expect(record).to.be.a(GeoExt.data.model.print.Capability);
+            expect(record.get('app')).to.be('');
+            expect(record.get('formats')).to.be.an('array');
+            expect(record.get('formats')).to.be.empty();
+        });
+
+        it('yielding accessor for associated layout model', function() {
+            expect(record.layouts).to.be.a('function');
+            expect(record.layouts()).to.be.an(Ext.data.Store);
+            expect(record.layouts().getCount()).to.be(0);
+        });
+    });
+
+    describe('can be initialized with Ext.create', function() {
+        var record;
+
+        it('from a property map', function() {
+            expect(createFromRawData)
+                .withArgs(data).to.not.throwException();
+            record = createFromRawData(data);
+            expect(record).to.be.a(GeoExt.data.model.print.Capability);
+            expect(record.get('app')).to.be('geoext');
+            expect(record.get('formats')).to.be.an('array');
+            expect(record.get('formats').length).to.be(6);
+        });
+
+        it('yielding accessor for associated layout model', function() {
+            expect(record.layouts).to.be.a('function');
+            expect(record.layouts()).to.be.an(Ext.data.Store);
+        });
+
+        it('but does not read nested associations data', function() {
+            expect(record.layouts().getCount()).to.be(0);
+        });
+    });
+
+    describe("can be initialized with static #loadRawData", function() {
+        var record;
+
+        it('from no properties at all', function() {
+            expect(loadFromRawData).to.not.throwException();
+            record = loadFromRawData();
+            expect(record).to.be.a(GeoExt.data.model.print.Capability);
+            expect(record.get('app')).to.be('');
+            expect(record.get('formats')).to.be.an('array');
+            expect(record.get('formats')).to.be.empty();
+        });
+
+        it('yielding accessor for associated layout model', function() {
+            expect(record.layouts).to.be.a('function');
+            expect(record.layouts()).to.be.an(Ext.data.Store);
+            expect(record.layouts().getCount()).to.be(0);
+        });
+    });
+
+    describe("can be initialized with static #loadRawData", function() {
+        var record;
+
+        it('from a property map', function() {
+            expect(loadFromRawData).withArgs(data).to.not.throwException();
+            record = loadFromRawData(data);
+            expect(record).to.be.a(GeoExt.data.model.print.Capability);
+            expect(record.get('app')).to.be('geoext');
+            expect(record.get('formats')).to.be.an('array');
+            expect(record.get('formats').length).to.be(6);
+        });
+
+        it('yielding accessor for associated layout model', function() {
+            expect(record.layouts).to.be.a('function');
+            expect(record.layouts()).to.be.an(Ext.data.Store);
+        });
+
+        it('and allows access to deeply nested assosciations data', function() {
+            var layouts = record.layouts(),
+                layout, attributes, attribute;
+
+            expect(layouts.getAt(0))
+                .to.be.a(GeoExt.data.model.print.Layout);
+            layout = layouts.getAt(0);
+            expect(layout.get('name')).to.be('A4 portrait');
+            expect(layout.attributes()).to.be.an(Ext.data.Store);
+            attributes = layout.attributes();
+            expect(attributes.getAt(0))
+                .to.be.a(GeoExt.data.model.print.LayoutAttribute);
+            attribute = attributes.getAt(0);
+            expect(attribute.get('name')).to.be('map');
+        });
+    });
+
+    describe("can be loaded from a remote ressource", function() {
+        var record;
+
+        it('configuring the proxy on the Capability model', function(done) {
+            GeoExt.data.model.print.Capability.getProxy().setUrl(url);
+            GeoExt.data.model.print.Capability.load(null, {
+                callback: function(r) {
+                    expect(r).to.be.a(GeoExt.data.model.print.Capability);
+                    expect(r.get('app')).to.be('geoext');
+                    expect(r.get('formats')).to.be.an('array');
+                    expect(r.get('formats').length).to.be(6);
+                    record = r;
+                    done();
+                }
+            });
+        });
+
+        it('yielding accessor for associated layout model', function() {
+            expect(record.layouts).to.be.a('function');
+            expect(record.layouts()).to.be.an(Ext.data.Store);
+        });
+
+        it('and allows access to deeply nested assosciations data', function() {
+            var layouts = record.layouts(),
+                layout, attributes, attribute;
+
+            expect(layouts.getAt(0))
+                .to.be.a(GeoExt.data.model.print.Layout);
+            layout = layouts.getAt(0);
+            expect(layout.get('name')).to.be('A4 portrait');
+            expect(layout.attributes()).to.be.an(Ext.data.Store);
+            attributes = layout.attributes();
+            expect(attributes.getAt(0))
+                .to.be.a(GeoExt.data.model.print.LayoutAttribute);
+            attribute = attributes.getAt(0);
+            expect(attribute.get('name')).to.be('map');
+        });
+    });
+});

--- a/test/spec/GeoExt/data/model/print/Layout.test.js
+++ b/test/spec/GeoExt/data/model/print/Layout.test.js
@@ -1,0 +1,139 @@
+describe('A GeoExt.data.model.print.Layout', function() {
+
+    var data = {
+        "name": "layoutName",
+        "attributes": [{
+            "name": "attributeName",
+            "type": "anAttribute",
+            "clientParams": {}
+        }]
+    };
+
+    function createFromRawData(props) {
+        return Ext.create('GeoExt.data.model.print.Layout', props);
+    }
+
+    function loadFromRawData(props) {
+        var recordProps = Ext.clone(props);
+        return GeoExt.data.model.print.Layout.loadRawData(recordProps);
+    }
+
+    before(function() {
+        Ext.syncRequire([
+            'GeoExt.data.model.print.Layout',
+            'GeoExt.data.model.print.Capability'
+        ]);
+    });
+
+    describe('can be initialized with Ext.create', function() {
+        var record;
+
+        it('from no properties at all', function() {
+            expect(createFromRawData).to.not.throwException();
+            record = createFromRawData();
+            expect(record).to.be.a(GeoExt.data.model.print.Layout);
+            expect(record.get('name')).to.be('');
+        });
+
+        describe('yielding accessors to assosciated models', function() {
+            it('for print capabilities (parent)', function() {
+                expect(record.getCapability).to.be.a('function');
+                expect(record.getCapability()).to.be(null);
+            });
+
+            it('for layout attributes (children)', function() {
+                expect(record.attributes).to.be.a('function');
+                expect(record.attributes()).to.be.an(Ext.data.Store);
+                expect(record.attributes().getCount()).to.be(0);
+            });
+        });
+    });
+
+    describe('can be initialized with Ext.create', function() {
+        var record;
+
+        it('from a properties map', function() {
+            expect(createFromRawData).withArgs(data).to.not.throwException();
+            record = createFromRawData(data);
+            expect(record).to.be.a(GeoExt.data.model.print.Layout);
+            expect(record.get('name')).to.be('layoutName');
+        });
+
+        describe('yielding accessors to assosciated models', function() {
+            it('for print capabilities (parent)', function() {
+                expect(record.getCapability).to.be.a('function');
+            });
+
+            it('for layout attributes (children)', function() {
+                expect(record.attributes).to.be.a('function');
+            });
+        });
+
+        describe('but', function() {
+            it('does not read nested associations data', function() {
+                expect(record.getCapability()).to.be(null);
+                expect(record.attributes()).to.be.an(Ext.data.Store);
+                expect(record.attributes().getCount()).to.be(0);
+            });
+        });
+    });
+
+    describe('can be initialized with #loadRawData', function() {
+        var record;
+
+        it('from no properties at all', function() {
+            expect(loadFromRawData).to.not.throwException();
+            record = loadFromRawData();
+            expect(record).to.be.a(GeoExt.data.model.print.Layout);
+            expect(record.get('name')).to.be('');
+        });
+
+        describe('yielding accessors to assosciated models', function() {
+            it('for print capabilities (parent)', function() {
+                expect(record.getCapability).to.be.a('function');
+                expect(record.getCapability()).to.be(null);
+            });
+
+            it('for layout attributes (children)', function() {
+                expect(record.attributes).to.be.a('function');
+                expect(record.attributes()).to.be.an(Ext.data.Store);
+                expect(record.attributes().getCount()).to.be(0);
+            });
+        });
+    });
+
+    describe('can be initialized with #loadRawData', function() {
+        var record;
+
+        it('from a properties map', function() {
+            expect(loadFromRawData).withArgs(data).to.not.throwException();
+            record = loadFromRawData(data);
+            expect(record).to.be.a(GeoExt.data.model.print.Layout);
+            expect(record.get('name')).to.be('layoutName');
+        });
+
+        describe('yielding accessors to assosciated models', function() {
+            it('for print capabilities (parent)', function() {
+                expect(record.getCapability).to.be.a('function');
+            });
+
+            it('for layout attributes (children)', function() {
+                expect(record.attributes).to.be.a('function');
+            });
+        });
+
+        it('reading nested associations data', function() {
+            var attribute;
+
+            expect(record.getCapability()).to.be(null); // no parent defined
+            expect(record.attributes()).to.be.an(Ext.data.Store);
+            expect(record.attributes().getCount()).to.be(1);
+            attribute = record.attributes().getAt(0);
+            expect(attribute)
+                .to.be.a(GeoExt.data.model.print.LayoutAttribute);
+            expect(attribute.get('name')).to.be('attributeName');
+            expect(attribute.get('type')).to.be('anAttribute');
+            expect(attribute.get('clientParams')).to.eql({});
+        });
+    });
+});

--- a/test/spec/GeoExt/data/model/print/LayoutAttribute.test.js
+++ b/test/spec/GeoExt/data/model/print/LayoutAttribute.test.js
@@ -1,0 +1,47 @@
+describe('A GeoExt.data.model.print.LayoutAttribute', function() {
+    var attribute;
+
+    function create(props) {
+        attribute =
+            Ext.create('GeoExt.data.model.print.LayoutAttribute', props);
+    }
+
+    before(function() {
+        Ext.syncRequire([
+            'GeoExt.data.model.print.LayoutAttribute',
+            'GeoExt.data.model.print.Layout'
+        ]);
+    });
+
+    it('can be created without attributes', function() {
+        expect(create).to.not.throwException();
+        expect(attribute).to.be.a(GeoExt.data.model.print.LayoutAttribute);
+        expect(attribute.get('name')).to.be('');
+    });
+
+    it('can be created with attributes', function() {
+        var clientInfo = {
+            height: 100,
+            width: 100,
+            dpiSuggestions: [
+                100
+            ],
+            maxDPI: 100
+        };
+
+        expect(create).withArgs({
+            name: 'attr1',
+            type: 'MapAttributeValues',
+            clientInfo: clientInfo
+        }).to.not.throwException();
+        expect(attribute).to.be.a(GeoExt.data.model.print.LayoutAttribute);
+        expect(attribute.get('name')).to.be('attr1');
+        expect(attribute.get('type')).to.be('MapAttributeValues');
+        expect(attribute.get('clientInfo')).to.eql(clientInfo);
+    });
+
+    it('can access its empty parent relationship', function() {
+        expect(attribute.getLayout).to.be.a('function');
+        expect(attribute.getLayout()).to.be(null);
+    });
+});


### PR DESCRIPTION
Calling `Ext.create("Model", nestedPropsMap)` will result in a record of `Model` whose associations aren't populated. The reason for this is, that the configured reader is never called as would be with any remote request using a proxy. This PR adds a static method `Model.loadData` to GeoExt models to load nested property maps. This is very convenient for cases like the print capabilities which may change less often and can be put into the applications codebase without the need of further remote requests.

To test the whole thing I added tests to the print models and found some inconsistencies when interacting with associations. Migrating the `hasMany` configurations to `reference` field configurations seems to be the recommended approach dealing with relationship in ExtJS 6 anyway.

The 'GeoExt.data.model.print.Capability' tests also contain an example how the capability model can be loaded from a remote source without the need of the MapFishPrintProvider. 

The provider itself is kept unchanged by this but I would like to send another PR that refactors it into the serializer.Base class. I think this makes sense, as all code that is left (apart from the loading of capabilities) is related to layer serialization.