### PR TITLE
Update documentation for supported OL version in master

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@
         </thead>
         <tbody>
           <tr>
-            <td>4.3.x</td>
+            <td>4.4.x</td>
             <td>6.2.0</td>
             <td>master</td>
             <td>work in progress</td>


### PR DESCRIPTION
Show v4.4.x as the currently supported OL-version in the master branch of GeoExt on the website.