### PR TITLE
Improve layer tree customization options

### DIFF
--- a/examples/tree/panel.js
+++ b/examples/tree/panel.js
@@ -32,10 +32,13 @@ Ext.application({
         layer3 = new ol.layer.Tile({
             source: source3,
             name: 'MapQuest Hybrid',
+            description: 'This is a layer description that will be visible '
+                + 'as a tooltip.',
             visible: false
         });
 
         group = new ol.layer.Group({
+            // name: 'Other Mapquest Layers',
             layers: [layer1, layer2],
             visible: true
         });

--- a/src/data/model/LayerTreeNode.js
+++ b/src/data/model/LayerTreeNode.js
@@ -36,27 +36,25 @@ Ext.define('GeoExt.data.model.LayerTreeNode', {
     ],
     // </debug>
 
-    fields: [
-        {
-            name: 'leaf',
-            type: 'boolean',
-            convert: function(v, record) {
-                var isGroup = record.get('isLayerGroup');
-                if (isGroup === undefined || isGroup) {
-                    return false;
-                } else {
-                    return true;
-                }
+    fields: [{
+        name: 'leaf',
+        type: 'boolean',
+        convert: function(v, record) {
+            var isGroup = record.get('isLayerGroup');
+            if (isGroup === undefined || isGroup) {
+                return false;
+            } else {
+                return true;
             }
-        }, {
-            /**
-             * This should be set via tree panel.
-             */
-            name: '__toggleMode',
-            type: 'string',
-            defaultValue: 'classic'
         }
-    ],
+    }, {
+        /**
+         * This should be set via tree panel.
+         */
+        name: '__toggleMode',
+        type: 'string',
+        defaultValue: 'classic'
+    }],
 
     proxy: {
         type: 'memory',

--- a/src/data/store/LayersTree.js
+++ b/src/data/store/LayersTree.js
@@ -58,13 +58,6 @@ Ext.define('GeoExt.data.store.LayersTree', {
         layerGroup: null,
 
         /**
-         * The layer property that will be used to label tree nodes.
-         *
-         * @cfg {String}
-         */
-        textProperty: 'name',
-
-        /**
          * Configures the behaviour of the checkbox of an `ol.layer.Group`
          * (folder). Possible values are `'classic'` or `'ol3'`.
          *
@@ -342,13 +335,7 @@ Ext.define('GeoExt.data.store.LayersTree', {
         }
 
         // 5. insert a new layer node at the specified index to that node
-        var layerNode = Ext.create('GeoExt.data.model.LayerTreeNode',
-            layerOrGroup
-        );
-        layerNode.set('text', layerOrGroup.get(me.getTextProperty()));
-        layerNode.commit();
-
-        parentNode.insertChild(layerIdx, layerNode);
+        var layerNode = parentNode.insertChild(layerIdx, layerOrGroup);
 
         if (layerOrGroup instanceof ol.layer.Group) {
             // See onBeforeGroupNodeCollapse for an explanation why we have this

--- a/test/spec/GeoExt/data/model/Layer.test.js
+++ b/test/spec/GeoExt/data/model/Layer.test.js
@@ -3,15 +3,28 @@ Ext.Loader.syncRequire([
     'GeoExt.data.model.Layer'
 ]);
 
-describe('GeoExt.data.model.Layer', function() {
+describe('A GeoExt.data.model.Layer', function() {
 
-    describe('basics', function(){
-        it('is defined', function(){
-            expect(GeoExt.data.model.Layer).not.to.be(undefined);
-        });
+    it('class is defined', function(){
+        expect(GeoExt.data.model.Layer).not.to.be(undefined);
     });
 
-    describe('constructor (no arguments)', function(){
+    it('provides a getter for the underlying layer', function(){
+        var layer = new ol.layer.Tile();
+        var instance = Ext.create('GeoExt.data.model.Layer', layer);
+        expect(instance.getOlLayer).to.be.a(Function);
+    });
+
+    it('provides a getter for the underlying layers properties', function () {
+        var layer = new ol.layer.Tile({name : 'title'});
+        var instance = Ext.create('GeoExt.data.model.Layer', layer);
+        expect(instance.getOlLayerProp('none')).to.be(undefined);
+        expect(instance.getOlLayerProp('none', 'default')).to.be('default');
+        expect(instance.getOlLayerProp('name')).to.be('title');
+        expect(instance.getOlLayerProp('name'), 'default').to.be('title');
+    });
+
+    describe('that has been created with no arguments', function(){
         var instance;
         var fields;
 
@@ -24,12 +37,12 @@ describe('GeoExt.data.model.Layer', function() {
             fields = null;
         });
 
-        it('can be constructed', function(){
+        it('is of expected type', function(){
             expect(instance).to.be.an(GeoExt.data.model.Layer);
         });
-        it('gives instances six fields', function(){
+        it('has predefined fields', function(){
             expect(fields).to.be.an(Array);
-            expect(fields.length).to.be(6); // 5 defined in class + id
+            expect(fields.length).to.be(8); // 7 defined in class + id
         });
         it('provides instances with an inherited id field', function(){
             var idField = Ext.Array.findBy(fields, function(field) {
@@ -61,7 +74,7 @@ describe('GeoExt.data.model.Layer', function() {
         });
     });
 
-    describe('constructor (with layer)', function(){
+    describe('that has been created from a layer', function(){
         var layer;
         var instance;
 
@@ -74,7 +87,7 @@ describe('GeoExt.data.model.Layer', function() {
             instance = null;
         });
 
-        it('can be constructed', function(){
+        it('is of expected type', function(){
             expect(instance).to.be.an(GeoExt.data.model.Layer);
         });
 
@@ -83,28 +96,47 @@ describe('GeoExt.data.model.Layer', function() {
         });
     });
 
-    describe('#getOlLayer', function(){
-        var layer;
-        var instance;
+    describe('that is created from a layer', function () {
 
-        beforeEach(function() {
-            layer = new ol.layer.Tile();
-            instance = Ext.create('GeoExt.data.model.Layer', layer);
-        });
-        afterEach(function() {
-            layer = null;
-            instance = null;
+        it('has a default text field', function() {
+            var layer = new ol.layer.Base({});
+            var record = Ext.create('GeoExt.data.model.LayerTreeNode', layer);
+            var name = record.unnamedLayerText;
+
+            expect(record.get('text')).to.be(name);
         });
 
-        it('provides a getter for the layer', function(){
-            expect(instance.getOlLayer).to.be.a(Function);
+        it('has a defined name as a text field', function() {
+            var name = 'test';
+            var layer = new ol.layer.Base({ name: name });
+            var record = Ext.create('GeoExt.data.model.LayerTreeNode', layer);
+
+            expect(record.get('text')).to.be(name);
         });
-        it('returns the passed layer', function(){
-            expect(instance.getOlLayer()).to.be(layer);
-        });
+
     });
 
-    describe('properties are read out of the layer', function(){
+    describe('that is created from a group layer', function () {
+
+        it('has a default text field', function() {
+            var layer = new ol.layer.Group({});
+            var record = Ext.create('GeoExt.data.model.LayerTreeNode', layer);
+            var name = record.unnamedGroupLayerText;
+
+            expect(record.get('text')).to.be(name);
+        });
+
+        it('has a defined name as a text field', function() {
+            var name = 'test';
+            var layer = new ol.layer.Group({ name: name });
+            var record = Ext.create('GeoExt.data.model.LayerTreeNode', layer);
+
+            expect(record.get('text')).to.be(name);
+        });
+
+    });
+
+    describe('maps layer properties from the ol object', function(){
         var layer;
         var instance;
 
@@ -122,18 +154,18 @@ describe('GeoExt.data.model.Layer', function() {
             instance = null;
         });
 
-        it('reads out the layers "opacity"', function(){
+        it('mapping the layers "opacity"', function(){
             expect(instance.get('opacity')).to.be(0.123);
         });
-        it('reads out the layers "minResolution"', function(){
+        it('mapping the layers "minResolution"', function(){
             expect(instance.get('minResolution')).to.be(12);
         });
-        it('reads out the layers "maxResolution"', function(){
+        it('mapping the layers "maxResolution"', function(){
             expect(instance.get('maxResolution')).to.be(99);
         });
     });
 
-    describe('getters return undefined if no layer', function(){
+    describe('getters', function(){
         var instance;
 
         beforeEach(function() {
@@ -143,17 +175,17 @@ describe('GeoExt.data.model.Layer', function() {
             instance = null;
         });
 
-        it('returns "undefined" for "opacity" if no layer was passed',
+        it('return "undefined" for "opacity" if no layer was passed',
             function(){
                 expect(instance.get('opacity')).to.be(undefined);
             }
         );
-        it('returns "undefined" for "minResolution" if no layer was passed',
+        it('return "undefined" for "minResolution" if no layer was passed',
             function(){
                 expect(instance.get('minResolution')).to.be(undefined);
             }
         );
-        it('returns "undefined" for "maxResolution" if no layer was passed',
+        it('return "undefined" for "maxResolution" if no layer was passed',
             function(){
                 expect(instance.get('maxResolution')).to.be(undefined);
             }

--- a/test/spec/GeoExt/data/store/LayersTree.test.js
+++ b/test/spec/GeoExt/data/store/LayersTree.test.js
@@ -760,3 +760,43 @@ describe('GeoExt.data.store.LayersTree', function() {
         });
     });
 });
+
+describe('A GeoExt.data.store.LayersTree', function () {
+
+    it('can be extended with custom LayerTreeNodes', function() {
+        var layer = new ol.layer.Group({name: 'any'});
+        var store;
+        var record;
+
+        // custom LayerTreeNode
+        Ext.define('GeoExt.CustomTreeNode',{
+            extend:'GeoExt.data.model.LayerTreeNode',
+            fields: [{
+                name: 'text',
+                type: 'string',
+                convert: function () {
+                    return 'test';
+                }
+            }]
+        });
+        expect(GeoExt.CustomTreeNode).to.not.be(undefined);
+
+        // custom LayersTree
+        Ext.define('GeoExt.CustomLayersTree', {
+            extend: 'GeoExt.data.store.LayersTree',
+            model: 'GeoExt.CustomTreeNode'
+        });
+        expect(GeoExt.CustomLayersTree).to.not.be(undefined);
+
+        store = Ext.create('GeoExt.CustomLayersTree', {
+            layerGroup: new ol.layer.Group({
+                layers: [layer]
+            })
+        });
+        record = store.getRootNode().getChildAt(0);
+
+        expect(store.getTotalCount()).to.be(1);
+        expect(record).to.be.a(GeoExt.CustomTreeNode);
+        expect(record.get('text')).to.be('test');
+    });
+});

--- a/test/spec/GeoExt/data/store/LayersTree.test.js
+++ b/test/spec/GeoExt/data/store/LayersTree.test.js
@@ -502,6 +502,8 @@ describe('GeoExt.data.store.LayersTree', function() {
         var topMostGroup;
         var store;
         var tree;
+        var rootNode;
+        var innerGroupNode;
 
         beforeEach(function(){
             dragTreeDiv = document.createElement('div');
@@ -531,6 +533,8 @@ describe('GeoExt.data.store.LayersTree', function() {
                 },
                 height: 300
             });
+            rootNode = store.getRootNode();
+            innerGroupNode = rootNode.getChildAt(1);
         });
         afterEach(function(){
             store.destroy();
@@ -548,8 +552,7 @@ describe('GeoExt.data.store.LayersTree', function() {
                 expect(innerGroup.getLayers().item(1)).to.be(layer3);
 
                 // Let's emulate drag
-                var innerGroupNode = store.getAt(2);
-                var threeNode = store.getAt(4);
+                var threeNode = innerGroupNode.getChildAt(1);
                 innerGroupNode.insertChild(0, threeNode);
 
                 // Now
@@ -559,8 +562,7 @@ describe('GeoExt.data.store.LayersTree', function() {
                 expect(innerGroup.getLayers().item(1)).to.be(layer2);
 
                 // Let's emulate a drag that reverts the previous one
-                innerGroupNode = store.getAt(2);
-                var twoNode = store.getAt(4);
+                var twoNode = innerGroupNode.getChildAt(1);
                 innerGroupNode.insertChild(0, twoNode);
 
                 // Now the order is again just like we started
@@ -582,8 +584,7 @@ describe('GeoExt.data.store.LayersTree', function() {
                 expect(innerGroup.getLayers().item(1)).to.be(layer3);
 
                 // Let's emulate drag
-                var innerGroupNode = store.getAt(2);
-                var oneNode = store.getAt(1);
+                var oneNode = rootNode.getChildAt(0);
                 innerGroupNode.appendChild(oneNode);
 
                 // Now
@@ -591,9 +592,8 @@ describe('GeoExt.data.store.LayersTree', function() {
                 expect(innerGroup.getLayers().getLength()).to.be(3);
 
                 // Let's emulate a drag that reverts the previous one
-                var root = store.getAt(0);
-                oneNode = store.getAt(4);
-                root.appendChild(oneNode);
+                oneNode = innerGroupNode.getChildAt(2);
+                rootNode.appendChild(oneNode);
 
                 // Now the length is again just like we started
                 //   length = 2
@@ -612,9 +612,7 @@ describe('GeoExt.data.store.LayersTree', function() {
                 expect(topMostGroup.getLayers().item(1)).to.be(innerGroup);
 
                 // Let's emulate drag
-                var innerGroupNode = store.getAt(2);
-                var root = store.getAt(0);
-                root.insertChild(0, innerGroupNode);
+                rootNode.insertChild(0, innerGroupNode);
 
                 // Now
                 //   0 => innerGroup
@@ -623,9 +621,8 @@ describe('GeoExt.data.store.LayersTree', function() {
                 expect(topMostGroup.getLayers().item(1)).to.be(layer1);
 
                 // Let's emulate a drag that reverts the previous one
-                var oneNode = store.getAt(4);
-                root = store.getAt(0);
-                root.insertChild(0, oneNode);
+                var oneNode = rootNode.getChildAt(1);
+                rootNode.insertChild(0, oneNode);
 
                 // Now the order is again just like we started
                 //   0 => layer1
@@ -676,17 +673,16 @@ describe('GeoExt.data.store.LayersTree', function() {
             });
             olMap = new ol.Map({
                 target: div,
-                layers: [topMostGroup],
+                layers: topMostGroup,
                 view: new ol.View({
                     center: [0, 0],
                     zoom: 2
                 })
             });
             store = Ext.create('GeoExt.data.store.LayersTree', {
-                layerGroup: olMap.getLayerGroup(),
+                layerGroup: topMostGroup,
                 inverseLayerOrder: false
             });
-            rootNode = store.getRootNode();
             tree = Ext.create('Ext.tree.Panel', {
                 store: store,
                 renderTo: dragTreeDiv,
@@ -695,6 +691,7 @@ describe('GeoExt.data.store.LayersTree', function() {
                 },
                 height: 300
             });
+            rootNode = store.getRootNode();
         });
         afterEach(function(){
             store.destroy();
@@ -710,7 +707,7 @@ describe('GeoExt.data.store.LayersTree', function() {
                 expect(numInInnerGroup).to.be(3);
 
                 // collapse innergroup node
-                var innerGroupNode = store.getAt(2);
+                var innerGroupNode = rootNode.getChildAt(1);
                 innerGroupNode.collapse(true, function(){
                     numInInnerGroup = innerGroup2.getLayers().getLength();
 
@@ -739,24 +736,24 @@ describe('GeoExt.data.store.LayersTree', function() {
                 }
                 // before collapse
                 var expandedNumtopMostGroup = store.getTotalCount();
-                // expecting all groups + layers + ExtJs rootNode = 9 items
-                expect(expandedNumtopMostGroup).to.be(9);
+                // expecting all groups + layers + ExtJs rootNode = 8 items
+                expect(expandedNumtopMostGroup).to.be(8);
                 var expandedAllLayersAndGroupsCount =
                     getAllLayers(olMap).length;
-                // expecting all groups + layers = 8 items
-                expect(expandedAllLayersAndGroupsCount).to.be(8);
+                // expecting all groups + layers = 7 items
+                expect(expandedAllLayersAndGroupsCount).to.be(7);
 
                 // collapse topgroup node
                 rootNode.collapseChildren(true, function(){
                     var collapsedNumtopMostGroup = store.getTotalCount();
-                    // expecting ExtJs rootNode + first folder = 2 items
+                    // expecting ExtJs rootNode + two folder of topMostGroup
                     // this is due to the strange behaviour that ExtJs removes
                     // all children from first visible node on collapsing
-                    expect(collapsedNumtopMostGroup).to.be(2);
+                    expect(collapsedNumtopMostGroup).to.be(3);
                     var collapsedAllLayersAndGroupsCount =
                         getAllLayers(olMap).length;
                     // still expecting all groups + layers = 8 items
-                    expect(collapsedAllLayersAndGroupsCount).to.be(8);
+                    expect(collapsedAllLayersAndGroupsCount).to.be(7);
                     done();
                 });
             });


### PR DESCRIPTION
This PR aims to improve the layer tree initialization and customization by doing the following:

* Simplify `GeoExt.data.model.Layer` attribute mapping by referring to helper function `getOlLayerProp`
* Add `text` field to `GeoExt.data.model.Layer` that is populated by sensible defaults. This field is used by the layer tree to show the layers name. It may very well be used in other model views, therefore I choose to place this here instead of `GeoExt.data.model.LayerTreeNode`. This also simplifies the layer node insertion logic of `GeoExt.data.store.LayersTree` and allows extending these objects.
* Add `tip` and `qtitle` fields to make it easy to define tooltips via the `description` property of the OpenLayers layer. 
* Add configuration properties to set the property keys that the aforementioned information is retrieved with from the OpenLayers layer object. For example, to read the layers description from the `abstract` property.
* Test the new features.
* Add a tooltip to tree example to show usage of `qtip`, `qtitle`.