### PR TITLE
Fix usage of collection events

### DIFF
--- a/examples/modern-layerlist/modern-layerlist.js
+++ b/examples/modern-layerlist/modern-layerlist.js
@@ -82,7 +82,7 @@ Ext.application({
         layerList = Ext.create('Ext.grid.Grid', {
             title: 'Layer List',
             columns: [
-                {text: 'Name',  dataIndex: 'text', flex: 1}
+                {text: 'Name', dataIndex: 'text', flex: 1}
             ],
             store: layerStore,
             mode: 'MULTI',

--- a/src/data/store/OlObjects.js
+++ b/src/data/store/OlObjects.js
@@ -78,13 +78,11 @@ Ext.define('GeoExt.data.store.OlObjects', {
          */
         remove: function(store, records, index) {
             var coll = store.olCollection;
-            var length = records.length;
-            var i;
 
             store.__updating = true;
-            for (i = 0; i < length; i++) {
-                coll.removeAt(index);
-            }
+            Ext.each(records, function(rec) {
+                coll.remove(rec.olObject);
+            });
             store.__updating = false;
         }
     },
@@ -109,53 +107,12 @@ Ext.define('GeoExt.data.store.OlObjects', {
         config.data = this.olCollection.getArray();
 
         this.callParent([config]);
-
-        this.olCollection.on('add', this.onOlCollectionAdd, this);
-        this.olCollection.on('remove', this.onOlCollectionRemove, this);
-    },
-
-    /**
-     * Forwards changes to the `ol.Collection` to the Ext.data.Store.
-     *
-     * @param {ol.CollectionEvent} evt The event emitted by the `ol.Collection`.
-     * @private
-     */
-    onOlCollectionAdd: function(evt) {
-        var target = evt.target;
-        var element = evt.element;
-        var idx = Ext.Array.indexOf(target.getArray(), element);
-
-        if (!this.__updating) {
-            this.insert(idx, element);
-        }
-    },
-
-    /**
-     * Forwards changes to the `ol.Collection` to the Ext.data.Store.
-     *
-     * @param {ol.CollectionEvent} evt The event emitted by the `ol.Collection`.
-     * @private
-     */
-    onOlCollectionRemove: function(evt) {
-        var element = evt.element;
-        var idx = this.findBy(function(rec) {
-            return rec.olObject === element;
-        });
-
-        if (idx !== -1) {
-            if (!this.__updating) {
-                this.removeAt(idx);
-            }
-        }
     },
 
     /**
      * @inheritdoc
      */
     destroy: function() {
-        this.olCollection.un('add', this.onCollectionAdd, this);
-        this.olCollection.un('remove', this.onCollectionRemove, this);
-
         delete this.olCollection;
 
         this.callParent(arguments);

--- a/test/spec/GeoExt/data/model/Feature.test.js
+++ b/test/spec/GeoExt/data/model/Feature.test.js
@@ -26,7 +26,7 @@ describe('GeoExt.data.model.Feature', function() {
 
     describe('#getFeature', function() {
         var feat;
-        var  rec;
+        var rec;
         beforeEach(function() {
             feat = new ol.Feature();
             rec = Ext.create('GeoExt.data.model.Feature', feat);

--- a/test/spec/GeoExt/data/store/Features.test.js
+++ b/test/spec/GeoExt/data/store/Features.test.js
@@ -245,6 +245,53 @@ describe('GeoExt.data.store.Features', function() {
         });
     });
 
+    describe('adding and removing items from the collection', function() {
+
+        var collection;
+        var store;
+
+        beforeEach(function() {
+            collection = new ol.Collection();
+            store = Ext.create('GeoExt.data.store.Features', {
+                features: collection
+            });
+        });
+
+        afterEach(function() {
+            if (store.destroy) {
+                store.destroy();
+            }
+            store = null;
+            collection = null;
+        });
+
+        it('will have records of collection items added', function() {
+            var olObj = new ol.Object();
+
+            expect(store.getCount()).to.be(0);
+
+            collection.push(new ol.Object());
+            expect(store.getCount()).to.be(1);
+
+            collection.push([new ol.Object(), new ol.Object()]);
+            expect(store.getCount()).to.be(3);
+
+            collection.insertAt(0, olObj);
+            expect(collection.item(0)).to.be(olObj);
+            expect(store.getAt(0).olObject).to.be(olObj);
+        });
+
+        it('will not have records of collection items that are removed',
+            function() {
+                collection.push(new ol.Object());
+                expect(store.getCount()).to.be(1);
+
+                collection.removeAt(0);
+                expect(store.getCount()).to.be(0);
+            }
+        );
+    });
+
     describe('config option "createLayer" without a map', function() {
         var coll;
         var store;

--- a/test/spec/GeoExt/data/store/OlObjects.test.js
+++ b/test/spec/GeoExt/data/store/OlObjects.test.js
@@ -60,35 +60,6 @@ describe('GeoExt.data.store.OlObjects', function() {
             });
         });
 
-        describe('adding and removing items from the collection', function() {
-
-            it('will have records of collection items added', function() {
-                var olObj = new ol.Object();
-
-                expect(store.getCount()).to.be(0);
-
-                collection.push(new ol.Object());
-                expect(store.getCount()).to.be(1);
-
-                collection.push([new ol.Object(), new ol.Object()]);
-                expect(store.getCount()).to.be(3);
-
-                collection.insertAt(0, olObj);
-                expect(collection.item(0)).to.be(olObj);
-                expect(store.getAt(0).olObject).to.be(olObj);
-            });
-
-            it('will not have records of collection items that are removed',
-                function() {
-                    collection.push(new ol.Object());
-                    expect(store.getCount()).to.be(1);
-
-                    collection.removeAt(0);
-                    expect(store.getCount()).to.be(0);
-                }
-            );
-        });
-
         describe('adding and removing records from the store', function() {
 
             it('the collection will have items of the added records',


### PR DESCRIPTION
Due to the inheritance between the `Features` store and the `OlObjects` depending on your configuration it was possible that eg. deleting a feature on the `ol.Collection` would result in deletion of two features instead of one due to listeners on the `ol.Collection` and the datasource of the underlying layer. This PR attempts to fix that.

@terrestris/devs @weskamm Please review carefully, the setup in the constructors is somewhat complicated.