### PR TITLE
Change how we include OpenLayers

### DIFF
--- a/bin/example-generator/example.html.tpl
+++ b/bin/example-generator/example.html.tpl
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>@@EXAMPLE_NAME@@ Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.1.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all.css"/>
 </head>
 
@@ -19,7 +19,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="http://cdn.sencha.com/ext/gpl/5.1.0/build/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/bin/example-generator/example.html.tpl
+++ b/bin/example-generator/example.html.tpl
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>@@EXAMPLE_NAME@@ Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/5.1.0/packages/ext-theme-crisp/build/resources/ext-theme-crisp-all.css"/>
 </head>
 
@@ -19,7 +19,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="http://cdn.sencha.com/ext/gpl/5.1.0/build/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/docresources/eg-iframe.html
+++ b/docresources/eg-iframe.html
@@ -6,7 +6,7 @@
     <title>GeoExt 3 Examples</title>
 
 
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
     <link rel="stylesheet" type="text/css" href="../resources/css/gx-popup.css">
     <style>
@@ -20,7 +20,7 @@
     }
     </style>
 
-    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
 
     <script>

--- a/examples/component/map.html
+++ b/examples/component/map.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.component.Map Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -20,7 +20,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/component/map.html
+++ b/examples/component/map.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.component.Map Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 

--- a/examples/component/overviewMap.html
+++ b/examples/component/overviewMap.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.component.OverviewMap Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -27,7 +27,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
             Ext.Loader.setConfig({

--- a/examples/component/overviewMap.html
+++ b/examples/component/overviewMap.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.component.OverviewMap Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -27,7 +27,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
             Ext.Loader.setConfig({

--- a/examples/features/grid.html
+++ b/examples/features/grid.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Feature Grid Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -25,7 +25,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/master/build/ol-debug.js"></script>
+    <script src="http://openlayers.org/en/v3.20.1/build/ol-debug.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/features/grid.html
+++ b/examples/features/grid.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Feature Grid Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -25,7 +25,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/v3.20.1/build/ol-debug.js"></script>
+    <script src="https://openlayers.org/en/v3.20.1/build/ol-debug.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/mapviewform/mapviewform.html
+++ b/examples/mapviewform/mapviewform.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Map View Form Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -18,7 +18,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/mapviewform/mapviewform.html
+++ b/examples/mapviewform/mapviewform.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Map View Form Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -18,7 +18,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/popup/gx-popup.html
+++ b/examples/popup/gx-popup.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Popup Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 
     <link rel="stylesheet" type="text/css" href="../../resources/css/gx-popup.css">
@@ -40,7 +40,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/popup/gx-popup.html
+++ b/examples/popup/gx-popup.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Popup Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 
     <link rel="stylesheet" type="text/css" href="../../resources/css/gx-popup.css">
@@ -40,7 +40,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/print/basic-mapfish.html
+++ b/examples/print/basic-mapfish.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.data.MapfishPrintProvider Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -30,7 +30,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/print/basic-mapfish.html
+++ b/examples/print/basic-mapfish.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.data.MapfishPrintProvider Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -30,7 +30,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/renderer/renderer.html
+++ b/examples/renderer/renderer.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.component.FeatureRenderer Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
     <style type="text/css">
          #swatches {
@@ -91,7 +91,7 @@
             })
         </textarea><br>
         <button id="render">render</button>
-        <script src="http://openlayers.org/en/v3.20.1/build/ol-debug.js"></script>
+        <script src="https://openlayers.org/en/v3.20.1/build/ol-debug.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
         <script>
             Ext.Loader.setConfig({

--- a/examples/renderer/renderer.html
+++ b/examples/renderer/renderer.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.component.FeatureRenderer Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
     <style type="text/css">
          #swatches {
@@ -91,7 +91,7 @@
             })
         </textarea><br>
         <button id="render">render</button>
-        <script src="http://openlayers.org/en/master/build/ol-debug.js"></script>
+        <script src="http://openlayers.org/en/v3.20.1/build/ol-debug.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
         <script>
             Ext.Loader.setConfig({

--- a/examples/tree/panel.html
+++ b/examples/tree/panel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>TreeStore Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -20,7 +20,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
             Ext.Loader.setConfig({

--- a/examples/tree/panel.html
+++ b/examples/tree/panel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>TreeStore Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -20,7 +20,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
             Ext.Loader.setConfig({

--- a/examples/tree/tree-legend-simple.html
+++ b/examples/tree/tree-legend-simple.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Ext.tree.Panel plus layer legends Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/master/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
     <style>
 .x-grid-rowbody {
@@ -33,7 +33,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/master/build/ol.js"></script>
+    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
             Ext.Loader.setConfig({

--- a/examples/tree/tree-legend-simple.html
+++ b/examples/tree/tree-legend-simple.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Ext.tree.Panel plus layer legends Example</title>
-    <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
     <style>
 .x-grid-rowbody {
@@ -33,7 +33,7 @@
         </p>
     </div>
 
-    <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
             Ext.Loader.setConfig({

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "karma-phantomjs-launcher": "1.0.2",
     "karma-sinon": "1.0.5",
     "mocha": "3.2.0",
+    "openlayers": "3.20.1",
     "phantomjs-prebuilt": "2.1.14",
     "sinon": "1.17.7"
   }

--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>GeoExt 3 Spec Runner</title>
   <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css">
-  <link rel="stylesheet" type="text/css" href="http://openlayers.org/en/v3.20.1/css/ol.css">
+  <link rel="stylesheet" type="text/css" href="../node_modules/openlayers/dist/ol.css">
   <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -14,7 +14,7 @@
   <script src="../node_modules/sinon/pkg/sinon.js"></script>
   <script src="../node_modules/mocha/mocha.js"></script>
 
-  <script src="http://openlayers.org/en/v3.20.1/build/ol.js"></script>
+  <script src="../node_modules/openlayers/dist/ol.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
   <script>
     // set Ext loader path


### PR DESCRIPTION
This PR suggests to change the following about how we include OpenLayers.

* for examples
  * use the published OpenLayers ressources from `openlayers.org`, via `https`
  * Also use the supported version, not `master`
  * This way we do not need to change the deployment process for the `gh-pages`, we could later do that of course
* for development: require the `openlayers`-package (which adds some overhead), and use local versions when testing.
