### PR TITLE
Fix printing of redlining layers

### DIFF
--- a/src/data/serializer/Vector.js
+++ b/src/data/serializer/Vector.js
@@ -200,6 +200,13 @@ Ext.define('GeoExt.data.serializer.Vector', {
                 var geometryType = geometry.getType();
                 var geojsonFeature = format.writeFeatureObject(feature);
 
+                // remove parent feature references as they break serialization
+                // later on
+                if (geojsonFeature.properties &&
+                        geojsonFeature.properties.parentFeature) {
+                    geojsonFeature.properties.parentFeature = undefined;
+                }
+
                 var styles = null;
                 var styleFunction = feature.getStyleFunction();
                 if (Ext.isDefined(styleFunction)) {
@@ -211,6 +218,9 @@ Ext.define('GeoExt.data.serializer.Vector', {
                     }
                 }
 
+                if (!Ext.isArray(styles)) {
+                    styles = [styles];
+                }
                 if (!Ext.isEmpty(styles)) {
                     geoJsonFeatures.push(geojsonFeature);
                     if (Ext.isEmpty(geojsonFeature.properties)) {


### PR DESCRIPTION
When trying to print/serialize redlining/measure layers, two problems were found:

* The geojson would include the parentFeature property. Being a reference to an ol feature, json serialization would fail because of cycles.
* Evaluating the style function would yield a single style, not an array of styles. This case had not been handled, resulting in the feature being skipped completely.

This PR fixes both issues.

@weskamm @marcjansen @terrestris/devs please review
