### PR TITLE
Apply correct model to FeatureStore with fields

### DIFF
--- a/examples/features/grid.js
+++ b/examples/features/grid.js
@@ -228,6 +228,8 @@ Ext.application({
 
         // create feature store by passing a feature collection
         featStore1 = Ext.create('GeoExt.data.store.Features', {
+            fields: ['city', 'pop'],
+            model: 'GeoExt.data.model.Feature',
             features: featColl,
             map: olMap,
             createLayer: true,
@@ -254,7 +256,7 @@ Ext.application({
                     },
                     onWidgetAttach: function(column, gxRenderer, record) {
                         // update the symbolizer with the related feature
-                        var feature = record.olObject;
+                        var feature = record.getFeature();
                         gxRenderer.update({
                             feature: feature,
                             symbolizers: featRenderer.determineStyle(record)

--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -145,6 +145,14 @@ Ext.define('GeoExt.data.store.Features', {
         me.bindLayerEvents();
     },
 
+    applyFields: function(fields) {
+        if (fields) {
+            this.setModel(
+                Ext.data.schema.Schema.lookupEntity('GeoExt.data.model.Feature')
+            );
+        }
+    },
+
     /**
      * Returns the FeatureCollection which is in sync with this store.
      *

--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -146,9 +146,10 @@ Ext.define('GeoExt.data.store.Features', {
     },
 
     applyFields: function(fields) {
+        var me = this;
         if (fields) {
             this.setModel(
-                Ext.data.schema.Schema.lookupEntity('GeoExt.data.model.Feature')
+                Ext.data.schema.Schema.lookupEntity(me.config.model)
             );
         }
     },

--- a/test/spec/GeoExt/data/store/Features.test.js
+++ b/test/spec/GeoExt/data/store/Features.test.js
@@ -60,6 +60,77 @@ describe('GeoExt.data.store.Features', function() {
 
     });
 
+    describe('constructor (with fields)', function() {
+        var feat;
+        var store;
+
+        beforeEach(function() {
+            var coll = new ol.Collection();
+            feat = new ol.Feature({foo: 'bar'});
+            coll.push(feat);
+            store = Ext.create('GeoExt.data.store.Features', {
+                features: coll,
+                fields: ['foo']
+            });
+        });
+
+        afterEach(function() {
+            if (store.destroy) {
+                store.destroy();
+            }
+            store = null;
+            feat = null;
+        });
+
+        it('constructs an instance of GeoExt.data.store.Features', function() {
+            expect(store).to.be.an(GeoExt.data.store.Features);
+        });
+        it('constructs records with an olObject reference', function() {
+            expect(store.getAt(0).getFeature()).to.be(feat);
+        });
+        it('constructs records with the right fields', function() {
+            expect(store.getAt(0).get('foo')).to.be('bar');
+            expect(store.getAt(0).get('xyz')).to.be(undefined);
+        });
+
+    });
+
+    describe('constructor (with fields and model)', function() {
+        var feat;
+        var store;
+
+        beforeEach(function() {
+            var coll = new ol.Collection();
+            feat = new ol.Feature({foo: 'bar'});
+            coll.push(feat);
+            store = Ext.create('GeoExt.data.store.Features', {
+                features: coll,
+                fields: ['foo'],
+                model: 'GeoExt.data.model.Feature'
+            });
+        });
+
+        afterEach(function() {
+            if (store.destroy) {
+                store.destroy();
+            }
+            store = null;
+            feat = null;
+        });
+
+        it('constructs an instance of GeoExt.data.store.Features', function() {
+            expect(store).to.be.an(GeoExt.data.store.Features);
+        });
+        it('constructs records with an olObject reference', function() {
+            expect(store.getAt(0).getFeature()).to.be(feat);
+        });
+        it('constructs records with the right fields', function() {
+            expect(store.getAt(0).get('foo')).to.be('bar');
+            expect(store.getAt(0).get('xyz')).to.be(undefined);
+        });
+
+    });
+
     describe('constructor (with layer)', function() {
         var div;
         var map;


### PR DESCRIPTION
This ensures that the FeatureStore (``GeoExt.data.store.Features``) uses the correct model class (``GeoExt.data.model.Feature``) in case of beeing instanciated with a ``fields`` configuration. Otherwise an implicit model is generated and the reference to the OL feature in the record is missing (fixes #171).

This also adds some tests and adapts the featuregrid example to show the fixed behaviour.