### PR TITLE
Fix nested node removal

### DIFF
--- a/src/data/store/LayersTree.js
+++ b/src/data/store/LayersTree.js
@@ -446,7 +446,7 @@ Ext.define('GeoExt.data.store.LayersTree', {
         // 1. find the node that existed for that layer
         var node = me.getRootNode().findChildBy(function(candidate) {
             return candidate.getOlLayer() === layerOrGroup;
-        });
+        }, me, true);
         if (!node) {
             return;
         }

--- a/test/spec/GeoExt/data/store/LayersTree.test.js
+++ b/test/spec/GeoExt/data/store/LayersTree.test.js
@@ -118,6 +118,23 @@ describe('GeoExt.data.store.LayersTree', function() {
             expect(treeNode.isFirst()).to.be(true);
             expect(treeNode.isLast()).to.be(true);
         });
+
+        it('does properly remove nested layer', function() {
+            var layer2 = new ol.layer.Vector();
+
+            var group = new ol.layer.Group({
+                layers:[layer2]
+            });
+
+            mapComponent.addLayer(group);
+
+            group.getLayers().remove(layer2);
+
+            var rootNode = treeStore.getRootNode();
+            var groupNode = rootNode.getChildAt(0);
+            expect(groupNode.childNodes.length).to.be(0);
+        });
+
     });
 
     describe('Filterable store', function(){


### PR DESCRIPTION
The treeNode removal candidate could not be found as the search was
performed only on root's direct children (no deep search). In such case when
layer is removed from group it is not being removed from tree.