### PR TITLE
Do not use regex global modifier to match symbols

### DIFF
--- a/src/mixin/SymbolCheck.js
+++ b/src/mixin/SymbolCheck.js
@@ -115,8 +115,8 @@ Ext.define('GeoExt.mixin.SymbolCheck', {
          */
         normalizeSymbol: (function() {
             // <debug>
-            var hashRegEx = /#/g;
-            var colonRegEx = /::/g;
+            var hashRegEx = /#/;
+            var colonRegEx = /::/;
             // </debug>
             var normalizeFunction = function(symbolStr){
                 // <debug>


### PR DESCRIPTION
Fixes bug related to `mixin.SymbolCheck` described in #128.

The reasoning behind this is, that the used `/pattern/g` describes a global regex match pattern which would yield the index of the first hit correctly. With the next symbol check this index isn't dropped but the new string is checked starting from that very index again.