### PR TITLE
Add handler params for LayerStore's 'update'-event

### DIFF
--- a/src/data/store/Layers.js
+++ b/src/data/store/Layers.js
@@ -154,7 +154,8 @@ Ext.define('GeoExt.data.store.Layers', {
             if (evt.key === 'title') {
                 record.set('title', layer.get('title'));
             } else {
-                this.fireEvent('update', this, record, Ext.data.Record.EDIT);
+                this.fireEvent('update', this, record, Ext.data.Record.EDIT,
+                    null, {});
             }
         }
     },


### PR DESCRIPTION
This adds the missing two parameters ``details`` and ``eOpts`` for the handler function when triggering the LayerStore's 'update'-event when changing the underlying OpenLayers layer. Otherwise an exception occurred because some ExtJS code tried to access the undefined parameters.

The issue was noticed in a setup with the modern toolkit of ExtJS.

See here: https://docs.sencha.com/extjs/6.2.1/modern/Ext.data.Store.html#event-update