### PR TITLE
Add @private-tags to internal handlers in store classes

### DIFF
--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -294,6 +294,7 @@ Ext.define('GeoExt.data.store.Features', {
     /**
      * Handles the 'filterchange'-event.
      * Applies the filter of this store to the underlying layer.
+     * @private
      */
     onFilterChange: function() {
         var me = this;

--- a/src/data/store/Layers.js
+++ b/src/data/store/Layers.js
@@ -323,6 +323,7 @@ Ext.define('GeoExt.data.store.Layers', {
      * @param {Ext.data.Model} record The model instance that was updated.
      * @param {String} operation The operation, either Ext.data.Model.EDIT,
      *     Ext.data.Model.REJECT or Ext.data.Model.COMMIT.
+     * @private
      */
     onStoreUpdate: function(store, record, operation) {
         if (operation === Ext.data.Record.EDIT) {

--- a/src/data/store/OlObjects.js
+++ b/src/data/store/OlObjects.js
@@ -55,6 +55,7 @@ Ext.define('GeoExt.data.store.OlObjects', {
         /**
          * Forwards changes on the Ext.data.Store to the ol.Collection.
          *
+         * @private
          * @inheritdoc
          */
         add: function(store, records, index) {
@@ -72,6 +73,7 @@ Ext.define('GeoExt.data.store.OlObjects', {
         /**
          * Forwards changes on the Ext.data.Store to the ol.Collection.
          *
+         * @private
          * @inheritdoc
          */
         remove: function(store, records, index) {
@@ -116,6 +118,7 @@ Ext.define('GeoExt.data.store.OlObjects', {
      * Forwards changes to the `ol.Collection` to the Ext.data.Store.
      *
      * @param {ol.CollectionEvent} evt The event emitted by the `ol.Collection`.
+     * @private
      */
     onOlCollectionAdd: function(evt) {
         var target = evt.target;
@@ -131,6 +134,7 @@ Ext.define('GeoExt.data.store.OlObjects', {
      * Forwards changes to the `ol.Collection` to the Ext.data.Store.
      *
      * @param {ol.CollectionEvent} evt The event emitted by the `ol.Collection`.
+     * @private
      */
     onOlCollectionRemove: function(evt) {
         var element = evt.element;


### PR DESCRIPTION
This adds the ``@private``-tag to the internal handler functions in the store-classes (``GeoExt.data.store.`*``).
So they do not appear as public API-functions in the API-docs.