### PR TITLE
Encode icons as data uri

### DIFF
--- a/src/data/serializer/Vector.js
+++ b/src/data/serializer/Vector.js
@@ -392,9 +392,16 @@ Ext.define('GeoExt.data.serializer.Vector', {
             } else if (imageStyle instanceof ol.style.Icon) {
                 var src = imageStyle.getSrc();
                 if (Ext.isDefined(src)) {
+                    var img = imageStyle.getImage();
+                    var canvas = document.createElement('canvas');
+                    canvas.width = img.naturalWidth;
+                    canvas.height = img.naturalHeight;
+                    canvas.getContext('2d').drawImage(img, 0, 0);
+                    var format = 'image/' + src.match(/\.(\w+)$/)[1];
                     symbolizer = {
                         type: 'point',
-                        externalGraphic: src
+                        externalGraphic: canvas.toDataURL(),
+                        graphicFormat: format
                     };
                     var rotation = imageStyle.getRotation();
                     if (rotation !== 0) {


### PR DESCRIPTION
Since loaded images are not necessarily requestable/accessible by the print service this PR encodes icons as data urls.

@terrestris/devs Please review.
