### PR TITLE
Update node devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-mocha": "0.2.2",
     "karma-phantomjs-launcher": "1.0.0",
     "karma-sinon": "1.0.4",
-    "mocha": "2.3.3",
+    "mocha": "2.4.5",
     "phantomjs": "1.9.19",
     "phantomjs-prebuilt": "2.1.7",
     "sinon": "1.17.3"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "karma-coverage": "0.5.5",
     "karma-eslint": "2.1.0",
     "karma-expect": "1.1.2",
-    "karma-mocha": "0.2.1",
+    "karma-mocha": "0.2.2",
     "karma-phantomjs-launcher": "0.2.3",
     "karma-sinon": "1.0.4",
     "mocha": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "karma-phantomjs-launcher": "1.0.0",
     "karma-sinon": "1.0.4",
     "mocha": "2.4.5",
-    "phantomjs": "1.9.19",
     "phantomjs-prebuilt": "2.1.7",
     "sinon": "1.17.3"
   }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "karma-sinon": "1.0.4",
     "mocha": "2.3.3",
     "phantomjs": "1.9.19",
+    "phantomjs-prebuilt": "2.1.7",
     "sinon": "1.17.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint": "2.8.0",
     "eslint-config-openlayers": "4.1.0",
     "expect.js": "0.3.1",
-    "karma": "0.13.20",
+    "karma": "0.13.22",
     "karma-coverage": "0.5.3",
     "karma-eslint": "2.0.1",
     "karma-expect": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-config-openlayers": "4.1.0",
     "expect.js": "0.3.1",
     "karma": "0.13.22",
-    "karma-coverage": "0.5.3",
+    "karma-coverage": "0.5.5",
     "karma-eslint": "2.0.1",
     "karma-expect": "1.1.2",
     "karma-mocha": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "karma-eslint": "2.1.0",
     "karma-expect": "1.1.2",
     "karma-mocha": "0.2.2",
-    "karma-phantomjs-launcher": "0.2.3",
+    "karma-phantomjs-launcher": "1.0.0",
     "karma-sinon": "1.0.4",
     "mocha": "2.3.3",
     "phantomjs": "1.9.19",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "browser-sync": "2.11.2",
+    "browser-sync": "2.12.5",
     "coveralls": "2.11.9",
     "eslint": "2.7.0",
     "eslint-config-openlayers": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "expect.js": "0.3.1",
     "karma": "0.13.22",
     "karma-coverage": "0.5.5",
-    "karma-eslint": "2.0.1",
+    "karma-eslint": "2.1.0",
     "karma-expect": "1.1.2",
     "karma-mocha": "0.2.1",
     "karma-phantomjs-launcher": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "browser-sync": "2.12.5",
     "coveralls": "2.11.9",
-    "eslint": "2.7.0",
+    "eslint": "2.8.0",
     "eslint-config-openlayers": "4.1.0",
     "expect.js": "0.3.1",
     "karma": "0.13.20",


### PR DESCRIPTION
This PR updates several `devDependencies` to their newest version:

* [`browser-sync`](https://www.npmjs.com/package/browser-sync) to `2.12.5`
* [`eslint`](https://www.npmjs.com/package/eslint) to `2.8.0`
* [`karma`](https://www.npmjs.com/package/karma) to `0.13.22`
* [`karma-coverage`](https://www.npmjs.com/package/karma-coverage) to `0.5.5`
* [`karma-eslint`](https://www.npmjs.com/package/karma-eslint) to `2.1.0`
* [`karma-mocha`](https://www.npmjs.com/package/karma-mocha) to `0.2.2`
* [`karma-phantomjs-launcher`](https://www.npmjs.com/package/karma-phantomjs-launcher) to `1.0.0`
  * To get rid of a future compatibility warning, [`phantomjs-prebuilt@2.1.7`](https://www.npmjs.com/package/phantomjs-prebuilt) is also required
* [`mocha`](https://www.npmjs.com/package/mocha) to `2.4.5`

Since we use `karma-phantomjs-launcher`, which uses `phantomjs-prebuilt`, we can remove the direct dependency to `phantomjs`; at least that's how I understand it.

@bentrm I'd favor you view here, you are the karma guy.
