### PR TITLE
Set version to '3.0.0.6203200'

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "summary": "GIS Package for ExtJS",
   "detailedDescription": "GeoExt is Open Source and enables building desktop-like GIS applications through the web. It is a JavaScript framework that combines the GIS functionality of OpenLayers with the user interface savvy of the ExtJS library provided by Sencha.",
   "license": "GPL-3.0",
-  "version": "3.0.0",
+  "//": "version is 3.0.0 + ExtJS + OpenLayers (compatible to 3.20.0)",
+  "version": "3.0.0.6203200",
   "compatVersion": "3.0.0",
   "format": "1",
   "slicer": {


### PR DESCRIPTION
This introduces a new strategy for versions of this package.

The first part is classical semver with major.minor.patch-structure. Then
a fourth part is introduced, which tells us something about the supported
versions of the base libraries:

* `620` stands for `ExtJS v6.2.0`
* `3200` stands for `OpenLayers v3.20.0` compatible (e.g. `v3.20.1`)

The ExtJS part will always be 3 digits, this software is released not as
often as OpenLayers, 3 digits should be enough for now.

The OpenLayers part will always be 4 digits, e.g. OpenLayers `v4.0.0` will
become `4000`; this way the last number is bigger than the last v3 release.
Any patch versions are ignored, so all of the following versions become
`4000`: `v4.0.0`, `v4.0.1` and `v4.0.42`. Version `v4.1.0` will become
`4100`, as we might depend on new features in the OpenLayers library. This
shouldn't be a problem, as OpenLayers switched to semver, which means that
patch releases should never break usability (API is the same).

Both `sencha cmd` and `npm` can deal with this schema.

Please review.