### PR TITLE
Adds required "imageExtension" to the XYZ serializer.

### DIFF
--- a/src/data/serializer/XYZ.js
+++ b/src/data/serializer/XYZ.js
@@ -68,7 +68,7 @@ Ext.define('GeoExt.data.serializer.XYZ', {
             var serialized = {
                 baseURL: source.getUrls()[0],
                 opacity: layer.getOpacity(),
-                imageExtension: this._getImageExtensionFromSource(source)
+                imageExtension: this.getImageExtensionFromSource(source)
                     || 'png',
                 resolutions: tileGrid.getResolutions(),
                 tileSize: ol.size.toSize(tileGrid.getTileSize()),
@@ -82,17 +82,19 @@ Ext.define('GeoExt.data.serializer.XYZ', {
          * Sources with an tileUrlFunction are currently not supported.
          *
          * @private
-         * @param {ol.Source} source An ol.Source.XYZ.
-         * @return {String} The fileExtension or false if no one is found.
+         * @param {ol.Source} source An ol.source.XYZ.
+         * @return {String} The fileExtension or `false` if none is found.
          */
-        _getImageExtensionFromSource: function(source){
-            var url = source.getUrls()[0];
+        getImageExtensionFromSource: function(source){
+            var urls = source.getUrls();
+            var url = urls ? urls[0] : "";
             var lastThree = url.substr(url.length - 3);
 
             if(Ext.isDefined(url) &&
-                Ext.Array.contains(this.allowedImageExtensions, lastThree)){
+                    Ext.Array.contains(this.allowedImageExtensions, lastThree)){
                 return lastThree;
             } else {
+                Ext.raise("No url(s) supplied for ", source);
                 return false;
             }
         }

--- a/src/data/serializer/XYZ.js
+++ b/src/data/serializer/XYZ.js
@@ -36,6 +36,13 @@ Ext.define('GeoExt.data.serializer.XYZ', {
 
     inheritableStatics: {
         /**
+         * An array of allowed image Extensions for the mapfish print OSM Layer.
+         * @type {Array[String]}
+         * @protected
+         */
+        allowedImageExtensions: ['png','jpg','gif'],
+
+        /**
          * @inheritdoc
          */
         sourceCls: ol.source.XYZ,
@@ -62,13 +69,33 @@ Ext.define('GeoExt.data.serializer.XYZ', {
             var serialized = {
                 baseURL: source.getUrls()[0],
                 opacity: layer.getOpacity(),
+                imageExtension: this._getImageExtensionFromURL(
+                    source.getUrls()[0]) || 'png',
                 resolutions: tileGrid.getResolutions(),
                 tileSize: ol.size.toSize(tileGrid.getTileSize()),
                 type: "OSM"
             };
             return serialized;
+        },
+
+        /**
+         * Returns the file extension from the url and compares it to whitelist.
+         *
+         * @private
+         * @param {String} url The first url from the urls array of
+         *    ol.Source.XYZ.
+         * @return {String} The fileExtension or false if no one is found.
+         */
+        _getImageExtensionFromURL: function(url){
+            var lastThree = url.substr(url.length - 3);
+            if(Ext.Array.contains(this.allowedImageExtensions, lastThree)){
+                return lastThree;
+            } else {
+                return false;
+            }
         }
     }
+
 }, function(cls) {
     // Register this serializer via the inherited method `register`.
     cls.register(cls);

--- a/src/data/serializer/XYZ.js
+++ b/src/data/serializer/XYZ.js
@@ -15,6 +15,7 @@
  */
  /**
   * A serializer for layers that have an `ol.source.XYZ` source.
+  * Sources with an tileUrlFunction are currently not supported.
   *
   * @class GeoExt.data.serializer.XYZ
   */
@@ -36,9 +37,7 @@ Ext.define('GeoExt.data.serializer.XYZ', {
 
     inheritableStatics: {
         /**
-         * An array of allowed image Extensions for the mapfish print OSM Layer.
-         * @type {Array[String]}
-         * @protected
+         *
          */
         allowedImageExtensions: ['png','jpg','gif'],
 
@@ -69,8 +68,8 @@ Ext.define('GeoExt.data.serializer.XYZ', {
             var serialized = {
                 baseURL: source.getUrls()[0],
                 opacity: layer.getOpacity(),
-                imageExtension: this._getImageExtensionFromURL(
-                    source.getUrls()[0]) || 'png',
+                imageExtension: this._getImageExtensionFromSource(source)
+                    || 'png',
                 resolutions: tileGrid.getResolutions(),
                 tileSize: ol.size.toSize(tileGrid.getTileSize()),
                 type: "OSM"
@@ -80,15 +79,18 @@ Ext.define('GeoExt.data.serializer.XYZ', {
 
         /**
          * Returns the file extension from the url and compares it to whitelist.
+         * Sources with an tileUrlFunction are currently not supported.
          *
          * @private
-         * @param {String} url The first url from the urls array of
-         *    ol.Source.XYZ.
+         * @param {ol.Source} source An ol.Source.XYZ.
          * @return {String} The fileExtension or false if no one is found.
          */
-        _getImageExtensionFromURL: function(url){
+        _getImageExtensionFromSource: function(source){
+            var url = source.getUrls()[0];
             var lastThree = url.substr(url.length - 3);
-            if(Ext.Array.contains(this.allowedImageExtensions, lastThree)){
+
+            if(Ext.isDefined(url) &&
+                Ext.Array.contains(this.allowedImageExtensions, lastThree)){
                 return lastThree;
             } else {
                 return false;

--- a/test/spec/GeoExt/data/serializer/XYZ.test.js
+++ b/test/spec/GeoExt/data/serializer/XYZ.test.js
@@ -79,6 +79,7 @@ describe('GeoExt.data.serializer.XYZ', function() {
                     1.42375059957013e-7, 7.11875299785065e-8,
                     3.559376498925325e-8
                 ],
+                imageExtension: 'png',
                 tileSize: [256, 256],
                 type: 'OSM'
             };


### PR DESCRIPTION
This PR adds the `imageExtension` property to the serializer as it is required by the mapfish print servlet v 3.4.

The docs http://mapfish.github.io/mapfish-print-doc/layers.html#OsmLayer seem to be kind of outdated or missleading as they say `imageFormat` is required and deprecated.

A request to the printservlet unveils that `imageExtension` can be used instead:

`The OneOf choice: extension was not satisfied.  One (and only one) of the following fields is required in the request data: java.lang.String imageFormat, java.lang.String imageExtension`