### PR TITLE
Fix wrong datatype in @param API doc

### DIFF
--- a/jsduck-cfg.json
+++ b/jsduck-cfg.json
@@ -21,6 +21,7 @@
         "ol.layer.Group",
         "ol.layer.Layer",
         "ol.source.Source",
+        "ol.source.XYZ",
         "ol.style.Fill",
         "ol.style.Image",
         "ol.style.Stroke",

--- a/src/data/serializer/XYZ.js
+++ b/src/data/serializer/XYZ.js
@@ -82,7 +82,7 @@ Ext.define('GeoExt.data.serializer.XYZ', {
          * Sources with an tileUrlFunction are currently not supported.
          *
          * @private
-         * @param {ol.Source} source An ol.source.XYZ.
+         * @param {ol.source.XYZ} source An ol.source.XYZ.
          * @return {String} The fileExtension or `false` if none is found.
          */
         getImageExtensionFromSource: function(source){


### PR DESCRIPTION
This PR suggests a minor change to the API docs of the XYZ-serializer: we were referencing a non-existing OpenLayers class.

Please review.