### PR TITLE
Update development dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "0.12"
+node_js: "stable"
 env:
   global:
     secure: "GHK4yb1Xb9rjV9pK9NtrA9ckRv7cz98w6Ihc20MlEwUK3zaQw7l1fvQ8GjrkG4nYY3trhZQn1bmsQ5Raip+o3PQ/tUasa3nEiAKYHnzrgCoNhPOBTGDCwpllstpM75P5jpY7Ap0Dt/QBm1joOyznLDJ91oKe3Vra5UYwMHFAqhA="

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "karma-eslint": "2.1.0",
     "karma-expect": "1.1.2",
     "karma-mocha": "1.1.1",
-    "karma-phantomjs-launcher": "1.0.0",
+    "karma-phantomjs-launcher": "1.0.2",
     "karma-sinon": "1.0.4",
     "mocha": "2.4.5",
     "phantomjs-prebuilt": "2.1.7",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint": "3.5.0",
     "eslint-config-openlayers": "5.0.0",
     "expect.js": "0.3.1",
-    "karma": "0.13.22",
+    "karma": "1.3.0",
     "karma-coverage": "0.5.5",
     "karma-eslint": "2.1.0",
     "karma-expect": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "karma-coverage": "1.1.1",
     "karma-eslint": "2.1.0",
     "karma-expect": "1.1.2",
-    "karma-mocha": "0.2.2",
+    "karma-mocha": "1.1.1",
     "karma-phantomjs-launcher": "1.0.0",
     "karma-sinon": "1.0.4",
     "mocha": "2.4.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-config-openlayers": "5.0.0",
     "expect.js": "0.3.1",
     "karma": "1.3.0",
-    "karma-coverage": "0.5.5",
+    "karma-coverage": "1.1.1",
     "karma-eslint": "2.1.0",
     "karma-expect": "1.1.2",
     "karma-mocha": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-mocha": "1.1.1",
     "karma-phantomjs-launcher": "1.0.2",
     "karma-sinon": "1.0.5",
-    "mocha": "2.4.5",
+    "mocha": "3.0.2",
     "phantomjs-prebuilt": "2.1.7",
     "sinon": "1.17.3"
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "browser-sync": "2.15.0",
     "coveralls": "2.11.12",
     "eslint": "3.5.0",
-    "eslint-config-openlayers": "4.1.0",
+    "eslint-config-openlayers": "5.0.0",
     "expect.js": "0.3.1",
     "karma": "0.13.22",
     "karma-coverage": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "browser-sync": "2.15.0",
     "coveralls": "2.11.12",
-    "eslint": "2.8.0",
+    "eslint": "3.5.0",
     "eslint-config-openlayers": "4.1.0",
     "expect.js": "0.3.1",
     "karma": "0.13.22",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "karma-phantomjs-launcher": "1.0.2",
     "karma-sinon": "1.0.5",
     "mocha": "3.0.2",
-    "phantomjs-prebuilt": "2.1.7",
+    "phantomjs-prebuilt": "2.1.12",
     "sinon": "1.17.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "browser-sync": "2.12.5",
+    "browser-sync": "2.15.0",
     "coveralls": "2.11.9",
     "eslint": "2.8.0",
     "eslint-config-openlayers": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {},
   "devDependencies": {
     "browser-sync": "2.15.0",
-    "coveralls": "2.11.9",
+    "coveralls": "2.11.12",
     "eslint": "2.8.0",
     "eslint-config-openlayers": "4.1.0",
     "expect.js": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "karma-expect": "1.1.2",
     "karma-mocha": "1.1.1",
     "karma-phantomjs-launcher": "1.0.2",
-    "karma-sinon": "1.0.4",
+    "karma-sinon": "1.0.5",
     "mocha": "2.4.5",
     "phantomjs-prebuilt": "2.1.7",
     "sinon": "1.17.3"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "karma-sinon": "1.0.5",
     "mocha": "3.0.2",
     "phantomjs-prebuilt": "2.1.12",
-    "sinon": "1.17.3"
+    "sinon": "1.17.5"
   }
 }


### PR DESCRIPTION
This PR suggests to update the development dependencies of GeoExt3 to the newest released versions. In detail the following updates were made:

* `browser-sync` from `v2.12.5` to `v2.15.0`
* `coveralls` from `v2.11.9` to `v2.11.12`
* `eslint` from `v2.8.0` to `v3.5.0`
* `eslint-config-openlayers` from `v4.1.0` to `v5.0.0`
* `karma` from `v0.13.22` to `v1.3.0`
* `karma-coverage` from `v0.5.5` to `v1.1.1`
* `karma-mocha` from `v0.2.2` to `v1.1.0`
* `karma-phantomjs-launcher` from `v1.0.0` to `v1.0.2`
* `karma-sinon` from `v1.0.4` to `v1.0.5`
* `mocha` from `v2.4.5` to `v3.0.2`
* `phantomjs-prebuilt` from `v2.1.7` to `v2.1.12`
* `sinon` from `v1.17.3` to `v1.17.5`

Additionally we now run the testsuite on latest Node.js (i.e. v6 currently)

Please review.

