### PR TITLE
Replace statics with inheritableStatics

### DIFF
--- a/src/component/FeatureRenderer.js
+++ b/src/component/FeatureRenderer.js
@@ -184,7 +184,7 @@ Ext.define('GeoExt.component.FeatureRenderer', {
         symbolType: 'Polygon'
     },
 
-    statics: {
+    inheritableStatics: {
 
         /**
          * Determines the style for the given feature record.

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -113,7 +113,7 @@ Ext.define('GeoExt.component.OverviewMap', {
     ],
     // </debug>
 
-    statics: {
+    inheritableStatics: {
 
         /**
          * Returns an object with geometries representing the extent of the

--- a/src/data/MapfishPrintProvider.js
+++ b/src/data/MapfishPrintProvider.js
@@ -54,7 +54,7 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
         url: ''
     },
 
-    statics: {
+    inheritableStatics: {
         /**
          * An array of objects specifying a serializer and a connected
          * OpenLayers class. This should not be manipulated by hand, but rather
@@ -96,7 +96,7 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
             Ext.each(available, function(candidate, idx) {
                 if (candidate.serializerCls === serializerCls) {
                     index = idx;
-                    return false;  // break early
+                    return false; // break early
                 }
             });
             if (Ext.isDefined(index)) {

--- a/src/data/model/OlObject.js
+++ b/src/data/model/OlObject.js
@@ -34,7 +34,7 @@ Ext.define('GeoExt.data.model.OlObject', {
     ],
     // </debug>
 
-    statics: {
+    inheritableStatics: {
         /**
          * Gets a reference to an ol contructor function.
          *

--- a/src/mixin/SymbolCheck.js
+++ b/src/mixin/SymbolCheck.js
@@ -58,7 +58,7 @@
  */
 Ext.define('GeoExt.mixin.SymbolCheck', {
     extend: 'Ext.Mixin',
-    statics: {
+    inheritableStatics: {
 
         /**
          * An object that we will use to store already looked up references in.

--- a/src/util/Layer.js
+++ b/src/util/Layer.js
@@ -19,7 +19,7 @@
  * @class GeoExt.util.Layer
  */
 Ext.define('GeoExt.util.Layer', {
-    statics: {
+    inheritableStatics: {
         /**
          * A utility method to find the `ol.layer.Group` which is the direct
          * parent of the passed layer. Searching starts at the passed


### PR DESCRIPTION
This replaces `statics` with `inheritableStatics` to avoid problems when extending this component.

e.g.: `me.self.getVisibleExtentGeometries` inLine 537 is undefined currently when extending the component.