### PR TITLE
Publish only tagged packages

### DIFF
--- a/ci/update-gh-pages.sh
+++ b/ci/update-gh-pages.sh
@@ -4,9 +4,10 @@ set -e
 # ------------------------------------------------------------------------------
 # This script is supposed to be called from Travis continuous integration server
 #
-# It will update the gh.pages branch of GeoExt with various artifacts created
+# It will update the gh-pages branch of GeoExt with various artifacts created
 # in the previous step
 # ------------------------------------------------------------------------------
+
 echo "$TRAVIS_BUILD_DIR/ci/shared.sh"
 if [ -f "$TRAVIS_BUILD_DIR/ci/shared.sh" ]; then
     # Load variables and the 'running-on-travis'-check
@@ -29,11 +30,14 @@ fi
 # default is master…
 SUB_FOLDER_NAME=$TRAVIS_BRANCH;
 DOC_SUFFIX="-dev"
+PUBLISH_SENCHA_PACKAGE="false"
 
 if [ "$TRAVIS_TAG" != "" ]; then
     # … but if we are building for a tag, let's use this as folder name
     SUB_FOLDER_NAME=$TRAVIS_TAG
     DOC_SUFFIX=""
+    # … only publish the tagged versions
+    PUBLISH_SENCHA_PACKAGE="true"
 fi
 
 DOCS_DIR=$SUB_FOLDER_NAME/docs
@@ -70,12 +74,14 @@ cd $GH_PAGES_DIR
 
 
 # 1. Update GeoExt package
-mkdir -p cmd/pkgs/$GEOEXT_PACKAGE_NAME
-rm -Rf cmd/pkgs/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_VERSION
-cp -r $INSTALL_DIR/../repo/pkgs/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_VERSION cmd/pkgs/$GEOEXT_PACKAGE_NAME
-# TODO the files catalog.json should better be updated, instead of overwritten…
-cp $INSTALL_DIR/../repo/pkgs/catalog.json cmd/pkgs/
-cp $INSTALL_DIR/../repo/pkgs/$GEOEXT_PACKAGE_NAME/catalog.json cmd/pkgs/$GEOEXT_PACKAGE_NAME
+if [ "$PUBLISH_SENCHA_PACKAGE" == "true" ]; then
+    mkdir -p cmd/pkgs/$GEOEXT_PACKAGE_NAME
+    rm -Rf cmd/pkgs/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_VERSION
+    cp -r $INSTALL_DIR/../repo/pkgs/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_VERSION cmd/pkgs/$GEOEXT_PACKAGE_NAME
+    # TODO the files catalog.json should better be updated, instead of overwritten…
+    cp $INSTALL_DIR/../repo/pkgs/catalog.json cmd/pkgs/
+    cp $INSTALL_DIR/../repo/pkgs/$GEOEXT_PACKAGE_NAME/catalog.json cmd/pkgs/$GEOEXT_PACKAGE_NAME
+fi
 
 # 2.
 # 2.1 examples, resources & src copied from repo

--- a/ci/update-gh-pages.sh
+++ b/ci/update-gh-pages.sh
@@ -75,12 +75,12 @@ cd $GH_PAGES_DIR
 
 # 1. Update GeoExt package
 if [ "$PUBLISH_SENCHA_PACKAGE" == "true" ]; then
-    mkdir -p cmd/pkgs/$GEOEXT_PACKAGE_NAME
-    rm -Rf cmd/pkgs/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_VERSION
-    cp -r $INSTALL_DIR/../repo/pkgs/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_VERSION cmd/pkgs/$GEOEXT_PACKAGE_NAME
-    # TODO the files catalog.json should better be updated, instead of overwritten…
-    cp $INSTALL_DIR/../repo/pkgs/catalog.json cmd/pkgs/
-    cp $INSTALL_DIR/../repo/pkgs/$GEOEXT_PACKAGE_NAME/catalog.json cmd/pkgs/$GEOEXT_PACKAGE_NAME
+    # mkdir -p cmd/pkgs/$GEOEXT_PACKAGE_NAME
+    # rm -Rf cmd/pkgs/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_VERSION
+    # cp -r $INSTALL_DIR/../repo/pkgs/$GEOEXT_PACKAGE_NAME/$GEOEXT_PACKAGE_VERSION cmd/pkgs/$GEOEXT_PACKAGE_NAME
+    # # TODO the files catalog.json should better be updated, instead of overwritten…
+    # cp $INSTALL_DIR/../repo/pkgs/catalog.json cmd/pkgs/
+    # cp $INSTALL_DIR/../repo/pkgs/$GEOEXT_PACKAGE_NAME/catalog.json cmd/pkgs/$GEOEXT_PACKAGE_NAME
 fi
 
 # 2.


### PR DESCRIPTION
This PR is WIP until we have released `v3.0.0`.

Previously we would publish a sencha package for every commit that
happened in the `master`-branch. This commit changes this in a way
that only tagged commits (released versions) will publish a sencha
package.

We still need to define how we actually want to react when we build
for say `v3.0.1`. The current approach would probably make the
originally published `v3.0.0` unusable (because we `rm` probably too
much, and also copy over `catalog.json` metatdata files where we
actually want to merge new `catalog.json` with existing ones).

Comit 21299d8 temporary disables the publishing alltogether,
so we cannot break any existing published package.