### PR TITLE
Add action draft and interactions

### DIFF
--- a/examples/measure-tool/measure-tool.html
+++ b/examples/measure-tool/measure-tool.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>measure-tool Example</title>
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.0.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
+    <style>
+      .gx-tooltip {
+        position: relative;
+        background: rgba(0, 0, 0, 0.5);
+        border-radius: 4px;
+        color: white;
+        padding: 4px 8px;
+        opacity: 0.7;
+        white-space: nowrap;
+      }
+      .gx-tooltip-measure {
+        opacity: 1;
+        font-weight: bold;
+      }
+      .gx-tooltip-static {
+        background-color: #ffcc33;
+        color: black;
+        border: 1px solid white;
+      }
+      .gx-tooltip-measure:before,
+      .gx-tooltip-static:before {
+        border-top: 6px solid rgba(0, 0, 0, 0.5);
+        border-right: 6px solid transparent;
+        border-left: 6px solid transparent;
+        content: "";
+        position: absolute;
+        bottom: -6px;
+        margin-left: -7px;
+        left: 50%;
+      }
+      .gx-tooltip-static:before {
+        border-top-color: #ffcc33;
+      }
+      </style>
+</head>
+
+<body>
+
+    <div id='description'>
+        <p>
+            This example shows how to combine the GeoExt.action.Interaction class
+            to bind multiple components to OpenLayers interactions.
+        </p>
+        <p>
+            Buttons that use the same action will be toggled in sync.
+        </p>
+        <p>
+            As the shown draw and measure interaction share a toggleGroup, activating
+            one after another will make sure only one interaction is added to the
+            map at the same time.
+        </p>
+        <p>
+            Have a look at <a href="measure-tool.js">measure-tool.js</a> to see GeoExt.action.Interaction
+            classes can be used. Check out GeoExt.action.Draw and GeoExt.action.Measure to
+            learn how to implement your own actions.
+        </p>
+    </div>
+
+    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.0.0/ext-all.js"></script>
+    <script>
+        Ext.Loader.setConfig({
+            enabled: true,
+            paths: {
+                'GeoExt': '../../src/'
+            }
+        });
+    </script>
+
+    <script src="measure-tool.js"></script>
+</body>
+</html>

--- a/examples/measure-tool/measure-tool.js
+++ b/examples/measure-tool/measure-tool.js
@@ -1,0 +1,106 @@
+Ext.require([
+    'Ext.Toolbar',
+    'Ext.Button',
+    'GeoExt.component.Map',
+    'GeoExt.action.Interaction',
+    'GeoExt.action.Draw',
+    'GeoExt.action.Measure'
+]);
+
+Ext.application({
+    name: 'measure-tool',
+    launch: function() {
+        var source = new ol.source.Vector();
+        var olMap = window.olMap = new ol.Map({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.Stamen({
+                        layer: 'terrain'
+                    })
+                }),
+                new ol.layer.Tile({
+                    source: new ol.source.Stamen({
+                        layer: 'terrain-labels'
+                    })
+                }),
+                new ol.layer.Vector({
+                    source: source,
+                    style: new ol.style.Style({
+                        fill: new ol.style.Fill({
+                            color: 'rgba(255, 255, 255, 0.2)'
+                        }),
+                        stroke: new ol.style.Stroke({
+                            color: '#ffcc33',
+                            width: 2
+                        }),
+                        image: new ol.style.Circle({
+                            radius: 7,
+                            fill: new ol.style.Fill({
+                                color: '#ffcc33'
+                            })
+                        })
+                    })
+                })
+            ],
+            view: new ol.View({
+                center: ol.proj.fromLonLat([13.73836, 51.049259]),
+                zoom: 15
+            })
+        });
+
+        var drawAction = Ext.create('GeoExt.action.Draw', {
+            map: olMap,
+            source: source,
+            type: 'Circle'
+        });
+
+        var lineStringMeasureAction = Ext.create('GeoExt.action.Measure', {
+            map: olMap,
+            source: source,
+            type: 'LineString'
+        });
+
+        var polygonMeasureAction = Ext.create('GeoExt.action.Measure', {
+            text: 'Measure Polygon',
+            map: olMap,
+            source: source
+        });
+
+        var mapPanel = window.mapPanel = Ext.create('Ext.panel.Panel', {
+            title: 'GeoExt.action.Measure Example',
+            region: 'center',
+            layout: 'fit',
+            tbar: [
+                drawAction,
+                lineStringMeasureAction,
+                polygonMeasureAction
+            ],
+            bbar: [
+                lineStringMeasureAction,
+                polygonMeasureAction
+            ],
+            items: [{
+                xtype: 'gx_component_map',
+                map: olMap
+            }]
+        });
+
+        Ext.create('Ext.Viewport', {
+            layout: 'border',
+            items: [
+                mapPanel,
+                {
+                    contentEl: 'description',
+                    title: 'Description',
+                    region: 'east',
+                    width: 300,
+                    border: false,
+                    bodyPadding: 5,
+                    tbar: [
+                        drawAction
+                    ]
+                }
+            ]
+        });
+    }
+});

--- a/src/action/Draw.js
+++ b/src/action/Draw.js
@@ -1,0 +1,247 @@
+/* Copyright (c) 2015-2016 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+Ext.define('GeoExt.action.Draw', {
+    extend: 'GeoExt.action.Interaction',
+
+    config: {
+        /**
+         * @inheritDoc
+         */
+        text: 'Draw',
+
+        /**
+         * Will allow to add/remove the interaction from the map by cycling the
+         * buttons state.
+         *
+         * @inheritDoc
+         */
+        enableToggle: true,
+
+        /**
+         * @inheritDoc
+         */
+        toggleGroup: 'gx-draw-interaction',
+
+        /**
+         * The map that will be measured on.
+         * @type {ol.Map}
+         */
+        map: null,
+
+        /**
+         * The layer source that will be used to add measure geometries.
+         * @type {ol.source.Source}
+         */
+        source: null,
+
+        /**
+         * Message to show before the user draws a geometry.
+         * @type {String}
+         */
+        helpTxt: 'Click to start drawing',
+
+        /**
+         * Message to show when the user is drawing a polygon.
+         * @type {string}
+         */
+        helpContinueTxt: 'Click to continue drawing',
+
+        /**
+         * Type of measuring tool. May be 'Polygon' or 'LineString'.
+         * @type {String}
+         */
+        type: 'Polygon',
+
+        /**
+         * Class that will be added to the tool elements.
+         * @type {String}
+         */
+        tooltipCls: 'gx-tooltip',
+
+        /**
+         * Default style of drawn features.
+         * @type {ol.style.Style}
+         */
+        style: new ol.style.Style({
+            fill: new ol.style.Fill({
+                color: 'rgba(255, 255, 255, 0.2)'
+            }),
+            stroke: new ol.style.Stroke({
+                color: 'rgba(0, 0, 0, 0.5)',
+                lineDash: [10, 10],
+                width: 2
+            }),
+            image: new ol.style.Circle({
+                radius: 5,
+                stroke: new ol.style.Stroke({
+                    color: 'rgba(0, 0, 0, 0.7)'
+                }),
+                fill: new ol.style.Fill({
+                    color: 'rgba(255, 255, 255, 0.2)'
+                })
+            })
+        })
+    },
+
+    /**
+     * Currently drawn feature.
+     * @type {ol.Feature}
+     * @private
+     */
+    sketch: null,
+
+    /**
+     * The interaction that will be added to the map.
+     * @type {ol.interaction.Draw}
+     * @private
+     */
+    drawInteraction: null,
+
+    /**
+     * The help tooltip element.
+     * @type {Element}
+     * @private
+     */
+    helpTooltipElement: null,
+
+    /**
+     * Overlay to show the help messages.
+     * @type {ol.Overlay}
+     * @private
+     */
+    helpTooltip: null,
+
+    constructor: function() {
+        this.callParent(arguments);
+    },
+
+    /**
+     * Adds the measure interaction to the map.
+     */
+    addInteraction: function() {
+        var config = this.initialConfig;
+
+        // has been added by another component that uses this action
+        this.drawInteraction = new ol.interaction.Draw({
+            source: config.source,
+            type: config.type,
+            style: config.style
+        });
+        config.map.addInteraction(this.drawInteraction);
+
+        config.map.on('pointermove', this.onPointerMove, this);
+        this.drawInteraction.on('drawstart', this.onDrawStart, this);
+        this.drawInteraction.on('drawend', this.onDrawEnd, this);
+
+        this.createHelpTooltip();
+    },
+
+    /**
+     * Removes the interaction from the map.
+     */
+    removeInteraction: function() {
+        var config = this.initialConfig;
+
+        // remove current tooltips
+        this.removeHelpTooltip();
+        if (this.measureTooltip) {
+            this.removeMeasureTooltip(this.measureTooltip);
+        }
+
+        // remove interaction from map
+        config.map.removeInteraction(this.drawInteraction);
+
+        // unbind event listeners
+        config.map.un('pointermove', this.onPointerMove, this);
+        this.drawInteraction.un('drawstart', this.onDrawStart, this);
+        this.drawInteraction.un('drawend', this.onDrawEnd, this);
+    },
+
+    /**
+     * Creates a new help tooltip
+     */
+    createHelpTooltip: function() {
+        var config = this.initialConfig;
+
+        this.removeHelpTooltip();
+
+        this.helpTooltipElement = document.createElement('div');
+        this.helpTooltipElement.className = config.tooltipCls + ' hidden';
+        this.helpTooltip = new ol.Overlay({
+            element: this.helpTooltipElement,
+            offset: [15, 0],
+            positioning: 'center-left'
+        });
+        config.map.addOverlay(this.helpTooltip);
+
+        // hide tooltip outside of map viewport
+        config.map.getViewport()
+            .removeEventListener('mouseout', this.onViewportMouseOut, this);
+    },
+
+    removeHelpTooltip: function() {
+        var config = this.initialConfig;
+        var viewport = config.map.getViewport();
+
+        if (this.helpTooltip) {
+            viewport.removeEventListener('mouseout',
+                this.onViewportMouseOut, this);
+
+            config.map.removeOverlay(this.helpTooltip);
+            this.helpTooltipElement.parentNode
+                .removeChild(this.helpTooltipElement);
+            this.helpTooltip = null;
+            this.helpTooltipElement = null;
+        }
+    },
+
+    onDrawStart: function(evt) {
+        this.sketch = evt.feature;
+        this.tooltipCoord = evt.coordinate;
+    },
+
+    onDrawEnd: function() {
+        this.sketch = null;
+    },
+
+    /**
+     * Handle pointer move.
+     * @param {ol.MapBrowserEvent} evt The event.
+     */
+    onPointerMove: function(evt) {
+        var config = this.initialConfig;
+        var helpTxt = this.sketch
+            ? config.helpContinueTxt
+            : config.helpTxt;
+
+        if (evt.dragging) {
+            return;
+        }
+
+        this.helpTooltipElement.innerHTML = helpTxt;
+        this.helpTooltip.setPosition(evt.coordinate);
+
+        this.helpTooltipElement.classList.remove('hidden');
+    },
+
+    /**
+     * Hides the pointer tooltip.
+     */
+    onViewportMouseOut: function() {
+        this.helpTooltipElement.classList.add('hidden');
+    }
+});

--- a/src/action/Interaction.js
+++ b/src/action/Interaction.js
@@ -1,0 +1,100 @@
+/* Copyright (c) 2015-2016 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+Ext.define('GeoExt.action.Interaction', {
+    extend: 'Ext.Action',
+
+    config: {
+        /**
+         * Makes the action toggleable.
+         * @type {Boolean}
+         */
+        enableToggle: false,
+
+        /**
+         * Handler that will be called when the action is called.
+         * @type {Function}
+         */
+        handler: Ext.emptyFn,
+
+        /**
+         * Handler that is called when the action is toggled.         *
+         * @type {Function}
+         * @param {Ext.Component} component The component that is toggled.
+         * @param {Boolean} pressed New state of the component.
+         */
+        toggleHandler: function(component, pressed) {
+            var action = this.baseAction;
+
+            if (pressed) {
+                action.addInteraction();
+            } else {
+                action.removeInteraction();
+            }
+
+            action.syncToggleState(component, pressed);
+        }
+    },
+
+    /**
+     * Overrides default constructor to allow extension of action
+     * configuration options via ExtJS inheritance.
+     * @param  {Object} config Configuration options passed by component.
+     */
+    constructor: function(config) {
+        // map default configuration to components configuration
+        Ext.applyIf(config, this.config);
+
+        this.initialConfig = config;
+        this.itemId = config.itemId = (config.itemId || config.id || Ext.id());
+        this.items = [];
+    },
+
+    /**
+     * Must be implemented to add interactions to the map.
+     * @type {Function}
+     */
+    addInteraction: Ext.emptyFn,
+
+    /**
+     * Must be implemented to remove interactions to the map.
+     * @type {Function}
+     */
+    removeInteraction: Ext.emptyFn,
+
+    /**
+     * Synchronizes the toggle state of toggle components that use the same
+     * action instance.
+     * @param  {Ext.Component} component The component that toggled an action.
+     * @param  {Boolean} pressed   The state that all compoents should have.
+     */
+    syncToggleState: function(component, pressed) {
+        this.items.forEach(function(item) {
+            if (item !== component) {
+                item.toggle(pressed, true);
+            }
+        }, this);
+    },
+
+    /**
+     * @inheritDoc
+     */
+    destroy: function() {
+        this.removeInteraction();
+        this.callParent(arguments);
+    }
+
+});

--- a/src/action/Measure.js
+++ b/src/action/Measure.js
@@ -1,0 +1,237 @@
+/* Copyright (c) 2015-2016 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+Ext.define('GeoExt.action.Measure', {
+    extend: 'GeoExt.action.Draw',
+
+    config: {
+        /**
+         * @inheritDoc
+         */
+        text: 'Measure',
+
+        /**
+         * Defaults to WGS84.
+         * Only used if geodesic = true.
+         * @type {ol.Sphere}
+         */
+        sphere: new ol.Sphere(6378137),
+
+        /**
+         * Geodesic calculation of measurement results.
+         * @type {Boolean}
+         */
+        geodesic: true,
+        //
+        // /**
+        //  * Type of measuring tool. May be 'Polygon' or 'LineString'.
+        //  * @type {String}
+        //  */
+        // type: 'Polygon',
+
+        /**
+         * Format length output.
+         * @param {ol.geom.LineString} line The line.
+         * @return {string} The formatted length.
+         */
+        formatLength: function(line) {
+            var length;
+            if (this.geodesic) {
+                var coordinates = line.getCoordinates();
+                length = 0;
+                var sourceProj = this.map.getView().getProjection();
+                for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
+                    var c1 = ol.proj
+                      .transform(coordinates[i], sourceProj, 'EPSG:4326');
+                    var c2 = ol.proj
+                      .transform(coordinates[i + 1], sourceProj, 'EPSG:4326');
+                    length += this.sphere.haversineDistance(c1, c2);
+                }
+            } else {
+                length = Math.round(line.getLength() * 100) / 100;
+            }
+
+            var output;
+            if (length > 100) {
+                output = (Math.round(length / 1000 * 100) / 100) + ' ' + 'km';
+            } else {
+                output = (Math.round(length * 100) / 100) + ' ' + 'm';
+            }
+
+            return output;
+        },
+
+        /**
+         * Format area output.
+         * @param {ol.geom.Polygon} polygon The polygon.
+         * @return {string} Formatted area.
+         */
+        formatArea: function(polygon) {
+            var area;
+            if (this.geodesic) {
+                var sourceProj = this.map.getView().getProjection();
+                var geom = polygon.clone().transform(sourceProj, 'EPSG:4326');
+                var coordinates = geom.getLinearRing(0).getCoordinates();
+                area = Math.abs(this.sphere.geodesicArea(coordinates));
+            } else {
+                area = polygon.getArea();
+            }
+
+            var output;
+            if (area > 10000) {
+                output = (Math.round(area / 1000000 * 100) / 100)
+                  + ' ' + 'km<sup>2</sup>';
+            } else {
+                output = (Math.round(area * 100) / 100) + ' ' + 'm<sup>2</sup>';
+            }
+
+            return output;
+        }
+    },
+
+    /**
+     * The measure tooltip element.
+     * @type {Element}
+     * @private
+     */
+    measureTooltipElement: null,
+
+    /**
+     * Overlay to show the measurement.
+     * @type {ol.Overlay}
+     */
+    measureTooltip: null,
+
+    /**
+     * Array of tooltips that have been drawn before by this interaction.
+     * @type {Array[ol.Overlay]}
+     */
+    measureTooltips: null,
+
+    constructor: function(config) {
+        var supportedTypes = ['LineString', 'Polygon'];
+        var type = (config.type || this.config.type);
+
+        if (!type || supportedTypes.indexOf(type) < 0) {
+            Ext.Error.raise('Type ' + type + ' unsupported.');
+        }
+
+        this.measureTooltips = [];
+        this.callParent(arguments);
+    },
+
+    /**
+     * Adds the measure interaction to the map.
+     */
+    addInteraction: function() {
+        this.callParent(arguments);
+        this.createMeasureTooltip();
+    },
+
+    /**
+     * Removes the interaction from the map.
+     */
+    removeInteraction: function() {
+        // remove existing measure tooltips
+        this.measureTooltips.forEach(function(tooltip) {
+            this.removeMeasureTooltip(tooltip);
+        }, this);
+        this.measureTooltips = [];
+
+        this.callParent(arguments);
+    },
+
+    /**
+     * Creates a new measure tooltip
+     */
+    createMeasureTooltip: function() {
+        var config = this.initialConfig;
+        var cls = config.tooltipCls;
+
+        this.measureTooltipElement = document.createElement('div');
+        this.measureTooltipElement.className = cls + ' ' + cls + '-measure';
+        this.measureTooltip = new ol.Overlay({
+            element: this.measureTooltipElement,
+            offset: [0, -15],
+            positioning: 'bottom-center'
+        });
+        config.map.addOverlay(this.measureTooltip);
+    },
+
+    /**
+     * Removes the provided tooltip from the map.
+     * @param  {ol.Overlay} measureTooltip The tooltip to remove.
+     */
+    removeMeasureTooltip: function(measureTooltip) {
+        var config = this.initialConfig;
+        var element = measureTooltip.getElement();
+        var sketch = measureTooltip.get('sketch');
+
+        if (sketch) {
+            config.source.removeFeature(sketch);
+            measureTooltip.unset('sketch');
+        }
+
+        config.map.removeOverlay(measureTooltip);
+        element.parentNode.removeChild(element);
+    },
+
+    onDrawStart: function(evt) {
+        this.callParent(arguments);
+        this.sketch.getGeometry().on('change', this.onGeomertyChange, this);
+    },
+
+    onDrawEnd: function() {
+        var config = this.initialConfig;
+        var cls = config.tooltipCls;
+
+        // make tooltip permanent for the lifetime of this interaction
+        this.measureTooltipElement.className = cls + ' ' + cls + '-static';
+        this.measureTooltip.setOffset([0, -7]);
+        this.measureTooltip.set('sketch', this.sketch);
+        this.measureTooltips.push(this.measureTooltip);
+        this.measureTooltip = null;
+        this.createMeasureTooltip();
+
+        this.sketch.getGeometry().un('change', this.onGeomertyChange, this);
+
+        this.callParent(arguments);
+    },
+
+    onGeomertyChange: function(evt) {
+        var config = this.initialConfig;
+        var geom = evt.target;
+        var output;
+
+        if (geom instanceof ol.geom.Polygon) {
+            output = config.formatArea(geom);
+            this.tooltipCoord = geom.getInteriorPoint().getCoordinates();
+        } else if (geom instanceof ol.geom.LineString) {
+            output = config.formatLength(geom);
+            this.tooltipCoord = geom.getLastCoordinate();
+        }
+
+        this.measureTooltipElement.innerHTML = output;
+        this.measureTooltip.setPosition(this.tooltipCoord);
+    },
+
+    /**
+     * Hides the pointer tooltip.
+     */
+    onViewportMouseOut: function() {
+        this.helpTooltipElement.classList.add('hidden');
+    }
+});

--- a/test/spec/GeoExt/action/Interaction.test.js
+++ b/test/spec/GeoExt/action/Interaction.test.js
@@ -1,0 +1,57 @@
+Ext.Loader.syncRequire([
+    'Ext.button.Button',
+    'GeoExt.action.Interaction',
+    'GeoExt.action.Measure'
+]);
+
+describe('A GeoExt.action.Interaction', function() {
+
+    it('can be instantiated', function() {
+        var action = Ext.create('GeoExt.action.Interaction', {});
+
+        expect(action.type).to.not.be('string');
+        expect(action.itemId).to.not.be('undefined');
+        expect(action.items).to.be.empty;
+        expect(action.initialConfig).to.be.an('object');
+        expect(action.initialConfig.enableToggle).to.be.false;
+        expect(action.initialConfig.handler).to.be.a('function');
+        expect(action.initialConfig.toggleHandler).to.be.a('function');
+    });
+
+    describe('can be mapped', function() {
+
+        var div;
+
+        beforeEach(function() {
+            div = document.createElement('div');
+            document.body.appendChild(div);
+        });
+
+        afterEach(function() {
+            document.body.removeChild(div);
+        });
+
+        it('to a button', function() {
+            var label = 'Label';
+            var clicked = 0;
+            var action = Ext.create('GeoExt.action.Interaction', {
+                text: label,
+                renderTo: div,
+                handler: function() {
+                    clicked++;
+                }
+            });
+            var button = Ext.create('Ext.Button', action);
+
+            expect(button.baseAction).to.be(action);
+            expect(action.items.length).to.equal(1);
+            expect(button.getText()).to.equal(label);
+            expect(button.handler).to.be(action.initialConfig.handler);
+            button.fireHandler();
+            expect(clicked).to.equal(1);
+            button.destroy();
+        });
+
+    });
+
+});


### PR DESCRIPTION
#198 showed that there is some interest in simple to use interactions. I was intrigued by the OpenLayers example and started to draft a generic solution for GeoExt 3 based on Ext.Action. I would like to know if these are desirable additions.

Anyway, turns out Ext.Action can't be used as every other class of ExtJS as inheritance is limited. This can be fixed by `Ext.applyIf`ing (yes, it's a thing) the provided initial configuration in an overridden constructor. This is done in `GeoExt.action.Interaction`, which tries to be as generic as possible to allow easy subclassing. 

This solution offers some interesting options as an Action encapsulates state properties from the components it is linked to. This allows
- enabling/activation of the same interaction from multiple components
- accessing all linked components from the actions logic
- synchronization of the components state (only tested with toggle buttons as of yet)

I added two interactions for now that allow to draw to a source (`GeoExt.action.Draw`) and a measure tool (`GeoExt.action.Measure`), an extension of the draw tool. The added example (`examples/measure-tool`) demonstrates the usage of these components.

The following things need to be finished before merging (if you agree to the changes):
- [ ] improve documentation
- [ ] add SCSS styling for tooltips
- [ ] more testing of `GeoExt.action.Interaction`
- [ ] test  `GeoExt.action.Draw`
- [ ] test `GeoExt.action.Measure`

Edit: 💯 💯 🎉 
