### PR TITLE
Reenable the API docs autoupdate

### DIFF
--- a/ci/update-gh-pages.sh
+++ b/ci/update-gh-pages.sh
@@ -86,24 +86,24 @@ cp $GEOEXT_IN_SENCHA_WS_FOLDER/build/$GEOEXT_PACKAGE_NAME-debug.js $SUB_FOLDER_N
 
 # 3. Update the API docs
 # 3.1 … without ExtJS
-# mkdir -p $DOCS_DIR # for the API-docs without ExtJS classes
-# rm -Rf $DOCS_DIR/* # remove any content from previous runs
-# jsduck \
-#     --title="$GEOEXT_PACKAGE_NAME $GEOEXT_PACKAGE_VERSION$DOC_SUFFIX Documentation" \
-#     --output="$DOCS_DIR/" \
-#     --eg-iframe=$TRAVIS_BUILD_DIR/docresources/eg-iframe.html \
-#     $TRAVIS_BUILD_DIR/src/
+mkdir -p $DOCS_DIR # for the API-docs without ExtJS classes
+rm -Rf $DOCS_DIR/* # remove any content from previous runs
+jsduck \
+     --title="$GEOEXT_PACKAGE_NAME $GEOEXT_PACKAGE_VERSION$DOC_SUFFIX Documentation" \
+     --output="$DOCS_DIR/" \
+     --eg-iframe=$TRAVIS_BUILD_DIR/docresources/eg-iframe.html \
+     $TRAVIS_BUILD_DIR/src/
 
 # 3.2 … with ExtJS
-# mkdir -p $DOCS_W_EXT_DIR # for the API-docs without ExtJS classes
-# rm -Rf $DOCS_W_EXT_DIR/* # remove any content from previous runs
-# jsduck \
-#     --title="$GEOEXT_PACKAGE_NAME $GEOEXT_PACKAGE_VERSION$DOC_SUFFIX Documentation (incl. ExtJS classes)" \
-#     --output="$DOCS_W_EXT_DIR/" \
-#     --eg-iframe=$TRAVIS_BUILD_DIR/docresources/eg-iframe.html \
-#     "$DOWN_DIR/ext-$SENCHA_EXTJS_VERSION/packages/core/src" \
-#     "$DOWN_DIR/ext-$SENCHA_EXTJS_VERSION/classic/classic/src" \
-#     $TRAVIS_BUILD_DIR/src/
+mkdir -p $DOCS_W_EXT_DIR # for the API-docs without ExtJS classes
+rm -Rf $DOCS_W_EXT_DIR/* # remove any content from previous runs
+jsduck \
+     --title="$GEOEXT_PACKAGE_NAME $GEOEXT_PACKAGE_VERSION$DOC_SUFFIX Documentation (incl. ExtJS classes)" \
+     --output="$DOCS_W_EXT_DIR/" \
+     --eg-iframe=$TRAVIS_BUILD_DIR/docresources/eg-iframe.html \
+     "$DOWN_DIR/ext-$SENCHA_EXTJS_VERSION/packages/core/src" \
+     "$DOWN_DIR/ext-$SENCHA_EXTJS_VERSION/classic/classic/src" \
+     $TRAVIS_BUILD_DIR/src/
 
 
 # 4. done.


### PR DESCRIPTION
In f0b17ecd1e4deccb39e50d8fe7fd3fcb316338fb (PR #133, merged 2016-03-01) we
disabled the automatic API documentation generation and publishing (via CI)
as a hotfix.

I really want have this back again and want to see if the API-doc generation
errors still occur now that 5 months of time have passed.

Anybody willing & brave enough to review this? We can only really test this once the PR is merged…