### PR TITLE
Link to http variants of the API docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@
         </a>
         <div class="nav-collapse collapse pull-right">
           <ul class="nav">
-            <li><a href="./master/docs/"><i class="icon-th-list icon-big"></i> Documentation</a></li>
-            <li><a href="./master/docs-w-ext/"><i class="icon-list icon-big"></i> Documentation (w/ Ext)</a></li>
+            <li><a href="http://geoext.github.io/geoext3/master/docs/"><i class="icon-th-list icon-big"></i> Documentation</a></li>
+            <li><a href="http://geoext.github.io/geoext3/master/docs-w-ext/"><i class="icon-list icon-big"></i> Documentation (w/ Ext)</a></li>
             <li><a href="https://github.com/geoext/geoext3"><i class="icon-folder-open icon-big"></i> Code</a></li>
           </ul>
         </div>


### PR DESCRIPTION
The docs use resources from openlayers.org, which aren't available via https.

The inline examples therefore do not work when th API docs are accessed via
https.