### PR TITLE
Add links to modern toolkit examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ To help with your first GeoExt 3 project, follow the instructions provided to bu
 
 ## Examples
 
+### Classic Toolkit
+
 * [Basic map component](https://rawgit.com/geoext/geoext3/master/examples/component/map.html)
 * [Overview component](https://rawgit.com/geoext/geoext3/master/examples/component/overviewMap.html)
 * [Basic TreePanel](https://rawgit.com/geoext/geoext3/master/examples/tree/panel.html)
@@ -83,6 +85,11 @@ To help with your first GeoExt 3 project, follow the instructions provided to bu
 * [Interactively filtered heatmap](https://rawgit.com/geoext/geoext3/master/examples/filtered-heatmap/filtered-heatmap.html)
 * [FeatureRenderer component](https://rawgit.com/geoext/geoext3/master/examples/renderer/renderer.html)
 * [MapView form](https://rawgit.com/geoext/geoext3/master/examples/mapviewform/mapviewform.html)
+
+### Modern Toolkit
+
+* [Basic map component ](https://rawgit.com/geoext/geoext3/master/examples/modern-map/modern-map.html)
+* [LayerList component ](https://rawgit.com/geoext/geoext3/master/examples/modern-layerlist/modern-layerlist.html)
 
 
 ## Want to contribute? Yes, please 😀


### PR DESCRIPTION
This adds the links to the examples built with the modern toolkit (introduced by #397) to our README file.