### PR TITLE
Introduce a PermalinkProvider

### DIFF
--- a/examples/state/stateful-map.html
+++ b/examples/state/stateful-map.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Stateful Map Example</title>
+    <link rel="stylesheet" type="text/css" href="../lib/ol/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
+</head>
+
+<body>
+
+    <div id='description'>
+        <p>
+            This example shows a stateful map with an
+            <code>GeoExt.state.PermalinkProvider</code>
+        </p>
+        <p>
+            Have a look at <a href="stateful-map.js">stateful-map.js</a> to see how this is
+            done.
+        </p>
+    </div>
+
+    <script src="../lib/ol/ol.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
+    <script>
+        Ext.Loader.setConfig({
+            enabled: true,
+            paths: {
+                'GeoExt': '../../src/'
+            }
+        });
+    </script>
+
+    <script src="stateful-map.js"></script>
+</body>
+</html>

--- a/examples/state/stateful-map.js
+++ b/examples/state/stateful-map.js
@@ -1,0 +1,102 @@
+Ext.require([
+    'Ext.panel.Panel',
+    'Ext.Viewport',
+    'GeoExt.state.PermalinkProvider',
+    'GeoExt.component.Map'
+]);
+
+var olMap;
+var mapComponent;
+var mapPanel;
+var permalinkProvider;
+
+Ext.application({
+    name: 'StatefulMap',
+    launch: function() {
+
+        // create permalink provider
+        permalinkProvider = Ext.create('GeoExt.state.PermalinkProvider');
+        // set it in the state manager
+        Ext.state.Manager.setProvider(permalinkProvider);
+
+        olMap = new ol.Map({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.Stamen({
+                        layer: 'watercolor'
+                    })
+                }),
+                new ol.layer.Tile({
+                    source: new ol.source.Stamen({
+                        layer: 'terrain-labels'
+                    })
+                })
+            ],
+            view: new ol.View({
+                center: [923938, 6346251],
+                zoom: 12
+            })
+        });
+
+        mapComponent = Ext.create('GeoExt.component.Map', {
+            map: olMap,
+            stateful: true,
+            stateId: 'gx_mapstate'
+        });
+
+        mapPanel = Ext.create('Ext.panel.Panel', {
+            title: 'GeoExt.state.PermalinkProvider Example',
+            region: 'center',
+            layout: 'fit',
+            items: [mapComponent]
+        });
+
+        var permalinkDisplayPanel = Ext.create('Ext.panel.Panel', {
+            title: 'Permalink',
+            region: 'south',
+            height: 100,
+            border: false,
+            bodyPadding: 5
+        });
+
+        var description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            title: 'Description',
+            region: 'east',
+            width: 300,
+            border: false,
+            bodyPadding: 5
+        });
+
+        Ext.create('Ext.Viewport', {
+            layout: 'border',
+            items: [
+                mapPanel,
+                description,
+                permalinkDisplayPanel
+            ]
+        });
+
+        if (window.location.hash !== '') {
+            mapComponent.applyState(
+                permalinkProvider.readPermalinkHash(window.location.hash)
+            );
+        }
+
+        // display permalink each time state is changed
+        permalinkProvider.on({
+            statechange: function(provider, name, value) {
+                // get the base URL without a hash
+                var base = window.location.href.split('#')[0];
+                // permalink hash from current state
+                var hash = provider.getPermalinkHash();
+                // assemble a permalink
+                var plink = Ext.urlAppend(base, hash);
+                permalinkDisplayPanel.setHtml(
+                    '<a href="' + plink + '" target="_blank">' + plink + '</a>'
+                );
+            }
+        });
+
+    }
+});

--- a/src/state/PermalinkProvider.js
+++ b/src/state/PermalinkProvider.js
@@ -1,0 +1,151 @@
+/* Copyright (c) 2015-2018 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * The permalink provider.
+ *
+ * Sample code displaying a new permalink each time the map is moved:
+ *
+ *     @example preview
+ *     // create permalink provider
+ *     var permalinkProvider = Ext.create('GeoExt.state.PermalinkProvider', {});
+ *     // set it in the state manager
+ *     Ext.state.Manager.setProvider(permalinkProvider);
+ *
+ *     // create a map panel, and make it stateful
+ *     var mapComponent = Ext.create('GeoExt.component.Map', {
+ *         stateful: true,
+ *         stateId: 'gx_mapstate',
+ *         map: new ol.Map({
+ *             layers: [
+ *                 new ol.layer.Tile({
+ *                     source: new ol.source.OSM()
+ *                 })
+ *             ],
+ *             view: new ol.View({
+ *                 center: ol.proj.fromLonLat([-8.751278, 40.611368]),
+ *                 zoom: 12
+ *             })
+ *         })
+ *     });
+ *     var mapPanel = Ext.create('Ext.panel.Panel', {
+ *         title: 'GeoExt.component.Map Example',
+ *         height: 200,
+ *         items: [mapComponent],
+ *         renderTo: Ext.getBody()
+ *     });
+ *     // display permalink hash each time state is changed
+ *     permalinkProvider.on({
+ *         statechange: function(provider, name, value) {
+ *             alert(provider.getPermalinkHash());
+ *         }
+ *     });
+ *
+ * @class GeoExt.state.PermalinkProvider
+ */
+Ext.define('GeoExt.state.PermalinkProvider', {
+    extend: 'Ext.state.Provider',
+    requires: [],
+
+    alias: 'state.gx_permalinkprovider',
+
+    /**
+     * Current map state object.
+     *
+     * @property {Object}
+     * @private
+     */
+    mapState: null,
+
+    constructor: function() {
+        var me = this;
+
+        me.callParent(arguments);
+
+        if (window.location.hash !== '') {
+            me.mapState = me.readPermalinkHash(window.location.hash);
+        }
+    },
+
+    /**
+     * Create a state object from a URL hash.
+     * The hash to be in the form `#map=12/-1035528.44/7073659.19/0`
+     *
+     * @param {String} plHash The URL hash to get the state from
+     * @return {Object} The state object
+     * @private
+     */
+    readPermalinkHash: function(plHash) {
+        var mapState;
+        // try to restore center, zoom-level and rotation from the URL
+        var hash = plHash.replace('#map=', '');
+        var parts = hash.split('/');
+
+        if (parts.length === 4) {
+            mapState = {
+                zoom: parseInt(parts[0], 10),
+                center: [
+                    parseFloat(parts[1]),
+                    parseFloat(parts[2])
+                ],
+                rotation: parseFloat(parts[3])
+            };
+        }
+
+        return mapState;
+    },
+
+    /**
+     * Returns the URL hash part with current zoom-level, center and rotation
+     * corresponding to the current state.
+     *
+     * @param {Boolean} doRound Flag if coords should be rounded to 2
+     *     digits or not
+     * @return {String} The hash part of the permalink
+     */
+    getPermalinkHash: function(doRound) {
+        var me = this;
+        var mapState = me.mapState;
+
+        var centerX = mapState.center[0];
+        var centerY = mapState.center[1];
+        if (doRound) {
+            centerX = Math.round(centerX * 100) / 100;
+            centerY = Math.round(centerY * 100) / 100;
+        }
+
+        var hash = '#map=' +
+            mapState.zoom + '/' +
+            centerX + '/' +
+            centerY + '/' +
+            mapState.rotation;
+
+        return hash;
+    },
+
+    /**
+     * Sets the value for a key.
+     *
+     * @param {String} name The key name
+     * @param {Object} value The value to set
+     */
+    set: function(name, value) {
+        var me = this;
+        // keep our mapState object in sync with the state
+        me.mapState = value;
+        // call 'set' of super class
+        me.callParent(arguments);
+    }
+});

--- a/test/index.html
+++ b/test/index.html
@@ -57,6 +57,7 @@
   <script src='spec/GeoExt/data/store/OlObjects.test.js'></script>
   <script src='spec/GeoExt/grid/column/Symbolizer.test.js'></script>
   <script src='spec/GeoExt/mixin/SymbolCheck.test.js'></script>
+  <script src='spec/GeoExt/state/PermalinkProvider.test.js'></script>
   <script src='spec/GeoExt/util/Layer.test.js'></script>
   <script>
     mocha.run();

--- a/test/spec/GeoExt/state/PermalinkProvider.test.js
+++ b/test/spec/GeoExt/state/PermalinkProvider.test.js
@@ -1,0 +1,97 @@
+Ext.Loader.syncRequire(['GeoExt.state.PermalinkProvider']);
+
+describe('GeoExt.state.PermalinkProvider', function() {
+
+    describe('basics', function() {
+        it('GeoExt.state.PermalinkProvider is defined', function() {
+            expect(GeoExt.state.PermalinkProvider).not.to.be(undefined);
+        });
+
+        describe('constructor', function() {
+            it('can be constructed wo/ arguments via Ext.create()', function() {
+                var plProvider = Ext.create('GeoExt.state.PermalinkProvider');
+                expect(plProvider).to.be.an(GeoExt.state.PermalinkProvider);
+            });
+        });
+    });
+
+    describe('public functions', function() {
+        var plProvider;
+
+        beforeEach(function() {
+            plProvider = Ext.create('GeoExt.state.PermalinkProvider');
+        });
+
+        afterEach(function() {
+            plProvider.destroy();
+        });
+        describe('readPermalinkHash()', function() {
+
+            it('returns a correct state object',
+                function() {
+                    var state = plProvider.readPermalinkHash(
+                        '#map=8/-1061011/6804570.83/0');
+                    expect(state).to.be.an(Object);
+                    expect(state.zoom).to.be(8);
+                    expect(state.center).to.be.an(Array);
+                    expect(state.center[0]).to.be(-1061011);
+                    expect(state.center[1]).to.be(6804570.83);
+                    expect(state.rotation).to.be(0);
+                }
+            );
+
+        });
+
+        describe('getPermalinkHash()', function() {
+
+            it('returns a correct URL hash',
+                function() {
+                    var state = {
+                        zoom: 8,
+                        center: [-1061011.123456, 6804570.9876],
+                        rotation: 0
+                    };
+                    plProvider.mapState = state;
+
+                    var hash = plProvider.getPermalinkHash();
+                    expect(hash).to.be('#map=8/-1061011.123456/6804570.9876/0');
+                }
+            );
+
+            it('rounds the coordinates if correspondig param is set',
+                function() {
+                    var state = {
+                        zoom: 8,
+                        center: [-1061011.123456, 6804570.9876],
+                        rotation: 0
+                    };
+                    plProvider.mapState = state;
+
+                    var hash = plProvider.getPermalinkHash(true);
+                    expect(hash).to.be('#map=8/-1061011.12/6804570.99/0');
+                }
+            );
+
+        });
+
+        describe('set()', function() {
+
+            it('keep our mapState object in sync with the state',
+                function() {
+                    var state = {
+                        zoom: 8,
+                        center: [-1061011.123456, 6804570.9876],
+                        rotation: 0
+                    };
+                    plProvider.set('foo', state);
+
+                    // var hash = plProvider.getPermalinkHash();
+                    expect(plProvider.mapState).to.be(state);
+                }
+            );
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
This adds an implementation of `Ext.state.Provider` to manage the app's map state and to (de)serialize it as URL hash. Currently the following properties are managed:

- Map Zoom (`zoom`)
- Map Center (`center`)
- Map Rotation (`rotation`)