### PR TITLE
Add first two examples for modern toolkit

### DIFF
--- a/examples/modern-layerlist/modern-layerlist.html
+++ b/examples/modern-layerlist/modern-layerlist.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Layer List Modern Example</title>
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.4/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/modern/theme-ios/resources/theme-ios-all.css"/>
+</head>
+
+<body>
+
+    <div id='description'>
+        <p>
+            This example shows how to use an <code>Ext.grid.Grid</code>
+            component with a <code>GeoExt.data.store.Layers</code>
+            to let the user change the visibility of the map layers in an GeoExt
+            app with the modern toolkit.
+        </p>
+        <br>
+        <p>
+            Have a look at <a href="modern-layerlist.js">modern-layerlist.js</a>
+            to see how this is done.
+        </p>
+    </div>
+
+    <script src="https://openlayers.org/en/v4.3.4/build/ol-debug.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-modern-all-debug.js"></script>
+    <script>
+        Ext.Loader.setConfig({
+            enabled: true,
+            paths: {
+                'GeoExt': '../../src/'
+            }
+        });
+    </script>
+
+    <script src="modern-layerlist.js"></script>
+</body>
+</html>

--- a/examples/modern-layerlist/modern-layerlist.js
+++ b/examples/modern-layerlist/modern-layerlist.js
@@ -69,11 +69,11 @@ Ext.application({
         });
 
         // handler for showing / hiding of layers via layer list
-        onSelect = function (grid, record) {
+        var onSelect = function(grid, record) {
             var layer = record.getOlLayer();
             layer.setVisible(true);
         };
-        onDeselect = function (grid, record) {
+        var onDeselect = function(grid, record) {
             var layer = record.getOlLayer();
             layer.setVisible(false);
         };
@@ -82,11 +82,11 @@ Ext.application({
         layerList = Ext.create('Ext.grid.Grid', {
             title: 'Layer List',
             columns: [
-                {text: 'Name',  dataIndex: 'text', flex: 1},
+                {text: 'Name',  dataIndex: 'text', flex: 1}
             ],
             store: layerStore,
             mode: 'MULTI',
-            striped : false,
+            striped: false,
             listeners: {
                 select: onSelect,
                 deselect: onDeselect
@@ -94,9 +94,9 @@ Ext.application({
         });
 
         // synchronize the initial layer visibility and the list selection
-        layerList.on('show', function () {
+        layerList.on('show', function() {
             var selection = [];
-            layerList.getStore().each(function (rec) {
+            layerList.getStore().each(function(rec) {
                 var layer = rec.getOlLayer();
                 if (layer.getVisible() === true) {
                     selection.push(rec);
@@ -124,19 +124,19 @@ Ext.application({
         // Create viewport and also add a button showing a description with the
         // link to this source code
         var viewport = Ext.create('Ext.TabPanel', {
-            fullscreen : true,
-            ui : 'dark',
-            tabBar : {
-                docked : 'top',
-                layout : {
-                    pack : 'center'
+            fullscreen: true,
+            ui: 'dark',
+            tabBar: {
+                docked: 'top',
+                layout: {
+                    pack: 'center'
                 }
             },
-            items : [
+            items: [
                 mapPanel,
                 layerList,
                 {
-                    xtype : 'toolbar',
+                    xtype: 'toolbar',
                     docked: 'bottom',
                     items: [
                         {
@@ -151,8 +151,8 @@ Ext.application({
         });
 
         // close the modal description when clicking mask
-        viewport.mon(Ext.getBody(), 'click', function(el, e){
+        viewport.mon(Ext.getBody(), 'click', function(el, e) {
             description.close(description.closeAction);
-        }, viewport, { delegate: '.x-mask' });
+        }, viewport, {delegate: '.x-mask'});
     }
 });

--- a/examples/modern-layerlist/modern-layerlist.js
+++ b/examples/modern-layerlist/modern-layerlist.js
@@ -1,0 +1,158 @@
+Ext.require([
+    'GeoExt.component.Map',
+    'GeoExt.data.store.Layers',
+    'Ext.panel.Panel',
+    'Ext.grid.Grid',
+    'Ext.Viewport',
+    'Ext.Toolbar',
+    'Ext.Button',
+    'Ext.TabPanel'
+]);
+
+var olMap;
+var mapComponent;
+var mapPanel;
+var layerStore;
+var layerList;
+var description;
+
+Ext.application({
+    name: 'modern-layerlist',
+    launch: function() {
+
+        olMap = new ol.Map({
+            layers: [
+                new ol.layer.Tile({
+                    name: 'OSM',
+                    source: new ol.source.OSM()
+                }),
+                new ol.layer.Tile({
+                    name: 'Labels',
+                    source: new ol.source.Stamen({
+                        layer: 'terrain-labels'
+                    })
+                }),
+                new ol.layer.Vector({
+                    name: 'Earthquakes',
+                    source: new ol.source.Vector({
+                        url: '../data/1.0_week.geojson',
+                        format: new ol.format.GeoJSON()
+                    }),
+                    style: new ol.style.Style({
+                        image: new ol.style.RegularShape({
+                            fill: new ol.style.Fill({color: 'red'}),
+                            stroke: new ol.style.Stroke({color: 'darkred'}),
+                            points: 3,
+                            radius: 6
+                        })
+                    })
+                })
+            ],
+            view: new ol.View({
+                center: [0, 0],
+                zoom: 2
+            })
+        });
+
+        mapComponent = Ext.create('GeoExt.component.Map', {
+            map: olMap
+        });
+
+        mapPanel = Ext.create('Ext.panel.Panel', {
+            title: 'Map Panel',
+            layout: 'fit',
+            items: [mapComponent]
+        });
+
+        layerStore = Ext.create('GeoExt.data.store.Layers', {
+            map: olMap
+        });
+
+        // handler for showing / hiding of layers via layer list
+        onSelect = function (grid, record) {
+            var layer = record.getOlLayer();
+            layer.setVisible(true);
+        };
+        onDeselect = function (grid, record) {
+            var layer = record.getOlLayer();
+            layer.setVisible(false);
+        };
+
+        // use a grid with 1 colum as layer list
+        layerList = Ext.create('Ext.grid.Grid', {
+            title: 'Layer List',
+            columns: [
+                {text: 'Name',  dataIndex: 'text', flex: 1},
+            ],
+            store: layerStore,
+            mode: 'MULTI',
+            striped : false,
+            listeners: {
+                select: onSelect,
+                deselect: onDeselect
+            }
+        });
+
+        // synchronize the initial layer visibility and the list selection
+        layerList.on('show', function () {
+            var selection = [];
+            layerList.getStore().each(function (rec) {
+                var layer = rec.getOlLayer();
+                if (layer.getVisible() === true) {
+                    selection.push(rec);
+                }
+            });
+            // set visible layer recs as initial selection
+            layerList.setSelection(selection);
+
+        }, layerList, {single: true});
+
+        description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            title: 'Description',
+            modal: true,
+            centered: true,
+            scrollable: true,
+            width: 400,
+            height: 400,
+            bodyPadding: 5,
+            hidden: true,
+            closeAction: 'hide'
+        });
+        Ext.Viewport.add(description);
+
+        // Create viewport and also add a button showing a description with the
+        // link to this source code
+        var viewport = Ext.create('Ext.TabPanel', {
+            fullscreen : true,
+            ui : 'dark',
+            tabBar : {
+                docked : 'top',
+                layout : {
+                    pack : 'center'
+                }
+            },
+            items : [
+                mapPanel,
+                layerList,
+                {
+                    xtype : 'toolbar',
+                    docked: 'bottom',
+                    items: [
+                        {
+                            text: 'Description',
+                            handler: function() {
+                                description.show();
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        // close the modal description when clicking mask
+        viewport.mon(Ext.getBody(), 'click', function(el, e){
+            description.close(description.closeAction);
+        }, viewport, { delegate: '.x-mask' });
+    }
+});

--- a/examples/modern-map/modern-map.html
+++ b/examples/modern-map/modern-map.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>GeoExt.component.Map Modern Example</title>
+    <link rel="stylesheet" type="text/css" href="https://openlayers.org/en/v4.3.4/css/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/modern/theme-ios/resources/theme-ios-all.css"/>
+</head>
+
+<body>
+
+    <div id='description'>
+        <p>
+            This example shows how to use the <code>GeoExt.component.Map</code>
+            class in an GeoExt app with the modern toolkit.
+        </p>
+        <br>
+        <p>
+            Have a look at <a href="modern-map.js">modern-map.js</a> to see how
+            this is done.
+        </p>
+    </div>
+
+    <script src="https://openlayers.org/en/v4.3.4/build/ol.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-modern-all.js"></script>
+    <script>
+        Ext.Loader.setConfig({
+            enabled: true,
+            paths: {
+                'GeoExt': '../../src/'
+            }
+        });
+    </script>
+
+    <script src="modern-map.js"></script>
+</body>
+</html>

--- a/examples/modern-map/modern-map.js
+++ b/examples/modern-map/modern-map.js
@@ -87,19 +87,19 @@ Ext.application({
         // Create viewport and also add a button showing a description with the
         // link to this source code
         var viewport = Ext.create('Ext.TabPanel', {
-            fullscreen : true,
-            ui : 'dark',
-            tabBar : {
-                docked : 'top',
-                layout : {
-                    pack : 'center'
+            fullscreen: true,
+            ui: 'dark',
+            tabBar: {
+                docked: 'top',
+                layout: {
+                    pack: 'center'
                 }
             },
-            items : [
+            items: [
                 mapPanel1,
                 mapPanel2,
                 {
-                    xtype : 'toolbar',
+                    xtype: 'toolbar',
                     docked: 'bottom',
                     items: [
                         {
@@ -114,8 +114,8 @@ Ext.application({
         });
 
         // close the modal description when clicking mask
-        viewport.mon(Ext.getBody(), 'click', function(el, e){
+        viewport.mon(Ext.getBody(), 'click', function(el, e) {
             description.close(description.closeAction);
-        }, viewport, { delegate: '.x-mask' });
+        }, viewport, {delegate: '.x-mask'});
     }
 });

--- a/examples/modern-map/modern-map.js
+++ b/examples/modern-map/modern-map.js
@@ -1,0 +1,121 @@
+Ext.require([
+    'GeoExt.component.Map',
+    'Ext.panel.Panel',
+    'Ext.Viewport',
+    'Ext.Toolbar',
+    'Ext.Button',
+    'Ext.TabPanel'
+]);
+
+var olMap1;
+var olMap2;
+var mapComponent1;
+var mapComponent2;
+var mapPanel1;
+var mapPanel2;
+var description;
+
+Ext.application({
+    name: 'modern-map',
+    launch: function() {
+
+        olMap1 = new ol.Map({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.Stamen({
+                        layer: 'watercolor'
+                    })
+                }),
+                new ol.layer.Tile({
+                    source: new ol.source.Stamen({
+                        layer: 'terrain-labels'
+                    })
+                })
+            ],
+            view: new ol.View({
+                center: ol.proj.fromLonLat([-122.416667, 37.783333]),
+                zoom: 12
+            })
+        });
+
+        mapComponent1 = Ext.create('GeoExt.component.Map', {
+            map: olMap1
+        });
+
+        mapPanel1 = Ext.create('Ext.panel.Panel', {
+            title: 'San Francisco',
+            layout: 'fit',
+            items: [mapComponent1]
+        });
+
+        olMap2 = new ol.Map({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.OSM()
+                })
+            ],
+            view: new ol.View({
+                center: ol.proj.fromLonLat([9.993682, 53.551086]),
+                zoom: 12
+            })
+        });
+
+        mapComponent2 = Ext.create('GeoExt.component.Map', {
+            map: olMap2
+        });
+
+        mapPanel2 = Ext.create('Ext.panel.Panel', {
+            title: 'Hamburg',
+            layout: 'fit',
+            items: [mapComponent2]
+        });
+
+        description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            title: 'Description',
+            modal: true,
+            centered: true,
+            scrollable: true,
+            width: 400,
+            height: 400,
+            bodyPadding: 5,
+            hidden: true,
+            closeAction: 'hide'
+        });
+        Ext.Viewport.add(description);
+
+        // Create viewport and also add a button showing a description with the
+        // link to this source code
+        var viewport = Ext.create('Ext.TabPanel', {
+            fullscreen : true,
+            ui : 'dark',
+            tabBar : {
+                docked : 'top',
+                layout : {
+                    pack : 'center'
+                }
+            },
+            items : [
+                mapPanel1,
+                mapPanel2,
+                {
+                    xtype : 'toolbar',
+                    docked: 'bottom',
+                    items: [
+                        {
+                            text: 'Description',
+                            handler: function() {
+                                description.show();
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        // close the modal description when clicking mask
+        viewport.mon(Ext.getBody(), 'click', function(el, e){
+            description.close(description.closeAction);
+        }, viewport, { delegate: '.x-mask' });
+    }
+});


### PR DESCRIPTION
This adds two examples using the modern toolkit of ExtJS:

1) Show how to use the <code>GeoExt.component.Map</code> class in an GeoExt app with the modern toolkit

![image](https://user-images.githubusercontent.com/1185547/35557794-7fc2528a-05a6-11e8-86a0-b7e019543da5.png)

2) Show how to use an <code>Ext.grid.Grid</code> component with a <code>GeoExt.data.store.Layers</code> to let the user change the visibility of the map layers in an GeoExt app with the modern toolkit

![image](https://user-images.githubusercontent.com/1185547/35557864-bb95e754-05a6-11e8-97b8-10638ae27731.png)


Once we have agreed on merging this, we can list them in the README and on the GeoExt website.

TIA for any review.