### PR TITLE
Allow creation of LayerStore with layer collection 

### DIFF
--- a/src/data/store/Layers.js
+++ b/src/data/store/Layers.js
@@ -14,8 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * A store that synchronizes a layers array of an OpenLayers.Map with a
- * layer store holding GeoExt.data.model.layer.Base instances.
+ * A store that synchronizes a collection of layers (e.g. of an OpenLayers.Map)
+ * with a layer store holding GeoExt.data.model.Layer instances.
  *
  * @class GeoExt.data.store.Layers
  */
@@ -52,14 +52,14 @@ Ext.define('GeoExt.data.store.Layers', {
 
     config: {
         /**
-         * A configured map or a configuration object for the map constructor.
+         * An OL map instance, whose layers will be managed by the store.
          *
-         * @cfg {ol.Map/Object} map
+         * @cfg {ol.Map} map
          */
         map: null,
 
         /**
-         * A configured map or a configuration object for the map constructor.
+         * A collection of OL layer objects, which will be managed by the store.
          *
          * @cfg {ol.Collection<ol.layer.Base>} layers
          */

--- a/src/data/store/Layers.js
+++ b/src/data/store/Layers.js
@@ -56,7 +56,14 @@ Ext.define('GeoExt.data.store.Layers', {
          *
          * @cfg {ol.Map/Object} map
          */
-        map: null
+        map: null,
+
+        /**
+         * A configured map or a configuration object for the map constructor.
+         *
+         * @cfg {ol.Collection<ol.layer.Base>} layers
+         */
+        layers: null
     },
 
     /**
@@ -71,34 +78,39 @@ Ext.define('GeoExt.data.store.Layers', {
 
         if (config.map) {
             this.bindMap(config.map);
+        } else if (config.layers) {
+            this.bindLayers(config.layers);
         }
     },
 
     /**
-     * Bind this store to a map instance; once bound, the store is synchronized
-     * with the map and vice-versa.
+     * Bind this store to a collection of layers; once bound, the store is
+     * synchronized with the layer collection and vice-versa.
      *
-     * @param {ol.Map} map The map instance.
+     * @param  {ol.Collection<ol.layer.Base>} layers The layer collection.
+     * @param  {ol.Map} map Optional map from which the layers were derived
      */
-    bindMap: function(map) {
+    bindLayers: function(layers, map) {
         var me = this;
 
-        if (!me.map) {
-            me.map = map;
+        if (!me.layers) {
+            me.layers = layers;
         }
 
-        if (map instanceof ol.Map) {
-            var mapLayers = map.getLayers();
-            mapLayers.forEach(function(layer) {
-                me.loadRawData(layer, true);
-            });
-
-            mapLayers.forEach(function(layer) {
-                layer.on('propertychange', me.onChangeLayer, me);
-            });
-            mapLayers.on('add', me.onAddLayer, me);
-            mapLayers.on('remove', me.onRemoveLayer, me);
+        if (me.layers instanceof ol.layer.Group) {
+            me.layers = me.layers.getLayers();
         }
+
+        var mapLayers = me.layers;
+        mapLayers.forEach(function(layer) {
+            me.loadRawData(layer, true);
+        });
+
+        mapLayers.forEach(function(layer) {
+            layer.on('propertychange', me.onChangeLayer, me);
+        });
+        mapLayers.on('add', me.onAddLayer, me);
+        mapLayers.on('remove', me.onRemoveLayer, me);
 
         me.on({
             'load': me.onLoad,
@@ -117,14 +129,33 @@ Ext.define('GeoExt.data.store.Layers', {
     },
 
     /**
-     * Unbind this store from the map it is currently bound.
+     * Bind this store to a map instance; once bound, the store is synchronized
+     * with the map and vice-versa.
+     *
+     * @param {ol.Map} map The map instance.
      */
-    unbindMap: function() {
+    bindMap: function(map) {
         var me = this;
 
-        if (me.map && me.map.getLayers()) {
-            me.map.getLayers().un('add', me.onAddLayer, me);
-            me.map.getLayers().un('remove', me.onRemoveLayer, me);
+        if (!me.map) {
+            me.map = map;
+        }
+
+        if (map instanceof ol.Map) {
+            var mapLayers = map.getLayers();
+            me.bindLayers(mapLayers, map);
+        }
+    },
+
+    /**
+     * Unbind this store from the layer collection it is currently bound.
+     */
+    unbindLayers: function() {
+        var me = this;
+
+        if (me.layers) {
+            me.layers.un('add', me.onAddLayer, me);
+            me.layers.un('remove', me.onRemoveLayer, me);
         }
         me.un('load', me.onLoad, me);
         me.un('clear', me.onClear, me);
@@ -133,6 +164,15 @@ Ext.define('GeoExt.data.store.Layers', {
         me.un('update', me.onStoreUpdate, me);
 
         me.data.un('replace', me.onReplace, me);
+    },
+
+    /**
+     * Unbind this store from the map it is currently bound.
+     */
+    unbindMap: function() {
+        var me = this;
+
+        me.unbindLayers();
 
         me.map = null;
     },
@@ -168,7 +208,7 @@ Ext.define('GeoExt.data.store.Layers', {
      */
     onAddLayer: function(evt) {
         var layer = evt.element;
-        var index = this.map.getLayers().getArray().indexOf(layer);
+        var index = this.layers.getArray().indexOf(layer);
         var me = this;
         layer.on('propertychange', me.onChangeLayer, me);
         if (!me._adding) {
@@ -215,10 +255,10 @@ Ext.define('GeoExt.data.store.Layers', {
             }
             if (!me._addRecords) {
                 me._removing = true;
-                me.map.getLayers().forEach(function(layer) {
+                me.layers.forEach(function(layer) {
                     layer.un('propertychange', me.onChangeLayer, me);
                 });
-                me.map.getLayers().clear();
+                me.layers.getLayers().clear();
                 delete me._removing;
             }
             var len = records.length;
@@ -229,7 +269,7 @@ Ext.define('GeoExt.data.store.Layers', {
                     layers[i].on('propertychange', me.onChangeLayer, me);
                 }
                 me._adding = true;
-                me.map.getLayers().extend(layers);
+                me.layers.extend(layers);
                 delete me._adding;
             }
         }
@@ -244,10 +284,10 @@ Ext.define('GeoExt.data.store.Layers', {
     onClear: function() {
         var me = this;
         me._removing = true;
-        me.map.getLayers().forEach(function(layer) {
+        me.layers.forEach(function(layer) {
             layer.un('propertychange', me.onChangeLayer, me);
         });
-        me.map.getLayers().clear();
+        me.layers.clear();
         delete me._removing;
     },
 
@@ -270,9 +310,9 @@ Ext.define('GeoExt.data.store.Layers', {
                 layer = records[i].getOlLayer();
                 layer.on('propertychange', me.onChangeLayer, me);
                 if (index === 0) {
-                    me.map.getLayers().push(layer);
+                    me.layers.push(layer);
                 } else {
-                    me.map.getLayers().insertAt(index, layer);
+                    me.layers.insertAt(index, layer);
                 }
             }
             delete me._adding;
@@ -307,7 +347,7 @@ Ext.define('GeoExt.data.store.Layers', {
                 layer = record.getOlLayer();
                 found = false;
                 layer.un('propertychange', me.onChangeLayer, me);
-                me.map.getLayers().forEach(compareFunc);
+                me.layers.forEach(compareFunc);
                 if (found) {
                     me._removing = true;
                     me.removeMapLayer(record);
@@ -345,7 +385,7 @@ Ext.define('GeoExt.data.store.Layers', {
      * @private
      */
     removeMapLayer: function(record) {
-        this.map.getLayers().remove(record.getOlLayer());
+        this.layers.remove(record.getOlLayer());
     },
 
     /**

--- a/test/spec/GeoExt/data/store/Layers.test.js
+++ b/test/spec/GeoExt/data/store/Layers.test.js
@@ -8,11 +8,35 @@ describe('GeoExt.data.store.Layers', function() {
         });
 
         describe('constructor', function() {
-            it('throws if no map component provided', function() {
+            it('throws if no map component or layers are provided', function() {
                 expect(function() {
                     Ext.create('GeoExt.data.store.Layers');
                 }).to.throwException();
             });
+        });
+    });
+
+    describe('function "bindLayers"', function() {
+        var store;
+        var map;
+        beforeEach(function() {
+            var layer = new ol.layer.Vector();
+            map = new ol.Map({
+                layers: [layer]
+            });
+            store =
+              Ext.create('GeoExt.data.store.Layers', {layers: map.getLayers()});
+        });
+
+        it('exists', function() {
+            expect(store.bindLayers).not.to.be(undefined);
+        });
+
+        it('couples store to layer collection', function() {
+            var newLayer = new ol.layer.Vector();
+            map.getLayers().push(newLayer);
+            expect(map.getLayers().getLength()).to.be(2);
+            expect(store.getCount()).to.be(2);
         });
     });
 
@@ -33,6 +57,31 @@ describe('GeoExt.data.store.Layers', function() {
 
         it('applies the map correctly', function() {
             expect(store.map).to.be(map);
+        });
+    });
+
+    describe('function "unbindLayers"', function() {
+        var store;
+        var map;
+        beforeEach(function() {
+            var layer = new ol.layer.Vector();
+            map = new ol.Map({
+                layers: [layer]
+            });
+            store =
+              Ext.create('GeoExt.data.store.Layers', {layers: map.getLayers()});
+        });
+
+        it('exists', function() {
+            expect(store.unbindLayers).not.to.be(undefined);
+        });
+
+        it('decouples store from layer collection', function() {
+            store.unbindLayers();
+            var newLayer = new ol.layer.Vector();
+            map.getLayers().push(newLayer);
+            expect(map.getLayers().getLength()).to.be(2);
+            expect(store.getCount()).to.be(1);
         });
     });
 

--- a/test/spec/GeoExt/data/store/Layers.test.js
+++ b/test/spec/GeoExt/data/store/Layers.test.js
@@ -183,6 +183,76 @@ describe('GeoExt.data.store.Layers', function() {
             });
         });
 
+        describe('"clear" event', function() {
+            var store;
+            var map;
+            beforeEach(function() {
+                var layer = new ol.layer.Vector();
+                map = new ol.Map({
+                    layers: [layer]
+                });
+
+                store = Ext.create('GeoExt.data.store.Layers', {
+                    map: map
+                });
+            });
+
+            it('clears the store and the layer collection', function() {
+                store.removeAll();
+                expect(store.getCount()).to.be(0);
+                expect(map.getLayers().getLength()).to.be(0);
+            });
+        });
+
+        describe('"add" event', function() {
+            var store;
+            var map;
+            beforeEach(function() {
+                var layer = new ol.layer.Vector();
+                map = new ol.Map({
+                    layers: [layer]
+                });
+
+                store = Ext.create('GeoExt.data.store.Layers', {
+                    map: map
+                });
+            });
+
+            it('adds the layer to layer collection', function() {
+                var newLayer = new ol.layer.Vector();
+                var layerRec = Ext.create('GeoExt.data.model.Layer', newLayer);
+                store.add(layerRec);
+                expect(store.getCount()).to.be(2);
+                expect(map.getLayers().getLength()).to.be(2);
+            });
+        });
+
+        describe('"remove" event', function() {
+            var store;
+            var map;
+            var layer;
+            var layer2;
+            beforeEach(function() {
+                layer = new ol.layer.Vector();
+                layer2 = new ol.layer.Vector();
+                map = new ol.Map({
+                    layers: [layer, layer2]
+                });
+
+                store = Ext.create('GeoExt.data.store.Layers', {
+                    map: map
+                });
+            });
+
+            it('removes the layer from layer collection', function() {
+                var layerRec = store.getByLayer(layer);
+                store.remove(layerRec);
+                expect(store.getCount()).to.be(1);
+                expect(map.getLayers().getLength()).to.be(1);
+                expect(map.getLayers().getArray()[0]).to.be(layer2);
+            });
+        });
+
     });
 
 });


### PR DESCRIPTION
This allows the creation of a `LayerStore` instance with a collection of OpenLayers layers (`ol.Collection.<ol.layer.Base>`). So there is no need to pass a complete map object, from which the layers are derived. This can be useful for several use cases, where just a subset of layers has to be manged by the store.
The old behaviour by creating with an OpenLayers map instance is still possible.