### PR TITLE
Add iconCls to LayerTreeNode model as field

### DIFF
--- a/src/data/model/LayerTreeNode.js
+++ b/src/data/model/LayerTreeNode.js
@@ -54,6 +54,12 @@ Ext.define('GeoExt.data.model.LayerTreeNode', {
         name: '__toggleMode',
         type: 'string',
         defaultValue: 'classic'
+    }, {
+        name: 'iconCls',
+        type: 'string',
+        convert: function(v, record) {
+            return record.getOlLayerProp('iconCls');
+        }
     }],
 
     proxy: {


### PR DESCRIPTION
This adds another field `'iconCls'` to the fields of `LayerTreeNode` model class (`GeoExt.data.model.LayerTreeNode`). The value is derived from the underlying OL-object.
`'iconCls'` is normally used to influence the rendered icon of the `LayerTreeNode`.