### PR TITLE
Update npm development dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "browser-sync": "2.18.8",
     "coveralls": "2.12.0",
-    "eslint": "3.17.0",
+    "eslint": "3.17.1",
     "eslint-config-openlayers": "7.0.0",
     "expect.js": "0.3.1",
     "karma": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {},
   "devDependencies": {
     "browser-sync": "2.18.8",
-    "coveralls": "2.11.16",
+    "coveralls": "2.12.0",
     "eslint": "3.17.0",
     "eslint-config-openlayers": "7.0.0",
     "expect.js": "0.3.1",


### PR DESCRIPTION
Before releasing `v3.0.0` I want to make sure that our development dependencies are as up to date as possible.

* Update coveralls to v2.12.0
  * Not exactly sure why the coverage decreases by ~ 3.5%, but since we do not enforce a hard limit, I don't really care right now
  * The same happened in [another repo](https://github.com/terrestris/BasiGX/pull/154)
  * The raw numbers are also unchanged:
    * master:
      * 60.3 hits per line
      * 1029 of 1210 relevant lines covered (85.04%, my calculation)
      * Summary says: 85.04%
    * This PR:
      * 60.3 hits per line
      * 1029 of 1210 relevant lines covered  (85.04%, my calculation)
      * 408 of 553 branches covered (73.78%, completely new)
      * Summary says: 81.50%
* Update eslint to v3.17.1 (Unproblematic)


