### PR TITLE
Support for ol v4.x.x

### DIFF
--- a/src/component/FeatureRenderer.js
+++ b/src/component/FeatureRenderer.js
@@ -65,6 +65,9 @@
 Ext.define('GeoExt.component.FeatureRenderer', {
     extend: 'Ext.Component',
     alias: 'widget.gx_renderer',
+    requires: [
+        'GeoExt.util.Version'
+    ],
     mixins: [
         'GeoExt.mixin.SymbolCheck'
     ],
@@ -394,7 +397,12 @@ Ext.define('GeoExt.component.FeatureRenderer', {
         ];
         me.el.setSize(Math.round(width), Math.round(height));
         me.map.updateSize();
-        me.map.getView().fit(bounds, me.map.getSize());
+        // Check for backwards compatibility
+        if (GeoExt.util.Version.isOl3()) {
+            me.map.getView().fit(bounds, me.map.getSize());
+        } else {
+            me.map.getView().fit(bounds);
+        }
     },
     /**
      * We're setting the symbolizers on the feature.

--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -49,7 +49,8 @@ Ext.define('GeoExt.component.Map', {
         'widget.gx_component_map'
     ],
     requires: [
-        'GeoExt.data.store.Layers'
+        'GeoExt.data.store.Layers',
+        'GeoExt.util.Version'
     ],
     mixins: [
         'GeoExt.mixin.SymbolCheck'

--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -429,7 +429,12 @@ Ext.define('GeoExt.component.Map', {
      * @param {ol.Extent} extent The extent as `ol.Extent`.
      */
     setExtent: function(extent) {
-        this.getView().fit(extent, this.getMap().getSize());
+        // Check for backwards compatibility
+        if (GeoExt.util.Version.isOl3()) {
+            this.getView().fit(extent, this.getMap().getSize());
+        } else {
+            this.getView().fit(extent);
+        }
     },
 
     /**

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -608,11 +608,20 @@ Ext.define('GeoExt.component.OverviewMap', {
 
                 // call fit to assure that resolutions are available on
                 // overviewView
-                overviewView.fit(
-                    parentExtentProjected,
-                    me.getMap().getSize(),
-                    {constrainResolution: false}
-                );
+
+                // Check for backwards compatibility
+                if (GeoExt.util.Version.isOl3()) {
+                    overviewView.fit(
+                        parentExtentProjected,
+                        me.getMap().getSize(),
+                        {constrainResolution: false}
+                    );
+                } else {
+                    overviewView.fit(
+                        parentExtentProjected,
+                        {constrainResolution: false}
+                    );
+                }
                 overviewView.set(
                     'resolution',
                     me.getMagnification() * overviewView.getResolution()

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -433,12 +433,12 @@ Ext.define('GeoExt.component.OverviewMap', {
         if (!dragInteraction) {
             return;
         }
+        dragInteraction.setActive(false);
         me.getMap().removeInteraction(dragInteraction);
         dragInteraction.un('translatestart', me.disableBoxUpdate, me);
         dragInteraction.un('translating', me.repositionAnchorFeature, me);
         dragInteraction.un('translateend', me.recenterParentFromBox, me);
         dragInteraction.un('translateend', me.enableBoxUpdate, me);
-        dragInteraction.setActive(false);
         me.dragInteraction = null;
     },
 

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -69,13 +69,17 @@ Ext.define('GeoExt.component.OverviewMap', {
         'widget.gx_overviewmap',
         'widget.gx_component_overviewmap'
     ],
+    requires: [
+        'GeoExt.util.Version'
+    ],
     mixins: [
         'GeoExt.mixin.SymbolCheck'
     ],
 
     // <debug>
     symbols: [
-        'ol.animation.pan',
+        // For ol4 support we can no longer require this symbol
+        // 'ol.animation.pan',
         'ol.Collection',
         'ol.Feature',
         'ol.Feature#setGeometry',
@@ -466,22 +470,29 @@ Ext.define('GeoExt.component.OverviewMap', {
         var overviewProjection = overviewView.getProjection();
 
         var currentMapCenter = parentView.getCenter();
-        var panAnimation = ol.animation.pan({
-            duration: me.getRecenterDuration(),
-            source: currentMapCenter
-        });
         var boxExtent = me.boxFeature.getGeometry().getExtent();
         var boxCenter = ol.extent.getCenter(boxExtent);
 
-        parentMap.beforeRender(panAnimation);
-
         // transform if necessary
         if (!ol.proj.equivalent(parentProjection, overviewProjection)) {
-            boxCenter = ol.proj.transform(boxCenter,
-                overviewProjection, parentProjection);
+            boxCenter = ol.proj.transform(boxCenter, overviewProjection,
+                parentProjection);
         }
 
-        parentView.setCenter(boxCenter);
+        // Check for backwards compatibility
+        if (GeoExt.util.Version.isOl3()) {
+            var panAnimation = ol.animation.pan({
+                duration: me.getRecenterDuration(),
+                source: currentMapCenter
+            });
+            parentMap.beforeRender(panAnimation);
+            parentView.setCenter(boxCenter);
+        } else {
+            parentView.animate({
+                center: boxCenter
+            });
+        }
+
     },
 
     /**
@@ -512,10 +523,6 @@ Ext.define('GeoExt.component.OverviewMap', {
         var overviewMap = me.getMap();
         var overviewView = overviewMap.getView();
         var overviewProjection = overviewView.getProjection();
-        var panAnimation = ol.animation.pan({
-            duration: me.getRecenterDuration(),
-            source: currentMapCenter
-        });
         var newCenter = evt.coordinate;
 
         // transform if necessary
@@ -524,8 +531,19 @@ Ext.define('GeoExt.component.OverviewMap', {
                 overviewProjection, parentProjection);
         }
 
-        parentMap.beforeRender(panAnimation);
-        parentView.setCenter(newCenter);
+        // Check for backwards compatibility
+        if (GeoExt.util.Version.isOl3()) {
+            var panAnimation = ol.animation.pan({
+                duration: me.getRecenterDuration(),
+                source: currentMapCenter
+            });
+            parentMap.beforeRender(panAnimation);
+            parentView.setCenter(newCenter);
+        } else {
+            parentView.animate({
+                center: newCenter
+            });
+        }
     },
 
     /**

--- a/src/data/serializer/Vector.js
+++ b/src/data/serializer/Vector.js
@@ -210,7 +210,8 @@ Ext.define('GeoExt.data.serializer.Vector', {
                         styles = styleFunction.call(layer, feature, viewRes);
                     }
                 }
-                if (styles !== null && styles.length > 0) {
+
+                if (!Ext.isEmpty(styles)) {
                     geoJsonFeatures.push(geojsonFeature);
                     if (Ext.isEmpty(geojsonFeature.properties)) {
                         geojsonFeature.properties = {};

--- a/src/data/store/LayersTree.js
+++ b/src/data/store/LayersTree.js
@@ -293,7 +293,8 @@ Ext.define('GeoExt.data.store.LayersTree', {
         var currentLayerInGroupIdx = GeoExt.util.Layer.getLayerIndex(
             layer, group
         );
-        if (currentLayerInGroupIdx !== insertIdx) {
+        if (currentLayerInGroupIdx !== insertIdx &&
+            !Ext.Array.contains(groupLayers.getArray(), layer)) {
             me.suspendCollectionEvents();
             groupLayers.insertAt(insertIdx, layer);
             me.resumeCollectionEvents();

--- a/src/util/Version.js
+++ b/src/util/Version.js
@@ -1,0 +1,41 @@
+/* Copyright (c) 2015-2017 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * A utility class for detecting if the OpenLayers version is 3.x.x or 4.x.x.
+ *
+ * @class GeoExt.util.Version
+ */
+Ext.define('GeoExt.util.Version', {
+    statics: {
+
+        /**
+        * As OpenLayers itself doesn't has any version methods we check for
+        * functionality that is only supported in ol3.
+         * @return {boolean} true if ol version is 3.x.x false if 4.x.x
+         */
+        isOl3: function() {
+            return !!(ol.animation && ol.Map.prototype.beforeRender);
+        },
+
+        /**
+         * Determine if the loaded version of OpenLayers is v.4.x.x.
+         * @return {boolean} true if ol version is 4.x.x false if 3.x.x
+         */
+        isOl4: function() {
+            return !this.isOl3();
+        }
+    }
+});

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -24,7 +24,7 @@ module.exports = function(config) {
             'node_modules/openlayers/dist/ol' + suffix + '.css',
             'resources/external/theme-crisp-all' + suffix + '_1.css',
             'resources/external/theme-crisp-all' + suffix + '_2.css',
-            // OpenLayers 3
+            // OpenLayers 3/4
             'node_modules/openlayers/dist/ol' + suffix + '.js',
             // ExtJS 6
             'resources/external/ext-all' + suffix + '.js',

--- a/test/spec/GeoExt/component/OverviewMap.test.js
+++ b/test/spec/GeoExt/component/OverviewMap.test.js
@@ -294,7 +294,7 @@ describe('GeoExt.component.OverviewMap', function() {
             it('creates and adds a Translate interaction', function() {
                 overviewMap.destroyDragBehaviour(); // destroy first
                 var before = overviewMap.getMap().getInteractions().getLength();
-                overviewMap.setupDragBehaviour();  // we test this call
+                overviewMap.setupDragBehaviour(); // we test this call
                 var after = overviewMap.getMap().getInteractions().getLength();
                 expect(overviewMap.dragInteraction).to.not.be(null);
                 expect(overviewMap.dragInteraction).to.be.a(
@@ -342,7 +342,10 @@ describe('GeoExt.component.OverviewMap', function() {
                 overviewMap.recenterParentFromBox();
 
                 var parentCenter = olMap.getView().getCenter();
-                expect(parentCenter).to.eql([1, 1]);
+
+                setTimeout(function() {
+                    expect(parentCenter).to.eql([1, 1]);
+                }, 100);
             });
 
             it('reprojects if projections are not equal', function() {
@@ -369,16 +372,18 @@ describe('GeoExt.component.OverviewMap', function() {
 
                 var parentCenter = olMap.getView().getCenter();
                 var expectedCenter = [4.491576420597607, 4.486983030705062];
-                expect(
-                    parentCenter[0].toFixed(12)
-                ).to.eql(
-                    expectedCenter[0].toFixed(12)
-                );
-                expect(
-                    parentCenter[1].toFixed(12)
-                ).to.eql(
-                    expectedCenter[1].toFixed(12)
-                );
+                setTimeout(function() {
+                    expect(
+                        parentCenter[0].toFixed(12)
+                    ).to.eql(
+                        expectedCenter[0].toFixed(12)
+                    );
+                    expect(
+                        parentCenter[1].toFixed(12)
+                    ).to.eql(
+                        expectedCenter[1].toFixed(12)
+                    );
+                }, 100);
             });
         });
     });

--- a/test/spec/GeoExt/component/OverviewMap.test.js
+++ b/test/spec/GeoExt/component/OverviewMap.test.js
@@ -333,7 +333,7 @@ describe('GeoExt.component.OverviewMap', function() {
         });
 
         describe('#recenterParentFromBox', function() {
-            it('updates the parent map center', function() {
+            it('updates the parent map center', function(done) {
                 overviewMap.destroyDragBehaviour(); // destroy first
                 overviewMap.setupDragBehaviour();
                 overviewMap.boxFeature.setGeometry(ol.geom.Polygon.fromExtent(
@@ -341,14 +341,14 @@ describe('GeoExt.component.OverviewMap', function() {
                 ));
                 overviewMap.recenterParentFromBox();
 
-                var parentCenter = olMap.getView().getCenter();
-
                 setTimeout(function() {
+                    var parentCenter = olMap.getView().getCenter();
                     expect(parentCenter).to.eql([1, 1]);
-                }, 100);
+                    done();
+                }, 1200);
             });
 
-            it('reprojects if projections are not equal', function() {
+            it('reprojects if projections are not equal', function(done) {
                 overviewMap.destroyDragBehaviour(); // destroy first
                 overviewMap.setupDragBehaviour();
                 overviewMap.boxFeature.setGeometry(ol.geom.Polygon.fromExtent(
@@ -370,9 +370,12 @@ describe('GeoExt.component.OverviewMap', function() {
                 // we test whether this call will reproject
                 overviewMap.recenterParentFromBox();
 
-                var parentCenter = olMap.getView().getCenter();
                 var expectedCenter = [4.491576420597607, 4.486983030705062];
+
+
                 setTimeout(function() {
+                    var parentCenter = olMap.getView().getCenter();
+
                     expect(
                         parentCenter[0].toFixed(12)
                     ).to.eql(
@@ -383,7 +386,8 @@ describe('GeoExt.component.OverviewMap', function() {
                     ).to.eql(
                         expectedCenter[1].toFixed(12)
                     );
-                }, 100);
+                    done();
+                }, 1200);
             });
         });
     });

--- a/test/spec/GeoExt/util/Version.test.js
+++ b/test/spec/GeoExt/util/Version.test.js
@@ -1,0 +1,30 @@
+Ext.Loader.syncRequire(['GeoExt.util.Version']);
+
+describe('GeoExt.util.Version', function() {
+
+    describe('basics', function() {
+
+        it('is defined', function() {
+            expect(GeoExt.util.Version).not.to.be(undefined);
+        });
+
+    });
+
+    describe('static methods', function() {
+
+        describe('isOl3', function() {
+            expect(GeoExt.util.Version.isOl3).not.to.be(undefined);
+
+            var isOl3 = GeoExt.util.Version.isOl3();
+            expect(isOl3).to.be.a('boolean');
+        });
+
+        describe('isOl4', function() {
+            expect(GeoExt.util.Version.isOl4).not.to.be(undefined);
+
+            var isOl4 = GeoExt.util.Version.isOl4();
+            expect(isOl4).to.be.a('boolean');
+        });
+    });
+
+});


### PR DESCRIPTION
- This introduces GeoExt.util.Version which can be used to determine if ol3
or ol4 is used.
- GeoExt.util.Version will be required in GeoExt.component.Map to be available
right when you use a map.
- It adds checks for `ol.animation` and `ol.View.fit()` which are the breaking changes.

Solves #243 