### PR TITLE
Allow different projection on overview map

### DIFF
--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -450,8 +450,15 @@ Ext.define('GeoExt.component.OverviewMap', {
      */
     recenterParentFromBox: function() {
         var me = this;
+
         var parentMap = me.getParentMap();
         var parentView = parentMap.getView();
+        var parentProjection = parentView.getProjection();
+
+        var overviewMap = me.getMap();
+        var overviewView = overviewMap.getView();
+        var overviewProjection = overviewView.getProjection();
+
         var currentMapCenter = parentView.getCenter();
         var panAnimation = ol.animation.pan({
             duration: me.getRecenterDuration(),
@@ -459,7 +466,15 @@ Ext.define('GeoExt.component.OverviewMap', {
         });
         var boxExtent = me.boxFeature.getGeometry().getExtent();
         var boxCenter = ol.extent.getCenter(boxExtent);
+
         parentMap.beforeRender(panAnimation);
+
+        // transform if necessary
+        if (!ol.proj.equivalent(parentProjection, overviewProjection)) {
+            boxCenter = ol.proj.transform(boxCenter,
+                    overviewProjection, parentProjection);
+        }
+
         parentView.setCenter(boxCenter);
     },
 

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -426,7 +426,7 @@ Ext.define('GeoExt.component.OverviewMap', {
     disableBoxUpdate: function() {
         var me = this;
         var parentMap = me.getParentMap();
-        if(parentMap) {
+        if (parentMap) {
             parentMap.un('postrender', me.updateBox, me);
         }
     },
@@ -438,7 +438,7 @@ Ext.define('GeoExt.component.OverviewMap', {
     enableBoxUpdate: function() {
         var me = this;
         var parentMap = me.getParentMap();
-        if(parentMap) {
+        if (parentMap) {
             parentMap.on('postrender', me.updateBox, me);
         }
     },

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -322,6 +322,7 @@ Ext.define('GeoExt.component.OverviewMap', {
 
         me.on('beforedestroy', me.onBeforeDestroy, me);
         me.on('resize', me.onResize, me);
+        me.on('afterrender', me.updateBox, me);
 
         me.callParent();
     },

--- a/test/spec/GeoExt/component/OverviewMap.test.js
+++ b/test/spec/GeoExt/component/OverviewMap.test.js
@@ -374,6 +374,33 @@ describe('GeoExt.component.OverviewMap', function() {
                 var parentCenter = olMap.getView().getCenter();
                 expect(parentCenter).to.eql([1, 1]);
             });
+
+            it('reprojects if projections are not equal', function() {
+                overviewMap.destroyDragBehaviour(); // destroy first
+                overviewMap.setupDragBehaviour();
+                overviewMap.boxFeature.setGeometry(ol.geom.Polygon.fromExtent(
+                    [0, 0, 1000000, 1000000]
+                    // --> center is [500000, 500000] in 3857, which is
+                    // [4.491576420597607, 4.486983030705062] in 4326
+                ));
+
+                // set a different projection (4326) for the parent map
+                // to force projection between overviewMap (3857) and
+                // parentMap (4326)
+                var newParentView = new ol.View({
+                    center: [0, 0],
+                    projection: 'EPSG:4326',
+                    zoom: 2
+                });
+                olMap.setView(newParentView);
+
+                // we test whether this call will reproject
+                overviewMap.recenterParentFromBox();
+
+                var parentCenter = olMap.getView().getCenter();
+                var expectedCenter = [4.491576420597607, 4.486983030705062];
+                expect(parentCenter).to.eql(expectedCenter);
+            });
         });
     });
 


### PR DESCRIPTION
I noticed that the overview map requires the same projection as the parent map.

This PR allows the overview map to use a projection that differs from the parent maps projection.

Changes basically include the transformation of coordinates/geoms, if necessary. To assure that the magnification mechanism also works initially, some effort was necessary (as resolutions had to be available on the overviewView).

Note: Tests are still missing. I'll soon try to add some.