### PR TITLE
Adds geometryType param to getUid function

### DIFF
--- a/src/data/serializer/Vector.js
+++ b/src/data/serializer/Vector.js
@@ -575,7 +575,7 @@ Ext.define('GeoExt.data.serializer.Vector', {
          * happened in a previous call.
          *
          * @param {Object} obj The object to get the uid of.
-         * @param {String} geometrType The geometryType for the style.
+         * @param {String} geometryType The geometryType for the style.
          * @return {String} The uid of the object.
          * @private
          */
@@ -583,7 +583,10 @@ Ext.define('GeoExt.data.serializer.Vector', {
             if (!Ext.isObject(obj)) {
                 Ext.raise('Cannot get uid of non-object.');
             }
-            var key = this.GX_UID_PROPERTY + '-' + geometryType;
+            var key = this.GX_UID_PROPERTY;
+            if (geometryType) {
+                key += '-' + geometryType;
+            }
             if (!Ext.isDefined(obj[key])) {
                 obj[key] = Ext.id();
             }

--- a/src/data/serializer/Vector.js
+++ b/src/data/serializer/Vector.js
@@ -227,7 +227,7 @@ Ext.define('GeoExt.data.serializer.Vector', {
                         geojsonFeature.properties = {};
                     }
                     Ext.each(styles, function(style, j) {
-                        var styleId = me.getUid(style);
+                        var styleId = me.getUid(style, geometryType);
                         var featureStyleProp = me.FEAT_STYLE_PREFIX + j;
                         me.encodeVectorStyle(
                             mapfishStyleObject,
@@ -575,14 +575,15 @@ Ext.define('GeoExt.data.serializer.Vector', {
          * happened in a previous call.
          *
          * @param {Object} obj The object to get the uid of.
+         * @param {String} geometrType The geometryType for the style.
          * @return {String} The uid of the object.
          * @private
          */
-        getUid: function(obj) {
+        getUid: function(obj, geometryType) {
             if (!Ext.isObject(obj)) {
                 Ext.raise('Cannot get uid of non-object.');
             }
-            var key = this.GX_UID_PROPERTY;
+            var key = this.GX_UID_PROPERTY + '-' + geometryType;
             if (!Ext.isDefined(obj[key])) {
                 obj[key] = Ext.id();
             }

--- a/test/spec/GeoExt/data/serializer/Vector.test.js
+++ b/test/spec/GeoExt/data/serializer/Vector.test.js
@@ -255,19 +255,28 @@ describe('GeoExt.data.serializer.Vector', function() {
         it('serializes as expected', function() {
             var vecSerializer = GeoExt.data.serializer.Vector;
 
-            var styleId0 = vecSerializer.getUid(style0);
-            var styleId1 = vecSerializer.getUid(style1);
-            var styleId2 = vecSerializer.getUid(style2);
-            var styleId3 = vecSerializer.getUid(style3);
-            var styleId4 = vecSerializer.getUid(style4);
+            var styleId0P = vecSerializer.getUid(style0, 'Point');
+            var styleId0L = vecSerializer.getUid(style0, 'LineString');
+            var styleId1 = vecSerializer.getUid(style1, 'LineString');
+            var styleId2 = vecSerializer.getUid(style2, 'Polygon');
+            var styleId3 = vecSerializer.getUid(style3, 'Point');
+            var styleId4 = vecSerializer.getUid(style4, 'Point');
 
             var expectedStyle = {
                 version: 2
             };
-            expectedStyle['[_gx3_style_0 = \'' + styleId0 + '\']'] = {
+            expectedStyle['[_gx3_style_0 = \'' + styleId0P + '\']'] = {
                 symbolizers: [{
                     type: 'point',
                     pointRadius: 1,
+                    strokeColor: '#010101',
+                    strokeOpacity: 0.1,
+                    strokeWidth: 1
+                }]
+            };
+            expectedStyle['[_gx3_style_0 = \'' + styleId0L + '\']'] = {
+                symbolizers: [{
+                    type: 'line',
                     strokeColor: '#010101',
                     strokeOpacity: 0.1,
                     strokeWidth: 1
@@ -318,13 +327,13 @@ describe('GeoExt.data.serializer.Vector', function() {
             // the expected properties of feature0
             var properties0 = {
                 'foo': '0',
-                '_gx3_style_0': styleId0
+                '_gx3_style_0': styleId0P
             };
 
             // the expected properties of feature1
             var properties1 = {
                 'foo': '1',
-                '_gx3_style_0': styleId0,
+                '_gx3_style_0': styleId0L,
                 '_gx3_style_1': styleId1
             };
 
@@ -433,7 +442,7 @@ describe('GeoExt.data.serializer.Vector', function() {
                     })
                 })
             });
-            var styleUid = GeoExt.data.serializer.Vector.getUid(style);
+            var styleUid = GeoExt.data.serializer.Vector.getUid(style, 'Point');
             feat.setStyle(function() {
                 return [style];
             });


### PR DESCRIPTION
This adds a `geometryType` parameter to the `getUid` function.

This is needed as we can pass an ol style which might cover multiple types of geometries.
e.g:
```javascript
var style = new ol.style.Style({
    fill: new ol.style.Fill({
        color: 'rgba(255, 255, 255, 0.2)'
    }),
    stroke: new ol.style.Stroke({
        color: '#ffcc33',
        width: 2
    }),
    image: new ol.style.Circle({
        radius: 7,
        fill: new ol.style.Fill({
            color: '#ffcc33'
        })
    })
});
```

This style covers `Point`, `LineString` and `Polygon`. But the old `getUid` function would return the same uid for every new call with the same `ol.style.Style`. Which leads to an overwrite of the symoblizer in the mapfishStyleObject in the `encodeVectorStyle` function.



