### PR TITLE
Prepare GeoExt v3.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,15 @@ JavaScript Toolkit for Rich Web Mapping Applications.
 
 GeoExt is Open Source and enables building desktop-like GIS applications through the web. It is a JavaScript framework that combines the GIS functionality of OpenLayers with the user interface savvy of the ExtJS library provided by Sencha.
 
-Version 3 of GeoExt is the successor to the GeoExt 2.x-series and is built atop the newest official installments of its base libraries; OpenLayers 3 and ExtJS 6.
+Version 3 of GeoExt is the successor to the GeoExt 2.x-series and is built atop the newest official installments of its base libraries; OpenLayers (v3.x and v4.x) and ExtJS 6.
 
 We are trying hard to keep up with developments on both our parent libraries.
-The current state of GeoExt is compatible with ExtJS 6.2.0 and OpenLayers 3.20.1. This state is released as GeoExt v3.0.0.
+The current state of GeoExt is compatible with ExtJS 6.2.0 and OpenLayers 4.3.2. This state is released as GeoExt v3.1.0.
 
-| OpenLayers | ExtJS | GeoExt |
-| ---------- | ----- | ------ |
-| 3.20.1     | 6.2.0 | 3.0.0  |
-| 4.2.x      | 6.2.0 | WIP    |
-
-We plan on making GeoExt compatible to the already released v4.2.x of OpenLayers. Stay tuned.
+| OpenLayers       | ExtJS | GeoExt |
+| ---------------- | ----- | ------ |
+| 3.20.1           | 6.2.0 | 3.0.0  |
+| 3.20.1 / 4.3.2   | 6.2.0 | 3.1.0  |
 
 ## More information on GeoExt 3
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ To help with your first GeoExt 3 project, follow the instructions provided to bu
 * [Basic print with Mapfish v3](http://rawgit.com/geoext/geoext3/master/examples/print/basic-mapfish.html)
 * [Popup on a map component](https://rawgit.com/geoext/geoext3/master/examples/popup/gx-popup.html)
 * [FeatureGrid component](https://rawgit.com/geoext/geoext3/master/examples/features/grid.html)
+* [Interactively filtered heatmap](https://rawgit.com/geoext/geoext3/master/examples/filtered-heatmap/filtered-heatmap.html)
+* [FeatureRenderer component](https://rawgit.com/geoext/geoext3/master/examples/renderer/renderer.html)
+* [MapView form](https://rawgit.com/geoext/geoext3/master/examples/mapviewform/mapviewform.html)
 
 
 ## Want to contribute? Yes, please 😀

--- a/bin/example-generator/example.html.tpl
+++ b/bin/example-generator/example.html.tpl
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>@@EXAMPLE_NAME@@ Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -19,7 +19,7 @@
         </p>
     </div>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/docresources/eg-iframe.html
+++ b/docresources/eg-iframe.html
@@ -6,7 +6,7 @@
     <title>GeoExt 3 Examples</title>
 
 
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
     <link rel="stylesheet" type="text/css" href="../resources/css/gx-popup.css">
     <style>
@@ -20,7 +20,7 @@
     }
     </style>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
 
     <script>

--- a/examples/component/map.html
+++ b/examples/component/map.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.component.Map Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -20,7 +20,7 @@
         </p>
     </div>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/component/overviewMap.html
+++ b/examples/component/overviewMap.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.component.OverviewMap Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -27,7 +27,7 @@
         </p>
     </div>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
             Ext.Loader.setConfig({

--- a/examples/features/grid.html
+++ b/examples/features/grid.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Feature Grid Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -25,7 +25,7 @@
         </p>
     </div>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol-debug.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol-debug.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/filtered-heatmap/filtered-heatmap.html
+++ b/examples/filtered-heatmap/filtered-heatmap.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Filtered FeatureStore Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -20,7 +20,7 @@
         </p>
     </div>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol-debug.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol-debug.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/mapviewform/mapviewform.html
+++ b/examples/mapviewform/mapviewform.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Map View Form Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -18,7 +18,7 @@
         </p>
     </div>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/popup/gx-popup.html
+++ b/examples/popup/gx-popup.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Popup Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 
     <link rel="stylesheet" type="text/css" href="../../resources/css/gx-popup.css">
@@ -40,7 +40,7 @@
         </p>
     </div>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/print/basic-mapfish.html
+++ b/examples/print/basic-mapfish.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.data.MapfishPrintProvider Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -30,7 +30,7 @@
         </p>
     </div>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
         Ext.Loader.setConfig({

--- a/examples/renderer/renderer.html
+++ b/examples/renderer/renderer.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>GeoExt.component.FeatureRenderer Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
     <style type="text/css">
          #swatches {
@@ -91,7 +91,7 @@
             })
         </textarea><br>
         <button id="render">render</button>
-        <script src="https://openlayers.org/en/v3.20.1/build/ol-debug.js"></script>
+        <script src="https://openlayers.org/en/v4.3.2/build/ol-debug.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
         <script>
             Ext.Loader.setConfig({

--- a/examples/tree/panel.html
+++ b/examples/tree/panel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>TreeStore Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
 </head>
 
@@ -20,7 +20,7 @@
         </p>
     </div>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
             Ext.Loader.setConfig({

--- a/examples/tree/tree-legend-simple.html
+++ b/examples/tree/tree-legend-simple.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Ext.tree.Panel plus layer legends Example</title>
-    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v3.20.1/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.2/css/ol.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
     <style>
 .x-grid-rowbody {
@@ -33,7 +33,7 @@
         </p>
     </div>
 
-    <script src="https://openlayers.org/en/v3.20.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v4.3.2/build/ol.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
     <script>
             Ext.Loader.setConfig({

--- a/package.json
+++ b/package.json
@@ -59,13 +59,11 @@
     "log-update": "2.1.0",
     "mkdirp": "0.5.1",
     "mocha": "3.5.0",
-    "openlayers": "3.20.1",
+    "openlayers": "4.3.2",
     "phantomjs-prebuilt": "2.1.15",
     "sinon": "3.2.1"
   },
   "greenkeeper": {
-    "ignore": [
-      "openlayers"
-    ]
+    "ignore": []
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "summary": "GIS Package for ExtJS",
   "detailedDescription": "GeoExt is Open Source and enables building desktop-like GIS applications through the web. It is a JavaScript framework that combines the GIS functionality of OpenLayers with the user interface savvy of the ExtJS library provided by Sencha.",
   "license": "GPL-3.0",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "compatVersion": "3.0.0",
   "format": "1",
   "slicer": {

--- a/universal-app.md
+++ b/universal-app.md
@@ -273,7 +273,7 @@ The application needs the OpenLayers library to work. Add this dependency to the
 
 ```
   "js": [{
-      "path": "https://openlayers.org/en/v3.20.1/build/ol.js",
+      "path": "https://openlayers.org/en/v4.3.2/build/ol.js",
       "remote": true
     }, {
       "path": "app.js",
@@ -285,7 +285,7 @@ and css file
 
 ```
     "css": [
-        {"path": "https://openlayers.org/en/v3.20.1/css/ol.css" , "remote": true},
+        {"path": "https://openlayers.org/en/v4.3.2/css/ol.css" , "remote": true},
         {
             // this entry uses an ant variable that is the calculated
             // value of the generated output css file for the app,
@@ -297,7 +297,7 @@ and css file
     ],
 ```
 
-This includes all OpenLayers 3 functionality. After this exercise, you can consider [creating a custom build](https://openlayers.org/en/v3.20.1/doc/tutorials/custom-builds.html) to create a smaller OL3 library, adjusted to only what you need.
+This includes all OpenLayers 3 functionality. After this exercise, you can consider [creating a custom build](https://openlayers.org/en/v4.3.2/doc/tutorials/custom-builds.html) to create a smaller OL3 library, adjusted to only what you need.
 
 ### Build and test the app
 


### PR DESCRIPTION
This prepares the upcoming release of GeoExt in the version 3.1.0:

- Using latest OpenLayers v4.3.2 in the devDependencies (and re-enable greenkeeper for OL)
- Using latest OpenLayers v4.3.2 in the examples
- Update the versions documented in the README, so it will be consistently documented in the release package
- Complete the listed examples in the README

After this is approved and merged the release can be done. I will come up with another PR adapting the ``gh-pages`` branch afterwards.

IMHO also closes #243 

Please review. 