### PR TITLE
Add a test utility and improve test coverage

### DIFF
--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -349,11 +349,13 @@ Ext.define('GeoExt.component.Map', {
      * over- and out-listeners.
      */
     unregisterPointerRestEvents: function() {
-        var map = this.getMap();
-        this.unbindOverOutListeners();
+        var me = this;
+        var map = me.getMap();
+        me.unbindOverOutListeners();
         if (map) {
-            map.un('pointermove', this.bufferedPointerMove);
+            map.un('pointermove', me.bufferedPointerMove);
         }
+        me.bufferedPointerMove = Ext.emptyFn;
     },
 
     /**
@@ -361,13 +363,34 @@ Ext.define('GeoExt.component.Map', {
      * care of registering or unregistering internal event listeners.
      *
      * @param {Boolean} val The new value that someone set for `pointerRest`.
-     * @return {Boolean} The passed new value for  `pointerRest` unchanged.
+     * @return {Boolean} The passed new value for `pointerRest` unchanged.
      */
     applyPointerRest: function(val) {
         if (val) {
             this.registerPointerRestEvents();
         } else {
             this.unregisterPointerRestEvents();
+        }
+        return val;
+    },
+
+    /**
+     * Whenever the value of #pointerRestInterval is changed, this method will
+     * take to reinitialize the #bufferedPointerMove method and handlers to
+     * actually trigger the event.
+     *
+     * @param {Boolean} val The new value that someone set for
+     *     `pointerRestInterval`.
+     * @return {Boolean} The passed new value for `pointerRestInterval`
+     *     unchanged.
+     */
+    applyPointerRestInterval: function(val) {
+        var me = this;
+        var isEnabled = me.getPointerRest();
+        if (isEnabled) {
+            // Toggle to rebuild the buffered pointer move.
+            me.setPointerRest(false);
+            me.setPointerRest(isEnabled);
         }
         return val;
     },
@@ -448,7 +471,7 @@ Ext.define('GeoExt.component.Map', {
     },
 
     /**
-     * Returns the GeoExt.data.store.Layers.
+     * Returns the `GeoExt.data.store.Layers`.
      *
      * @return {GeoExt.data.store.Layers} The layer store.
      */

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -9,6 +9,7 @@
     "module": false,
     "expect": false,
     "it": false,
-    "sinon": false
+    "sinon": false,
+    "TestUtil": true
   }
 }

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -1,0 +1,145 @@
+(function(global) {
+    /**
+     * Ensures that the `BasiGX.view.component.Map` is available for
+     * instantiation by calling `Ext.Loader.syncRequire` if needed.
+     *
+     * @private
+     */
+    function ensureMapComponentAvailable() {
+        if (!GeoExt || !GeoExt.component || !GeoExt.component.Map) {
+            Ext.Loader.syncRequire(['GeoExt.component.Map']);
+        }
+    }
+
+    /**
+     * A utility function that creates and adds a `<div>` to the `<body>` of the
+     * document. The div is positioned absolutely off the screen and configured
+     * with fixed dimensions to never be visible to the user (e.g. when the
+     * test suite is viewed in a browser).
+     *
+     * Use this method in `beforeEach` if you need a `<div>` (e.g. to render
+     * ExtJS components with their `renderTo` configuration).
+     *
+     * The created `<div>` is returned, so that it can easily be used in
+     * `afterEach`-calls to cleanup. Most of the time you'll be using the helper
+     * function #teardownTestDiv in such a case.
+     *
+     * @return {HTMLDivElement} The created `<div>`.
+     */
+    function setupTestDiv() {
+        var div = document.createElement('div');
+        div.style.position = 'absolute';
+        div.style.top = 0;
+        div.style.left = -500;
+        div.style.width = 256;
+        div.style.height = 128;
+        document.body.appendChild(div);
+        return div;
+    }
+
+    /**
+     * A utility function that removes the passed `div` from the document and
+     * nullifies it.
+     *
+     * Use this method (e.g. in `afterEach`-calls) to cleanup any divs that you
+     * have setup earlier (often by calling #setupTestDiv).
+     *
+     * @param {HTMLDivElement} div The `<div>` you want to remove.
+     */
+    function teardownTestDiv(div) {
+        if (!div) {
+            return;
+        }
+        var parent = div.parentNode;
+        if (parent) {
+            parent.removeChild(div);
+        }
+        div = null;
+    }
+
+    /**
+     * A utility function to create several objects that our tests need every
+     * now and then. Will return an object that provides the created components
+     * and HTML elements.
+     *
+     * Use this method (e.g. in `beforeEach` calls) to have easy access to an
+     * `ol.Map` and a `GeoExt.component.Map`. In order to teardown all
+     * created objects, use #teardownTestObjects.
+     *
+     * The created objects can be configured by passing in an `opts` object,
+     * where the key `mapOpts` is an object with configs for the `ol.Map`, and
+     * the key `mapComponentOpts` is an object with configs for the
+     * `GeoExt.component.Map`.
+     *
+     * @param {Object} opts The options for the objects to create. Optional.
+     * @param {Object} opts.mapOpts The options for the `ol.Map` constructor.
+     *     Optional.
+     * @param {Object} opts.mapComponentOpts The options for the map component
+     *     constructor. Optional.
+     * @return {Object} An object with the following keys: `map`, `mapDiv`,
+     *     `mapComponent` and `mapComponentDiv`. `map` will hold the `ol.Map`
+     *     instance, `mapDiv` will hold the `<div>` of the `map`, `mapComponent`
+     *     will hold the `GeoExt.component.Map` that is configured with the
+     *     `map` and `mapComponentDiv` will hold the `<div>` of the created
+     *     `mapComponent`. Usually you'll only interact with the components, not
+     *     with the `<div>`s.
+     */
+    function setupTestObjects(opts) {
+        ensureMapComponentAvailable();
+
+        var options = opts || {};
+        var mapOpts = options.mapOpts || {};
+        var mapComponentOpts = options.mapComponentOpts || {};
+
+        var mapDiv = setupTestDiv();
+        var mapComponentDiv = setupTestDiv();
+
+        var view = new ol.View({
+            center: [0, 0]
+        });
+        var map = new ol.Map(Ext.apply({target: mapDiv, view: view}, mapOpts));
+        var mapComponent = Ext.create('GeoExt.component.Map', Ext.apply({
+            map: map,
+            renderTo: mapComponentDiv
+        }, mapComponentOpts));
+
+        return {
+            map: map,
+            mapComponent: mapComponent,
+            mapDiv: mapDiv,
+            mapComponentDiv: mapComponentDiv
+        };
+    }
+
+    /**
+     * A utility method to clean up test objects when they are no longer needed.
+     * This is the companion method for #setupTestObjects; If you pass in the
+     * object that was created using #setupTestObjects, all created elements
+     * will properly be cleaned up.
+     *
+     * Usually you'll call this method inside of e.g. `afterEach`.
+     *
+     * @param {Object} createdObjs The object holding the objects created by
+     *     the method #setupTestObjects.
+     */
+    function teardownTestObjects(createdObjs) {
+        if (!createdObjs) {
+            return;
+        }
+        if (createdObjs.mapComponent && createdObjs.mapComponent.destroy) {
+            createdObjs.mapComponent.destroy();
+        }
+        if (createdObjs.map && createdObjs.map.setTarget) {
+            createdObjs.map.setTarget(null);
+        }
+        teardownTestDiv(createdObjs.mapComponentDiv);
+        teardownTestDiv(createdObjs.mapDiv);
+    }
+
+    global.TestUtil = {
+        setupTestDiv: setupTestDiv,
+        teardownTestDiv: teardownTestDiv,
+        setupTestObjects: setupTestObjects,
+        teardownTestObjects: teardownTestObjects
+    };
+}(this));

--- a/test/index.html
+++ b/test/index.html
@@ -16,6 +16,7 @@
 
   <script src="../node_modules/openlayers/dist/ol.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
+  <script src="./TestUtil.js"></script>
   <script>
     // set Ext loader path
     Ext.Loader.setConfig({

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -30,6 +30,8 @@ module.exports = function(config) {
             'resources/external/ext-all' + suffix + '.js',
             // Ext.Loader configuration
             'test/loader.js',
+            // Our utility class with some test helpers
+            'test/TestUtil.js',
             // GeoExt source files
             {
                 pattern: 'src/**/*.js',

--- a/test/spec/GeoExt/component/Map.test.js
+++ b/test/spec/GeoExt/component/Map.test.js
@@ -202,5 +202,38 @@ describe('GeoExt.component.Map', function() {
 
         });
 
+        describe('pointerrest configuration', function() {
+            it('is off by default', function() {
+                expect(mapComponent.getPointerRest()).to.be(false);
+            });
+            it('when it is off, there is no buffered handler', function() {
+                expect(mapComponent.bufferedPointerMove).to.be(Ext.emptyFn);
+            });
+            it('can be turned on (config)', function() {
+                var testObjs2 = TestUtil.setupTestObjects({
+                    mapComponentOpts: {
+                        pointerRest: true
+                    }
+                });
+                var mapComponent2 = testObjs2.mapComponent;
+
+                expect(mapComponent2.getPointerRest()).to.be(true);
+                expect(mapComponent2.bufferedPointerMove).to.not.be(
+                    Ext.emptyFn
+                );
+
+                TestUtil.teardownTestObjects(testObjs2);
+            });
+            it('can be turned on (setter)', function() {
+                // sanity check
+                expect(mapComponent.getPointerRest()).to.be(false);
+                mapComponent.setPointerRest(true);
+                expect(mapComponent.getPointerRest()).to.be(true);
+                expect(mapComponent.bufferedPointerMove).to.not.be(
+                    Ext.emptyFn
+                );
+            });
+        });
+
     });
 });

--- a/test/spec/GeoExt/component/Map.test.js
+++ b/test/spec/GeoExt/component/Map.test.js
@@ -16,50 +16,31 @@ describe('GeoExt.component.Map', function() {
     });
 
     describe('public functions', function() {
-        var div;
-        var mapComponent;
-        var mapPanel;
-        var source;
         var layer;
-        var olMap;
+        var map;
+        var mapComponent;
+        var testObjs;
 
         beforeEach(function() {
-            div = document.createElement('div');
-            div.style.position = 'absolute';
-            div.style.top = '0';
-            div.style.left = '-1000px';
-            div.style.width = '512px';
-            div.style.height = '256px';
-            document.body.appendChild(div);
-
-            source = new ol.source.OSM();
             layer = new ol.layer.Tile({
-                source: source
+                source: new ol.source.OSM()
+            });
+            testObjs = TestUtil.setupTestObjects({
+                mapOpts: {
+                    layers: [layer],
+                    view: new ol.View({
+                        center: [0, 0],
+                        zoom: 2
+                    })
+                }
             });
 
-            olMap = new ol.Map({
-                layers: [layer],
-                view: new ol.View({
-                    center: [0, 0],
-                    zoom: 2
-                })
-            });
-
-            mapComponent = Ext.create('GeoExt.component.Map', {
-                map: olMap
-            });
-
-            mapPanel = Ext.create('Ext.panel.Panel', {
-                title: 'GeoExt.component.Map Example',
-                items: [mapComponent],
-                layout: 'fit',
-                renderTo: div
-            });
+            map = testObjs.map;
+            mapComponent = testObjs.mapComponent;
         });
 
         afterEach(function() {
-            mapPanel.destroy();
-            document.body.removeChild(div);
+            TestUtil.teardownTestObjects(testObjs);
         });
         describe('getters and setters', function() {
 
@@ -109,7 +90,7 @@ describe('GeoExt.component.Map', function() {
             it('setCenter() sets the correct center', function() {
                 var center = [1183893.8882437304, 7914041.721258021];
                 mapComponent.setCenter(center);
-                expect(olMap.getView().getCenter()).to.be(center);
+                expect(map.getView().getCenter()).to.be(center);
             });
 
             it('setExtent() sets the correct center', function() {
@@ -124,7 +105,7 @@ describe('GeoExt.component.Map', function() {
                         (extent[3] - (extent[3] - extent[1]) / 2).toFixed(3)
                     ];
                     mapComponent.setExtent(extent);
-                    var olCenter = olMap.getView().getCenter();
+                    var olCenter = map.getView().getCenter();
                     var derivedCenter = [
                         olCenter[0].toFixed(3),
                         olCenter[1].toFixed(3)
@@ -143,7 +124,7 @@ describe('GeoExt.component.Map', function() {
                         zoom: 4
                     });
                     mapComponent.setView(view);
-                    expect(olMap.getView()).to.be(view);
+                    expect(map.getView()).to.be(view);
                 }
             );
         });
@@ -156,7 +137,7 @@ describe('GeoExt.component.Map', function() {
                         source: source2
                     });
                     mapComponent.addLayer(layer2);
-                    expect(olMap.getLayers().getArray()).to.contain(layer2);
+                    expect(map.getLayers().getArray()).to.contain(layer2);
                 }
             );
 
@@ -167,7 +148,7 @@ describe('GeoExt.component.Map', function() {
                         undefined,
                         new ol.source.OSM(),
                         '',
-                        olMap
+                        map
                     ];
 
                     nolayer.forEach(function(oneLayer) {
@@ -180,9 +161,9 @@ describe('GeoExt.component.Map', function() {
             );
 
             it('removeLayer() removes an ol.layer.Base', function() {
-                expect(olMap.getLayers().getArray()).to.contain(layer);
+                expect(map.getLayers().getArray()).to.contain(layer);
                 mapComponent.removeLayer(layer);
-                expect(olMap.getLayers().getArray()).to.not.contain(layer);
+                expect(map.getLayers().getArray()).to.not.contain(layer);
             });
 
             it('removeLayer() throws error if no layer is passed',
@@ -192,7 +173,7 @@ describe('GeoExt.component.Map', function() {
                         undefined,
                         new ol.source.OSM(),
                         '',
-                        olMap
+                        map
                     ];
 
                     nolayer.forEach(function(oneLayer) {
@@ -208,7 +189,7 @@ describe('GeoExt.component.Map', function() {
         describe('listening to size changes', function() {
 
             it('ensure the map is updated when the size changes', function() {
-                var spy = sinon.spy(olMap, 'updateSize');
+                var spy = sinon.spy(map, 'updateSize');
 
                 mapComponent.setSize(100, 100);
 
@@ -216,7 +197,7 @@ describe('GeoExt.component.Map', function() {
                 expect(spy.callCount).to.be(1);
 
                 // restore old method
-                olMap.updateSize.restore();
+                map.updateSize.restore();
             });
 
         });

--- a/test/spec/GeoExt/component/Map.test.js
+++ b/test/spec/GeoExt/component/Map.test.js
@@ -233,6 +233,45 @@ describe('GeoExt.component.Map', function() {
                     Ext.emptyFn
                 );
             });
+            it('can be turned off', function() {
+                // sanity checks
+                expect(mapComponent.getPointerRest()).to.be(false);
+                expect(mapComponent.bufferedPointerMove).to.be(Ext.emptyFn);
+                // 1) enable it…
+                mapComponent.setPointerRest(true);
+                expect(mapComponent.bufferedPointerMove).to.not.be(Ext.emptyFn);
+                // 2) …disable it…
+                mapComponent.setPointerRest(false);
+                // 3) … bufferedPointerMove is the emptyFn again
+                expect(mapComponent.bufferedPointerMove).to.be(Ext.emptyFn);
+            });
+            it('ensures bufferedPointerMove calls unbuffered one',
+                function(done) {
+                    var spy = sinon.spy(mapComponent, 'unbufferedPointerMove');
+                    mapComponent.setPointerRestInterval(50);
+                    mapComponent.setPointerRest(true);
+
+                    // call into the generated bufferedPointerMove
+                    var mockOlEvt = {pixel: [0, 0]};
+                    mapComponent.bufferedPointerMove(mockOlEvt);
+
+                    setTimeout(function() {
+                        expect(spy.called).to.be(true);
+                        expect(spy.callCount).to.be(1);
+                        mapComponent.unbufferedPointerMove.restore();
+                        done();
+                    }, 100); // interval plus a bit offset
+                }
+            );
+            it('ensures changing the interval changes the buffered method',
+                function() {
+                    mapComponent.setPointerRest(true);
+                    var oldBuffered = mapComponent.bufferedPointerMove;
+                    mapComponent.setPointerRestInterval(50);
+                    var newBuffered = mapComponent.bufferedPointerMove;
+                    expect(newBuffered).to.not.be(oldBuffered);
+                }
+            );
         });
 
     });


### PR DESCRIPTION
This PR sugests to add a test utility, that makes the actual tests little less verbose, especially when it comes to set up / teardown `<div>`-elements, instances of `ol.Map` or instances of `GeoExt.component.Map`.

The utility is used in the map component tests, to which I have some more as well. Coverage now is at `85.1%`

Please review.