### PR TITLE
Remove OpenLayers MapQuest sources

### DIFF
--- a/examples/component/overviewMap.js
+++ b/examples/component/overviewMap.js
@@ -20,12 +20,16 @@ Ext.application({
         var ovMapPanel1;
         var ovMapPanel2;
 
-        source = new ol.source.MapQuest({layer: 'sat'});
+        source = new ol.source.OSM();
         layer = new ol.layer.Tile({
             source: source
         });
 
-        source2 = new ol.source.MapQuest({layer: 'osm'});
+
+        source2 = new ol.source.TileWMS({
+            url: 'http://ows.terrestris.de/osm-gray/service',
+            params: {'LAYERS': 'OSM-WMS', 'TILED': true}
+        });
         layer2 = new ol.layer.Tile({
             source: source2
         });

--- a/examples/tree/panel.js
+++ b/examples/tree/panel.js
@@ -20,29 +20,32 @@ Ext.application({
         var olMap;
         var treeStore;
 
-        source1 = new ol.source.MapQuest({layer: 'sat'});
+        source1 = new ol.source.Stamen({layer: 'watercolor'});
         layer1 = new ol.layer.Tile({
             source: source1,
-            name: 'MapQuest Satellite'
+            name: 'Stamen Watercolor'
         });
 
-        source2 = new ol.source.MapQuest({layer: 'osm'});
+        source2 = new ol.source.Stamen({layer: 'terrain-labels'});
         layer2 = new ol.layer.Tile({
             source: source2,
-            name: 'MapQuest OSM'
+            name: 'Stamen Terrain Labels'
         });
 
-        source3 = new ol.source.MapQuest({layer: 'hyb'});
+        source3 = new ol.source.TileWMS({
+            url: 'http://ows.terrestris.de/osm-gray/service',
+            params: {'LAYERS': 'OSM-WMS', 'TILED': true}
+        });
         layer3 = new ol.layer.Tile({
             source: source3,
-            name: 'MapQuest Hybrid',
-            description: 'This is a layer description that will be visible '
-                + 'as a tooltip.',
+            name: 'terrestris OSM WMS',
+            description: 'This is a layer description that will be visible ' +
+                'as a tooltip.',
             visible: false
         });
 
         group = new ol.layer.Group({
-            // name: 'Other Mapquest Layers',
+            name: 'Some Stamen Layers',
             layers: [layer1, layer2],
             visible: true
         });

--- a/examples/tree/tree-legend-simple.js
+++ b/examples/tree/tree-legend-simple.js
@@ -96,25 +96,36 @@ Ext.application({
         var treeStore;
         var treeStore2;
 
-        source1 = new ol.source.MapQuest({layer: 'sat'});
+
+        source1 = new ol.source.Stamen({layer: 'watercolor'});
         layer1 = new ol.layer.Tile({
-            legendUrl: 'https://otile4-s.mqcdn.com/tiles/1.0.0/sat/4/4/7.jpg',
+            legendUrl: 'https://stamen-tiles-d.a.ssl.fastly.net/' +
+                'watercolor/2/1/0.jpg',
             source: source1,
-            name: 'MapQuest Satellite'
+            name: 'Stamen Watercolor'
         });
 
-        source2 = new ol.source.MapQuest({layer: 'osm'});
+        source2 = new ol.source.Stamen({layer: 'terrain-labels'});
         layer2 = new ol.layer.Tile({
-            legendUrl: 'https://otile4-s.mqcdn.com/tiles/1.0.0/osm/4/4/7.jpg',
+            legendUrl: 'https://stamen-tiles-b.a.ssl.fastly.net/' +
+                'terrain-labels/4/4/6.png',
             source: source2,
-            name: 'MapQuest OSM'
+            name: 'Stamen Terrain Labels'
         });
 
-        source3 = new ol.source.MapQuest({layer: 'hyb'});
+        source3 = new ol.source.TileWMS({
+            url: 'http://ows.terrestris.de/osm-gray/service',
+            params: {'LAYERS': 'OSM-WMS', 'TILED': true}
+        });
         layer3 = new ol.layer.Tile({
-            legendUrl: 'https://otile4-s.mqcdn.com/tiles/1.0.0/hyb/4/4/7.jpg',
+            legendUrl: 'http://ows.terrestris.de/osm-gray/service?' +
+                'SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&' +
+                'TRANSPARENT=true&LAYERS=OSM-WMS&TILED=true&WIDTH=256&' +
+                'HEIGHT=256&CRS=EPSG%3A3857&STYLES=&' +
+                'BBOX=0%2C0%2C10018754.171394622%2C10018754.171394622',
             source: source3,
-            name: 'MapQuest Hybrid'
+            name: 'terrestris OSM WMS',
+            visible: false
         });
 
         layer4 = new ol.layer.Vector({
@@ -123,7 +134,8 @@ Ext.application({
         });
 
         group = new ol.layer.Group({
-            layers: [layer1, layer2]
+            layers: [layer1, layer2],
+            name: 'Some Stamen Layers'
         });
 
         olMap = new ol.Map({

--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -24,7 +24,7 @@
  *         map: new ol.Map({
  *             layers: [
  *                 new ol.layer.Tile({
- *                     source: new ol.source.MapQuest({layer: 'osm'})
+ *                     source: new ol.source.OSM()
  *                 })
  *             ],
  *             view: new ol.View({

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -25,7 +25,7 @@
  *     var olMap = new ol.Map({
  *         layers: [
  *             new ol.layer.Tile({
- *                source: new ol.source.MapQuest({layer: 'osm'})
+ *                source: new ol.source.OSM()
  *             })
  *         ],
  *         view: new ol.View({

--- a/src/component/Popup.js
+++ b/src/component/Popup.js
@@ -22,7 +22,7 @@
  *     var olMap = new ol.Map({
  *         layers: [
  *             new ol.layer.Tile({
- *                source: new ol.source.MapQuest({layer: 'osm'})
+ *                source: new ol.source.OSM()
  *             })
  *         ],
  *         view: new ol.View({

--- a/test/spec/GeoExt/component/Map.test.js
+++ b/test/spec/GeoExt/component/Map.test.js
@@ -32,7 +32,7 @@ describe('GeoExt.component.Map', function() {
             div.style.height = '256px';
             document.body.appendChild(div);
 
-            source = new ol.source.MapQuest({layer: 'sat'});
+            source = new ol.source.OSM();
             layer = new ol.layer.Tile({
                 source: source
             });
@@ -143,7 +143,7 @@ describe('GeoExt.component.Map', function() {
         describe('layer handling', function() {
             it('addLayer() adds an ol.layer.Base to the ol.Map',
                 function() {
-                    var source2 = new ol.source.MapQuest({layer: 'osm'});
+                    var source2 = new ol.source.OSM();
                     var layer2 = new ol.layer.Tile({
                         source: source2
                     });

--- a/test/spec/GeoExt/data/store/Features.test.js
+++ b/test/spec/GeoExt/data/store/Features.test.js
@@ -183,7 +183,7 @@ describe('GeoExt.data.store.Features', function() {
         beforeEach(function() {
             div = document.createElement('div');
             document.body.appendChild(div);
-            var source = new ol.source.MapQuest({layer: 'sat'});
+            var source = new ol.source.OSM();
             var layer = new ol.layer.Tile({
                 source: source
             });
@@ -234,7 +234,7 @@ describe('GeoExt.data.store.Features', function() {
         beforeEach(function() {
             div = document.createElement('div');
             document.body.appendChild(div);
-            var source = new ol.source.MapQuest({layer: 'sat'});
+            var source = new ol.source.OSM();
             var layer = new ol.layer.Tile({
                 source: source
             });

--- a/test/spec/GeoExt/data/store/LayersTree.test.js
+++ b/test/spec/GeoExt/data/store/LayersTree.test.js
@@ -28,7 +28,7 @@ describe('GeoExt.data.store.LayersTree', function() {
         treeDiv.style.height = '256px';
         document.body.appendChild(treeDiv);
 
-        source = new ol.source.MapQuest({layer: 'sat'});
+        source = new ol.source.OSM();
         layer = new ol.layer.Tile({
             source: source,
             name: 'LAYERONE'
@@ -96,7 +96,7 @@ describe('GeoExt.data.store.LayersTree', function() {
 
         it('adds/removes listeners for ol.Collections', function() {
             var layer2 = new ol.layer.Tile({
-                source: new ol.source.MapQuest({
+                source: new ol.source.OSM({
                     layer: 'hyb'
                 }),
                 name: 'LAYERZWO'


### PR DESCRIPTION
Because of the removal of ol.source.MapQuest in OpenLayers (https://github.com/openlayers/ol3/commit/ed80d243fbbeb3c414f9234f80233dd3f560c2ab) this PR removes all MapQuest sources and replaces them with appropriate other data sources.

This affects the examples, tests and live-code snippets, not the library code itself.