### PR TITLE
Use more local resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ sass/example/bootstrap.json
 sass/example/bootstrap.jsonp
 docs/
 coverage/
+resources/external/
 src_instrumented/

--- a/bin/external-resources.json
+++ b/bin/external-resources.json
@@ -1,0 +1,10 @@
+{
+    "urls": [
+        "https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all_1.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all_2.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all-debug_1.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all-debug_2.css",
+        "https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all-debug.js"
+    ]
+}

--- a/bin/fetch-external-resources.js
+++ b/bin/fetch-external-resources.js
@@ -1,0 +1,45 @@
+/* eslint-env node */
+var fs = require('fs');
+var path = require('path');
+var mkdirpSync = require('mkdirp').sync;
+var log = require('console').log;
+
+var util = require('./util.js');
+var download = util.download;
+var filenameFromUrl = util.filenameFromUrl;
+
+var targetDir = path.normalize(
+    path.join(
+        path.basename(__dirname), '..', 'resources', 'external'
+    )
+);
+mkdirpSync(targetDir);
+
+var downloadFiles = require('./external-resources.json').urls;
+var numFiles = downloadFiles.length;
+var pluralS = numFiles !== 1 ? 's' : '';
+
+log('Downloading ' + numFiles + ' file' + pluralS + ' if needed\n');
+
+var allDoneCb = function() {
+    log('Done\n');
+};
+var logProgress = util.logProgress(numFiles, 'Downloading…');
+logProgress.start();
+
+downloadFiles.forEach(function(url) {
+    var rawFilename = filenameFromUrl(url);
+    var targetFileName = path.join(targetDir, rawFilename);
+    if (fs.existsSync(targetFileName)) {
+        logProgress.oneDoneCheckIfAllDone(rawFilename, true, allDoneCb);
+        return;
+    }
+
+    download(url, targetFileName, function(err) {
+        if (err) {
+            logProgress.oneDoneCheckIfAllDone(rawFilename, false, allDoneCb);
+            return;
+        }
+        logProgress.oneDoneCheckIfAllDone(rawFilename, true, allDoneCb);
+    });
+});

--- a/bin/util.js
+++ b/bin/util.js
@@ -1,0 +1,101 @@
+/* eslint-env node */
+var fs = require('fs');
+var http = require('http');
+var https = require('https');
+var path = require('path');
+var url = require('url');
+var logUpdate = require('log-update');
+
+/**
+ * The frames for the progressbar.
+ * @type {Array}
+ */
+var progressFrames = [
+    '=       ', '=>      ', ' =>     ', '  =>    ', '   =>   ', '    =>  ',
+    '     => ', '      =>', '       =', '      <=', '     <= ', '    <=  ',
+    '   <=   ', '  <=    ', ' <=     ', '<=      '
+];
+
+/**
+ * Returns an object with methods to start the progressbar, and another one to
+ * signal that one progress step (of a total of `totalSteps`) completed, so we
+ * should check if we are done in total.
+ *
+ * @param {Number} totalSteps The number of total expected steps. Call the
+ *     method `oneDoneCheckIfAllDone` this often, to stop the progress, i.e.
+ *     simply call it for every step.
+ * @param {String} runningMsg The message to display behind the spinner, while
+ *     the steps hav not completed.
+ * @return {[type]} An object with methods to start (`start`) the progressbar,
+ *     and to signal that one step was completed (``).
+ */
+var logProgress = function(totalSteps, runningMsg) {
+    var finishedSteps = 0;
+    var frameIdx = 0;
+    var progressInterval;
+    return {
+        start: function() {
+            if (totalSteps <= 0) {
+                return;
+            }
+            progressInterval = setInterval(function() {
+                var frame = progressFrames[frameIdx++ % progressFrames.length];
+                logUpdate('  ' + frame + ' ' + runningMsg);
+            }, 100);
+        },
+        oneDoneCheckIfAllDone: function(stepDescription, ok, allDoneCb) {
+            finishedSteps++;
+            logUpdate((ok ? '  ✔ ' : '  ✖ ') + stepDescription);
+            logUpdate.done();
+            if (finishedSteps >= totalSteps) {
+                clearInterval(progressInterval);
+                allDoneCb();
+            }
+        }
+    };
+};
+
+/**
+ * Downloads the `urlStr` to `dest` and then invokes `cb`. Based on this answer
+ * on Stack Overflow: http://stackoverflow.com/a/22907134
+ *
+ * @param {String} urlStr The URL to download, supports `https:` and `http:`
+ *     protocol.
+ * @param {String} dest The target filename.
+ * @param {Function} cb A callback to invoke after the donload is done, or when
+ *     an error occured (in that case an error is passed).
+ */
+var download = function(urlStr, dest, cb) {
+    var file = fs.createWriteStream(dest);
+    var urlObj = url.parse(urlStr);
+    var nodeModule = urlObj.protocol === 'https:' ? https : http;
+    nodeModule.get(urlStr, function(response) {
+        response.pipe(file);
+        file.on('finish', function() {
+            file.close(cb);  // close() is async, call cb after close completes.
+        });
+    }).on('error', function(err) { // Handle errors
+        // Delete the file async.(But we don't check the result)
+        fs.unlink(dest);
+        if (cb) {
+            cb(err.message);
+        }
+    });
+};
+
+/**
+ * Extracts a filename from an URL. Source http://stackoverflow.com/a/27006391.
+ *
+ * @param {String} URL The URL.
+ * @return {String} The filename.
+ */
+var filenameFromUrl = function(URL) {
+    var parsed = url.parse(URL);
+    return path.basename(parsed.pathname);
+};
+
+module.exports = {
+    logProgress: logProgress,
+    download: download,
+    filenameFromUrl: filenameFromUrl
+};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "clean": "rm -rf coverage apidoc",
+    "postinstall": "node ./bin/fetch-external-resources.js",
     "lint": "eslint src/ examples/ && eslint -c test/.eslintrc test/",
     "lint:fix": "eslint --fix src/ examples/ && eslint --fix -c test/.eslintrc test/",
     "pretest": "npm run-script lint",
@@ -55,6 +56,8 @@
     "karma-mocha": "1.3.0",
     "karma-phantomjs-launcher": "1.0.2",
     "karma-sinon": "1.0.5",
+    "log-update": "1.0.2",
+    "mkdirp": "0.5.1",
     "mocha": "3.2.0",
     "openlayers": "3.20.1",
     "phantomjs-prebuilt": "2.1.14",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,16 +5,13 @@ module.exports = function(config) {
     var suffix = (config.debug ? '-debug' : '');
 
     config.set({
-
         // base path that will be used to resolve all patterns (eg. files,
         // exclude)
         basePath: '../',
 
-
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
         frameworks: ['mocha', 'expect', 'sinon'],
-
 
         // list of files / patterns to load in the browser
         files: [
@@ -24,17 +21,13 @@ module.exports = function(config) {
                 included: false
             },
             // CSS files
-            'https://openlayers.org/en/v3.20.1/css/ol.css',
-            'https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/'
-                + 'theme-crisp/resources/theme-crisp-all' + suffix + '.css',
-            // requestAnimationFrame shim
-            'https://cdn.rawgit.com/paulirish/1579671/raw/'
-                + '682e5c880c92b445650c4880a6bf9f3897ec1c5b/rAF.js',
+            'node_modules/openlayers/dist/ol' + suffix + '.css',
+            'resources/external/theme-crisp-all' + suffix + '_1.css',
+            'resources/external/theme-crisp-all' + suffix + '_2.css',
             // OpenLayers 3
-            'https://openlayers.org/en/v3.20.1/build/ol' + suffix + '.js',
+            'node_modules/openlayers/dist/ol' + suffix + '.js',
             // ExtJS 6
-            'https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all'
-                + suffix + '.js',
+            'resources/external/ext-all' + suffix + '.js',
             // Ext.Loader configuration
             'test/loader.js',
             // GeoExt source files
@@ -46,11 +39,9 @@ module.exports = function(config) {
             'test/spec/GeoExt/**/*.test.js'
         ],
 
-
         // list of files to exclude
         exclude: [
         ],
-
 
         // preprocess matching files before serving them to the browser
         // available preprocessors:
@@ -59,12 +50,10 @@ module.exports = function(config) {
             'src/**/*.js': ['coverage']
         },
 
-
         // test results reporter to use
         // possible values: 'dots', 'progress'
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter
         reporters: ['dots', 'coverage'],
-
 
         // extra config for coverage reporter
         coverageReporter: {
@@ -75,31 +64,28 @@ module.exports = function(config) {
             ]
         },
 
-
         // web server port
         port: 9876,
 
-
         // enable / disable colors in the output (reporters and logs)
         colors: true,
-
 
         // level of logging
         // possible values: config.LOG_DISABLE || config.LOG_ERROR ||
         // config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
         logLevel: config.LOG_INFO,
 
-
         // enable / disable watching file and executing tests whenever any
         // file changes
         autoWatch: true,
 
-
-        // start these browsers
         // available browser launchers:
         // https://npmjs.org/browse/keyword/karma-launcher
         browsers: ['PhantomJS'],
 
+        phantomjsLauncher: {
+            flags: ['--load-images=false']
+        },
 
         // Continuous Integration mode
         // if true, Karma captures browsers, runs the tests and exits


### PR DESCRIPTION
This PR suggests to add a `postinstall`script, which will download the ExtJS requirements (CSS and JS in standard and debug variants) and store them in a local (but ignored by `git`) folder.

The karma runner uses these files and I can see quite a speed-up in the execution of the testsuite.

Please review. 