### PR TITLE
Correct extent in overviewmaps for rotated views

### DIFF
--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -84,7 +84,6 @@ Ext.define('GeoExt.component.OverviewMap', {
         'ol.geom.Point#getCoordinates',
         'ol.geom.Point#setCoordinates',
         'ol.geom.Polygon',
-        'ol.geom.Polygon.fromExtent',
         'ol.geom.Polygon#getCoordinates',
         'ol.geom.Polygon#setCoordinates',
         'ol.interaction.Translate',
@@ -113,6 +112,46 @@ Ext.define('GeoExt.component.OverviewMap', {
         'ol.View#un'
     ],
     // </debug>
+
+    statics: {
+
+        /**
+         * Returns an object with geometries representing the extent of the
+         * passed map and the top left point.
+         *
+         * @param {ol.Map} map The map to the extent and top left corner
+         *     geometries from.
+         * @return {Object} An object with keys `extent` and `topLeft`.
+         */
+        getVisibleExtentGeometries: function(map) {
+            var mapSize = map && map.getSize();
+            var w = mapSize && mapSize[0];
+            var h = mapSize && mapSize[1];
+            if (!mapSize || isNaN(w) || isNaN(h)) {
+                return;
+            }
+            var pixels = [
+                [0, 0], [w, 0], [w, h], [0, h], [0, 0]
+            ];
+            var extentCoords = [];
+            Ext.each(pixels, function(pixel) {
+                var coord = map.getCoordinateFromPixel(pixel);
+                if (coord === null) {
+                    return false;
+                }
+                extentCoords.push(coord);
+            });
+            if (extentCoords.length !== 5) {
+                return;
+            }
+            var geom = new ol.geom.Polygon([extentCoords]);
+            var anchor = new ol.geom.Point(extentCoords[0]);
+            return {
+                extent: geom,
+                topLeft: anchor
+            };
+        }
+    },
 
     config: {
         /**
@@ -194,70 +233,6 @@ Ext.define('GeoExt.component.OverviewMap', {
          */
         recenterDuration: 500
     },
-
-    statics: {
-        /**
-         * Rotates a coordinate around another center coordinate and returns the
-         * new coordinate.
-         *
-         * @param {Number[]} coord The coordinate to rotate as array with
-         *     `[x, y]`.
-         * @param {Number[]} center The coordinate to rotate around as array
-         *     with `[x, y]`.
-         * @param {Number} rotation The rotation in radians.
-         * @return {Number[]} The rotate coordinate as array with `[x, y]`.
-         */
-        rotateCoordAroundCoord: function(coord, center, rotation) {
-            var cosTheta = Math.cos(rotation);
-            var sinTheta = Math.sin(rotation);
-
-            var x = (cosTheta * (coord[0] - center[0]) - sinTheta *
-                    (coord[1] - center[1]) + center[0]);
-            var y = (sinTheta * (coord[0] - center[0]) + cosTheta *
-                    (coord[1] - center[1]) + center[1]);
-
-            return [x, y];
-        },
-
-        /**
-         * Rotates a geometry around a center coordinate and returns the
-         * new geometry. Only reliably works with instances of `ol.geom.Point`
-         * or `ol.geom.Polygon`, the latter loosing any inner rings (holes) it
-         * may have.
-         *
-         * @param {ol.geom.Point|ol.geom.Polygon} geom The geometry to rotate.
-         * @param {Number[]} centerCoord The coordinate to rotate around as
-         *     array with `[x, y]`.
-         * @param {Number} rotation The rotation in radians.
-         * @return {Number[]} The rotate coordinate as array with `[x, y]`.
-         */
-        rotateGeomAroundCoord: function(geom, centerCoord, rotation) {
-            var me = this;
-            var ar = [];
-            var coords;
-
-            if (geom instanceof ol.geom.Point) {
-                ar.push(
-                    me.rotateCoordAroundCoord(
-                        geom.getCoordinates(), centerCoord, rotation
-                    )
-                );
-                geom.setCoordinates(ar[0]);
-            } else if (geom instanceof ol.geom.Polygon) {
-                coords = geom.getCoordinates()[0];
-                coords.forEach(function(coord) {
-                    ar.push(
-                        me.rotateCoordAroundCoord(
-                            coord, centerCoord, rotation
-                        )
-                    );
-                });
-                geom.setCoordinates([ar]);
-            }
-            return geom;
-        }
-    },
-
     /**
      * The `ol.Feature` that represents the extent of the parent map.
      *
@@ -470,7 +445,7 @@ Ext.define('GeoExt.component.OverviewMap', {
     repositionAnchorFeature: function() {
         var me = this;
         var boxCoords = me.boxFeature.getGeometry().getCoordinates();
-        var topLeftCoord = boxCoords[0][1];
+        var topLeftCoord = boxCoords[0][0];
         var newAnchorGeom = new ol.geom.Point(topLeftCoord);
         me.anchorFeature.setGeometry(newAnchorGeom);
     },
@@ -558,25 +533,16 @@ Ext.define('GeoExt.component.OverviewMap', {
      */
     updateBox: function() {
         var me = this;
-        var parentMapView = me.getParentMap().getView();
-        var parentMapProjection = parentMapView.getProjection();
-        var parentExtent = parentMapView.calculateExtent(
-            me.getParentMap().getSize()
-        );
-        var parentRotation = parentMapView.getRotation();
-        var parentCenter = parentMapView.getCenter();
-        var geom = ol.geom.Polygon.fromExtent(parentExtent);
-        var overviewView = me.getMap().getView();
-        var overviewProjection = overviewView.getProjection();
+        var parentMap = me.getParentMap();
+        var extentGeometries = me.self.getVisibleExtentGeometries(parentMap);
+        if (!extentGeometries) {
+            return;
+        }
+        var geom = extentGeometries.extent;
+        var anchor = extentGeometries.topLeft;
 
-        geom = me.self.rotateGeomAroundCoord(
-            geom, parentCenter, parentRotation
-        );
-
-        var anchor = new ol.geom.Point(ol.extent.getTopLeft(parentExtent));
-        anchor = me.self.rotateGeomAroundCoord(
-            anchor, parentCenter, parentRotation
-        );
+        var parentMapProjection = parentMap.getView().getProjection();
+        var overviewProjection = me.getMap().getView().getProjection();
 
         // transform if necessary
         if (!ol.proj.equivalent(parentMapProjection, overviewProjection)) {

--- a/test/spec/GeoExt/component/OverviewMap.test.js
+++ b/test/spec/GeoExt/component/OverviewMap.test.js
@@ -2,21 +2,47 @@ Ext.Loader.syncRequire(['GeoExt.component.OverviewMap']);
 
 describe('GeoExt.component.OverviewMap', function() {
 
+    var giveDimensions = function(elem, cssOpts) {
+        if (elem) {
+            var css = Ext.apply({
+                position: 'absolute',
+                top: 0,
+                left: '-1000px',
+                width: '256px',
+                height: '128px'
+            }, cssOpts || {});
+            Ext.iterate(css, function(cssKey, cssValue) {
+                elem.style[cssKey] = cssValue;
+            });
+        }
+    };
+
     var div;
     var ovDiv;
+    var olMap;
 
     beforeEach(function() {
         div = document.createElement('div');
+        giveDimensions(div);
         document.body.appendChild(div);
         ovDiv = document.createElement('div');
+        giveDimensions(ovDiv);
         document.body.appendChild(ovDiv);
+        olMap = new ol.Map({
+            view: new ol.View({
+                center: [0, 0],
+                zoom: 2
+            }),
+            target: div
+        });
     });
 
     afterEach(function() {
-        document.body.removeChild(div);
-        div = null;
+        olMap.setTarget(null);
         document.body.removeChild(ovDiv);
         ovDiv = null;
+        document.body.removeChild(div);
+        div = null;
     });
 
     describe('basics', function() {
@@ -42,14 +68,6 @@ describe('GeoExt.component.OverviewMap', function() {
             );
 
             it('can be constructed with a parentMap', function() {
-                var olMap = new ol.Map({
-                    view: new ol.View({
-                        center: [0, 0],
-                        zoom: 2
-                    }),
-                    target: div
-                });
-
                 var overviewMap = Ext.create('GeoExt.component.OverviewMap', {
                     parentMap: olMap
                 });
@@ -64,14 +82,8 @@ describe('GeoExt.component.OverviewMap', function() {
                 var layer1 = new ol.layer.Tile({title: 'moehri'});
                 var layer2 = new ol.layer.Tile({title: 'zwiebli'});
 
-                var olMap = new ol.Map({
-                    view: new ol.View({
-                        center: [0, 0],
-                        zoom: 2
-                    }),
-                    layers: [layer1, layer2],
-                    target: div
-                });
+                olMap.addLayer(layer1);
+                olMap.addLayer(layer2);
 
                 var overviewMap = Ext.create('GeoExt.component.OverviewMap', {
                     parentMap: olMap
@@ -90,14 +102,7 @@ describe('GeoExt.component.OverviewMap', function() {
             var layer1 = new ol.layer.Tile({title: 'moehri'});
             var layer2 = new ol.layer.Tile({title: 'zwiebli'});
 
-            var olMap = new ol.Map({
-                view: new ol.View({
-                    center: [0, 0],
-                    zoom: 2
-                }),
-                layers: [layer1],
-                target: div
-            });
+            olMap.addLayer(layer1);
 
             var overviewMap = Ext.create('GeoExt.component.OverviewMap', {
                 parentMap: olMap,
@@ -109,14 +114,6 @@ describe('GeoExt.component.OverviewMap', function() {
             expect(ovLayers[0]).to.be(layer2);
         });
         it('does not throw if no layers can be found', function() {
-            var olMap = new ol.Map({
-                view: new ol.View({
-                    center: [0, 0],
-                    zoom: 2
-                }),
-                target: div
-            });
-
             var overviewMap;
             expect(function() {
                 overviewMap = Ext.create('GeoExt.component.OverviewMap', {
@@ -130,18 +127,10 @@ describe('GeoExt.component.OverviewMap', function() {
     });
 
     describe('view properties in sync', function() {
-        var olMap;
         var overviewMap;
 
         beforeEach(function() {
-            olMap = new ol.Map({
-                view: new ol.View({
-                    center: [0, 0],
-                    zoom: 2
-                }),
-                layers: [new ol.layer.Tile({title: 'moehri'})],
-                target: div
-            });
+            olMap.addLayer(new ol.layer.Tile({title: 'moehri'}));
             overviewMap = Ext.create('GeoExt.component.OverviewMap', {
                 parentMap: olMap
             });
@@ -149,7 +138,6 @@ describe('GeoExt.component.OverviewMap', function() {
 
         afterEach(function() {
             overviewMap.destroy();
-            olMap = null;
             overviewMap = null;
         });
 
@@ -189,18 +177,10 @@ describe('GeoExt.component.OverviewMap', function() {
     });
 
     describe('extent layer features can be styled', function() {
-        var olMap;
         var overviewMap;
 
         beforeEach(function() {
-            olMap = new ol.Map({
-                view: new ol.View({
-                    center: [0, 0],
-                    zoom: 2
-                }),
-                layers: [new ol.layer.Tile({title: 'moehri'})],
-                target: div
-            });
+            olMap.addLayer(new ol.layer.Tile({title: 'moehri'}));
             overviewMap = Ext.create('GeoExt.component.OverviewMap', {
                 parentMap: olMap
             });
@@ -208,7 +188,6 @@ describe('GeoExt.component.OverviewMap', function() {
 
         afterEach(function() {
             overviewMap.destroy();
-            olMap = null;
             overviewMap = null;
         });
 
@@ -256,18 +235,10 @@ describe('GeoExt.component.OverviewMap', function() {
     });
 
     describe('dragging of extent box to recenter', function() {
-        var olMap;
         var overviewMap;
 
         beforeEach(function() {
-            olMap = new ol.Map({
-                view: new ol.View({
-                    center: [0, 0],
-                    zoom: 2
-                }),
-                layers: [new ol.layer.Tile({title: 'moehri'})],
-                target: div
-            });
+            olMap.addLayer(new ol.layer.Tile({title: 'moehri'}));
             overviewMap = Ext.create('GeoExt.component.OverviewMap', {
                 parentMap: olMap,
                 target: ovDiv
@@ -276,7 +247,6 @@ describe('GeoExt.component.OverviewMap', function() {
 
         afterEach(function() {
             overviewMap.destroy();
-            olMap = null;
             overviewMap = null;
         });
 
@@ -358,7 +328,7 @@ describe('GeoExt.component.OverviewMap', function() {
 
                 var anchorGeom = overviewMap.anchorFeature.getGeometry();
                 var anchorCoords = anchorGeom.getCoordinates();
-                expect(anchorCoords).to.eql([0, 2]);
+                expect(anchorCoords).to.eql([0, 0]);
             });
         });
 
@@ -399,147 +369,87 @@ describe('GeoExt.component.OverviewMap', function() {
 
                 var parentCenter = olMap.getView().getCenter();
                 var expectedCenter = [4.491576420597607, 4.486983030705062];
-                expect(parentCenter).to.eql(expectedCenter);
+                expect(
+                    parentCenter[0].toFixed(12)
+                ).to.eql(
+                    expectedCenter[0].toFixed(12)
+                );
+                expect(
+                    parentCenter[1].toFixed(12)
+                ).to.eql(
+                    expectedCenter[1].toFixed(12)
+                );
             });
         });
     });
 
     describe('static functions', function() {
-
-        describe('#rotateCoordAroundCoord', function() {
-            var center;
-            var coords;
-            var expected;
-            var center2;
-            var coords2;
-            var expected2;
-            var rotation;
-
-            beforeEach(function() {
-                center = [0, 0];
-                coords = [-15615167.634322086, 10997148.133444877];
-                expected = [-17331393.46990493, -8024557.788953042];
-                center2 = [-1104754.8263107014, 2093211.9255832366];
-                coords2 = [-16719922.460632788, 13090360.059028113];
-                expected2 = [-18436148.29621563, -5931345.863369805];
-                rotation = Math.PI / 3;
+        var clazz = GeoExt.component.OverviewMap;
+        describe('#getVisibleExtentGeometries', function() {
+            it('is a defined function', function() {
+                expect(clazz.getVisibleExtentGeometries).to.be.a('function');
             });
-
-            it('gives the same result as ol.coordinate.rotate center == [0, 0]',
-                function() {
-                    var cls = GeoExt.component.OverviewMap;
-                    var got = cls.rotateCoordAroundCoord(
-                        coords, center, rotation
-                    );
-                    expect(got).to.eql(expected);
-                    var gotOl = ol.coordinate.rotate(coords, rotation);
-                    expect(gotOl).to.eql(got);
-                }
-            );
-
-            it('gives the correct result for center != [0, 0]',
-                function() {
-                    var cls = GeoExt.component.OverviewMap;
-                    var got = cls.rotateCoordAroundCoord(
-                        coords2, center2, rotation
-                    );
-                    expect(got).to.eql(expected2);
-                }
-            );
-        });
-
-        describe('#rotateGeomAroundCoord', function() {
-
-            var point;
-            var point2;
-            var line;
-            var line2;
-            var polygon;
-            var polygon2;
-
-            var center;
-            var rotation;
-
-            beforeEach(function() {
-                point = new ol.geom.Point([0.8, 15]);
-                point2 = point.clone();
-                line = new ol.geom.LineString([[0, 0], [69, 69]]);
-                line2 = line.clone();
-                polygon = new ol.geom.Polygon([[
-                    [0, 0], [0, 10], [10, 10], [10, 0], [0, 0]
-                ]]);
-                polygon2 = polygon.clone();
-
-                center = [-7, 8];
-                rotation = Math.PI / 6;
+            it('returns undefined if not passed a map', function() {
+                var got = clazz.getVisibleExtentGeometries();
+                expect(got).to.be(undefined);
             });
-
-            it('only rotates points and polygons, others returned unchanged',
-                function() {
-                    var cls = GeoExt.component.OverviewMap;
-                    var rotatedPoint = cls.rotateGeomAroundCoord(
-                        point, center, rotation
-                    );
-                    expect(rotatedPoint.getCoordinates()).to.not.eql(
-                        point2.getCoordinates()
-                    );
-
-                    var rotatedLine = cls.rotateGeomAroundCoord(
-                        line, center, rotation
-                    );
-                    expect(rotatedLine.getCoordinates()).to.eql(
-                        line2.getCoordinates()
-                    );
-
-                    var rotatedPolygon = cls.rotateGeomAroundCoord(
-                        polygon, center, rotation
-                    );
-                    expect(rotatedPolygon.getCoordinates()).to.not.eql(
-                        polygon2.getCoordinates()
-                    );
-
-                }
-            );
-
-            it('changes the given points and polygons in place', function() {
-                GeoExt.component.OverviewMap.rotateGeomAroundCoord(
-                    point, center, rotation
-                );
-                expect(point.getCoordinates()).to.not.eql(
-                    point2.getCoordinates()
-                );
-
-                GeoExt.component.OverviewMap.rotateGeomAroundCoord(
-                    polygon, center, rotation
-                );
-                expect(polygon.getCoordinates()).to.not.eql(
-                    polygon2.getCoordinates()
-                );
+            it('returns undefined if map has no size (unrendered)', function() {
+                var got = clazz.getVisibleExtentGeometries(olMap);
+                expect(got).to.be(undefined);
             });
-
-            it('rotates points correctly', function() {
-                var expectedPoint = [-3.7450018504813776, 17.96217782649107];
-                GeoExt.component.OverviewMap.rotateGeomAroundCoord(
-                    point, center, rotation
-                );
-                expect(point.getCoordinates()).to.eql(expectedPoint);
+            it('returns an object if map has size (rendered)', function() {
+                olMap.renderSync();
+                var got = clazz.getVisibleExtentGeometries(olMap);
+                expect(got).to.not.be(undefined);
             });
+            it('returns an object with keys "extent" & "topLeft"', function() {
+                olMap.renderSync();
+                var got = clazz.getVisibleExtentGeometries(olMap);
+                expect(got.extent).to.not.be(undefined);
+                expect(got.topLeft).to.not.be(undefined);
+            });
+            it('returns an extent as polygon', function() {
+                olMap.renderSync();
+                var got = clazz.getVisibleExtentGeometries(olMap);
+                expect(got.extent).to.be.a(ol.geom.Polygon);
+            });
+            it('returns a topLeft as point', function() {
+                olMap.renderSync();
+                var got = clazz.getVisibleExtentGeometries(olMap);
+                expect(got.topLeft).to.be.a(ol.geom.Point);
+            });
+            it('returns a correctly rotated polygon', function() {
+                olMap.renderSync();
+                var angle = Math.PI / 4;
+                var before = clazz.getVisibleExtentGeometries(olMap).extent;
+                var center = ol.extent.getCenter(before.getExtent());
+                var manually = before.clone();
+                manually.rotate(angle, center);
+                var manuallyCoords = manually.getCoordinates()[0];
 
-            it('rotates polygons correctly', function() {
-                var expectedPoly = [
-                    [
-                        [3.0621778264910713, 4.5717967697244895],
-                        [-1.9378221735089287, 13.232050807568877],
-                        [6.722431864335459, 18.232050807568875],
-                        [11.722431864335459, 9.57179676972449],
-                        [3.0621778264910713, 4.5717967697244895]
-                    ]
-                ];
+                // now rotate the parent map
+                olMap.getView().setRotation(angle);
+                olMap.renderSync();
+                var afterViewRotated = clazz.getVisibleExtentGeometries(olMap);
+                var autoRotated = afterViewRotated.extent;
+                var autoRotatedCoords = autoRotated.getCoordinates()[0];
 
-                GeoExt.component.OverviewMap.rotateGeomAroundCoord(
-                    polygon, center, rotation
-                );
-                expect(polygon.getCoordinates()).to.eql(expectedPoly);
+                var precision = 8;
+                Ext.each(autoRotatedCoords, function(autoRotatedCoord, i) {
+                    var manualCoord = manuallyCoords[i];
+                    // x-coordinate
+                    expect(
+                        autoRotatedCoord[0].toFixed(precision)
+                    ).to.be(
+                        manualCoord[0].toFixed(precision)
+                    );
+                    // y-coordinate
+                    expect(
+                        autoRotatedCoord[1].toFixed(precision)
+                    ).to.be(
+                        manualCoord[1].toFixed(precision)
+                    );
+                });
             });
         });
     });


### PR DESCRIPTION
This PR suggests to change how we reflect rotation in Overview maps. Before this PR we would take the extent of the parent map, rotate that with the rotation of the parent map, and then create a new polygon, which we would render in the overview map. This very easily leads to images like the following, where the polygon in the overview map is way to big, and doesn't really reflect the visiblke extent of the parent map:

![before](https://cloud.githubusercontent.com/assets/227934/23183040/e9f1de94-f87a-11e6-96bd-7de098102ba7.png)

The approach taken in thi PR doesn't rotate at all. Instead it takes the size of the map, and queries the parent map for coordinates at the corners. This way we get the real coordinates of a rectangle we currently see. The visual outcome is what one would expect:

![after](https://cloud.githubusercontent.com/assets/227934/23183050/f3146eec-f87a-11e6-85aa-d37458fb35e4.png)

In total this PR removes code and simplifies it quite a bit, I think.

Please review.

Fixes #252