### PR TITLE
Add section for modern toolkit examples to website

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,10 @@
     <div class="row">
       <h1 class="span12 topic">Examples</h1>
     </div>
+
     <div class="examples_container">
+
+      <h2 class="">Classic Toolkit</h2>
 
       <div class="row">
         <div class="span4">
@@ -243,6 +246,31 @@
         </div>
       </div>
     </div>
+
+    <div class="examples_container">
+
+      <h2 class="">Modern Toolkit</h2>
+
+      <div class="row">
+        <div class="span4">
+          <a href="https://rawgit.com/geoext/geoext3/master/examples/modern-map/modern-map.html" class="big-link">
+            <h3>Map</h3>
+            <p>A basic Map component in a modern toolkit app.</p>
+          </a>
+        </div>
+        <div class="span4">
+          <a href="https://rawgit.com/geoext/geoext3/master/examples/modern-layerlist/modern-layerlist.html" class="big-link">
+            <h3>LayerList</h3>
+            <p>A LayerList component in a modern toolkit app.</p>
+          </a>
+        </div>
+        <div class="span4">
+          <h3>More examples …</h3>
+          <p>… coming soon</p>
+        </div>
+      </div>
+    </div>
+
   <div class="row">
     <h1 class="span12 topic">Versions of GeoExt</h1>
     <div class="span12">


### PR DESCRIPTION
This adds a new section for modern toolkit examples to the GeoExt3 website and lists the newly created examples based on the modern toolkit (see #397):

![image](https://user-images.githubusercontent.com/1185547/35614026-f46863d2-066d-11e8-9b2c-2756515f3298.png)

TIA for any review.
