### PR TITLE
Enable travis for greenkeeper branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ after_success:
 branches:
   only:
     - master
+    - /^greenkeeper-.*$/
 cache:
   directories:
     - __download


### PR DESCRIPTION
In order to enable [greenkeeper](https://greenkeeper.io/) for this repository, we should allow travis also for the branches starting with `greenkeeper-`.

Please review.