### PR TITLE
Set GeoExt version to 3.1.1-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "summary": "GIS Package for ExtJS",
   "detailedDescription": "GeoExt is Open Source and enables building desktop-like GIS applications through the web. It is a JavaScript framework that combines the GIS functionality of OpenLayers with the user interface savvy of the ExtJS library provided by Sencha.",
   "license": "GPL-3.0",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "compatVersion": "3.0.0",
   "format": "1",
   "slicer": {


### PR DESCRIPTION
Because of releasing GeoExt v3.1.0 this increases the version number in the package.json for the next development cycle.