### PR TITLE
Fix tree's nested node ordering

### DIFF
--- a/src/data/store/LayersTree.js
+++ b/src/data/store/LayersTree.js
@@ -353,7 +353,9 @@ Ext.define('GeoExt.data.store.LayersTree', {
         if (layerOrGroup instanceof ol.layer.Group) {
             // See onBeforeGroupNodeCollapse for an explanation why we have this
             layerNode.on('beforecollapse', me.onBeforeGroupNodeCollapse, me);
-            layerOrGroup.getLayers().forEach(me.addLayerNode, me);
+
+            var childLayers = layerOrGroup.getLayers().getArray();
+            Ext.each(childLayers, me.addLayerNode, me, me.inverseLayerOrder);
         }
     },
 


### PR DESCRIPTION
Check issue #135 for more details.

Also added new tests that check node ordering for both inverse and non inverse layer ordering Tests cover following cases:
1. initial ordering
2. after layer being inserted
3. after layer appended