### PR TITLE
Reformat API docs for better rendering

### DIFF
--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -67,8 +67,8 @@ Ext.define('GeoExt.data.store.Features', {
     map: null,
 
     /**
-     * Setting this flag to true will create a vector #layer with the given
-     * #features and adds it to the given #map (if available).
+     * Setting this flag to `true` will create a vector #layer with the
+     * given #features and adds it to the given #map (if available).
      *
      * @cfg {Boolean}
      */


### PR DESCRIPTION
This fixes the following rendering:

![image](https://cloud.githubusercontent.com/assets/227934/24789709/645d6b5a-1b74-11e7-9ff0-5a0be96be639.png)

When API doc blocks start with `#` they aren't interpreted as links, but as headings.

Please review.