### PR TITLE
Don't use OL master due to breaking changes in OL4

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>GeoExt 3 Spec Runner</title>
   <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css">
-  <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+  <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
   <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -14,7 +14,7 @@
   <script src="../node_modules/sinon/pkg/sinon.js"></script>
   <script src="../node_modules/mocha/mocha.js"></script>
 
-  <script src="http://openlayers.org/en/master/build/ol.js"></script>
+  <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
   <script>
     // set Ext loader path

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -24,14 +24,14 @@ module.exports = function(config) {
                 included: false
             },
             // CSS files
-            'http://openlayers.org/en/master/css/ol.css',
+            'http://openlayers.org/en/v3.20.1/css/ol.css',
             'https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/'
                 + 'theme-crisp/resources/theme-crisp-all' + suffix + '.css',
             // requestAnimationFrame shim
             'https://cdn.rawgit.com/paulirish/1579671/raw/'
                 + '682e5c880c92b445650c4880a6bf9f3897ec1c5b/rAF.js',
             // OpenLayers 3
-            'http://openlayers.org/en/master/build/ol' + suffix + '.js',
+            'http://openlayers.org/en/v3.20.1/build/ol' + suffix + '.js',
             // ExtJS 6
             'http://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all'
                 + suffix + '.js',


### PR DESCRIPTION
With the release of OpenLayers v4, the `ol.animation` functions have been removed:
https://github.com/openlayers/openlayers/releases/tag/v4.0.0

As the tests in this project rely on the OpenLayers master branch, there is a failing test now.

This PR changes the test resources to load the latest compatible version of OpenLayers (v3.20.1)