### PR TITLE
Set OL version to 3.20.1 in universal-app tutorial

### DIFF
--- a/universal-app.md
+++ b/universal-app.md
@@ -250,7 +250,7 @@ The application needs the OpenLayers library to work. Add this dependency to the
 
 ```
   "js": [{
-      "path": "https://openlayers.org/en/master/build/ol.js",
+      "path": "https://openlayers.org/en/v3.20.1/build/ol.js",
       "remote": true
     }, {
       "path": "app.js",
@@ -262,7 +262,7 @@ and css file
 
 ```
     "css": [
-        {"path": "https://openlayers.org/en/master/css/ol.css" , "remote": true},
+        {"path": "https://openlayers.org/en/v3.20.1/css/ol.css" , "remote": true},
         {
             // this entry uses an ant variable that is the calculated
             // value of the generated output css file for the app,
@@ -274,7 +274,7 @@ and css file
     ],
 ```
 
-This includes all OpenLayers 3 functionality. After this exercise, you can consider [creating a custom build](https://openlayers.org/en/v3.9.0/doc/tutorials/custom-builds.html) to create a smaller OL3 library, adjusted to only what you need.
+This includes all OpenLayers 3 functionality. After this exercise, you can consider [creating a custom build](https://openlayers.org/en/v3.20.1/doc/tutorials/custom-builds.html) to create a smaller OL3 library, adjusted to only what you need.
 
 ### Build and test the app
 


### PR DESCRIPTION
This corrects the OpenLayers version to v3.20.1 (the currently supported version) in the Universal App tutorial (related to #245).