### PR TITLE
Introducing the OGCFilter util

### DIFF
--- a/examples/features/grid-filter.html
+++ b/examples/features/grid-filter.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Feature Grid with filtering Example</title>
+    <link rel="stylesheet" type="text/css" href="../lib/ol/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
+</head>
+
+<body>
+
+    <div id='description'>
+        <p>
+            This example shows how to use the util `OGCFilter`, which helps to synchronize
+            your map layers and feature-grid while using filters on the grid.<br>
+            The util generates OGC compliant filters that can be attached to WMS
+            or WFS requests in order to filter the map layers content in sync
+            with the grid. Have a look at the `filterchange` listener to see the magic.
+            <br><br>
+            The map contains three layers for showcase reasons:<br>
+            1.) A vectorlayer that is connected with the featuregrid and the map<br>
+            2.) A WFS vectorlayer which gets filtered through an OGC-Filter which
+                is derived from the utils `buildWfsGetFeatureWithFilter` method<br>
+            3.) A WMS layer which gets filtered through an OGC-Filter which
+                is derived from the utils `getOGCWMSFilterFromExtJSFilter` method
+        </p>
+        <p>
+            Have a look at <a href="grid-filter.js">grid-filter.js</a> to see how this is
+            done.
+        </p>
+    </div>
+
+    <script src="../lib/ol/ol.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
+    <script>
+        Ext.Loader.setConfig({
+            enabled: true,
+            paths: {
+                'GeoExt': '../../src/'
+            }
+        });
+    </script>
+
+    <script src="grid-filter.js"></script>
+</body>
+</html>

--- a/examples/features/grid-filter.js
+++ b/examples/features/grid-filter.js
@@ -1,0 +1,241 @@
+Ext.require([
+    'Ext.container.Container',
+    'Ext.panel.Panel',
+    'Ext.grid.Panel',
+    'GeoExt.component.Map',
+    'GeoExt.data.store.Features',
+    'GeoExt.util.OGCFilter'
+]);
+
+var olMap;
+var gridWest;
+var featStore;
+var vectorSource;
+var wfsSource;
+var wmsLayer;
+var wfsGetFeatureFilter;
+
+Ext.application({
+    name: 'FeatureGridWithFilter',
+    launch: function() {
+
+        // prepare the vector layer which will be used
+        // in the featuregrid and on the map
+        vectorSource = new ol.source.Vector({
+            format: new ol.format.GeoJSON({
+                featureProjection: 'EPSG:3857'
+            })
+        });
+        var vectorLayer = new ol.layer.Vector({
+            source: vectorSource
+        });
+
+        // prepare the wfs layer just to show that its also supported
+        wfsSource = new ol.source.Vector({
+            format: new ol.format.GeoJSON({
+                featureProjection: 'EPSG:3857'
+            }),
+            // the loader will load all features via `GET` per default.
+            // If a filter is set, request will change to
+            // `POST` with valid OGC filter
+            loader: function() {
+                var url = 'https://maps.dwd.de/geoserver/dwd/ows?';
+                var params = 'service=WFS&' +
+                    'version=2.0.0&' +
+                    'request=GetFeature&' +
+                    'typeName=dwd:Warngebiete_Kreise&' +
+                    'outputFormat=application/json';
+                var xhr = new XMLHttpRequest();
+                xhr.onload = function() {
+                    if (xhr.status == 200) {
+                        wfsSource.addFeatures(
+                            wfsSource.getFormat().readFeatures(
+                                xhr.responseText));
+                    }
+                };
+                if (wfsGetFeatureFilter) {
+                    params += '&filter=' + wfsGetFeatureFilter;
+                    xhr.open('POST', url);
+                    xhr.setRequestHeader(
+                        'Content-type',
+                        'application/x-www-form-urlencoded'
+                    );
+                    xhr.send(params);
+                } else {
+                    xhr.open('GET', url + params);
+                    xhr.send();
+                }
+            }
+        });
+        var wfsLayer = new ol.layer.Vector({
+            source: wfsSource,
+            style: new ol.style.Style({
+                stroke: new ol.style.Stroke({
+                    color: 'rgba(255, 255, 0, 1.0)',
+                    width: 2
+                })
+            })
+        });
+
+        // fetch the data for the vector layer
+        this.getData(vectorLayer.getSource());
+
+        // also add an WMS layer to show the support
+        // via `filter` request parameter
+        wmsLayer = new ol.layer.Tile({
+            source: new ol.source.TileWMS({
+                url: 'https://maps.dwd.de/geoserver/dwd/ows?',
+                params: {
+                    'LAYERS': 'dwd:Warngebiete_Kreise',
+                    'TILED': true
+                },
+                attributions: [new ol.Attribution({
+                    html: '<a href="https://www.dwd.de">' +
+                      'Copyright: © Deutscher Wetterdienst</a>'
+                })]
+            })
+        });
+
+        olMap = new ol.Map({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.TileWMS({
+                        url: 'https://ows.terrestris.de/osm-gray/service',
+                        params: {'LAYERS': 'OSM-WMS', 'TILED': true},
+                        attributions: [new ol.Attribution({
+                            html: '<a href="https://www.openstreetmap.org/' +
+                            'copyright">OpenStreetMap contributors</a>'
+                        })]
+                    })
+                }),
+                wmsLayer,
+                wfsLayer,
+                vectorLayer
+            ],
+            view: new ol.View({
+                center: ol.proj.fromLonLat([8, 50]),
+                zoom: 5
+            })
+        });
+
+        // create feature store by passing a layer
+        featStore = Ext.create('GeoExt.data.store.Features', {
+            model: 'GeoExt.data.model.Feature',
+            layer: vectorLayer,
+            passThroughFilter: true
+        });
+
+        // create the feature grid
+        gridWest = Ext.create('Ext.grid.Panel', {
+            title: 'Feature Grid with selection',
+            border: true,
+            region: 'west',
+            store: featStore,
+            plugins: 'gridfilters',
+            columns: [
+                {
+                    text: 'List',
+                    dataIndex: 'WARNCELLID',
+                    flex: 1,
+                    filter: {
+                        type: 'list'
+                    }
+                },
+                {
+                    text: 'String',
+                    dataIndex: 'NAME',
+                    flex: 2,
+                    filter: {
+                        type: 'string'
+                    }
+                },
+                {
+                    text: 'Number',
+                    dataIndex: 'WARNCELLID',
+                    flex: 2,
+                    filter: {
+                        type: 'number'
+                    }
+                },
+                {
+                    text: 'Date',
+                    xtype: 'datecolumn',
+                    formatter: 'date("Y-m-d")',
+                    dataIndex: 'PROCESSTIME',
+                    flex: 2,
+                    filter: {
+                        type: 'date',
+                        dateFormat: 'Y-m-d'
+                    }
+                }
+            ],
+            width: 500,
+            listeners: {
+                'filterchange': function(rec, filters) {
+                    var wmsFilter = GeoExt.util.OGCFilter.
+                        getOGCWMSFilterFromExtJSFilter(filters);
+                    wmsLayer.getSource().updateParams({
+                        filter: wmsFilter,
+                        cacheBuster: Math.random()
+                    });
+                    wfsGetFeatureFilter = GeoExt.util.OGCFilter.
+                        getOGCWFSFilterFromExtJSFilter(filters, 'And', '2.0.0');
+                    wfsLayer.getSource().clear();
+                    wfsLayer.getSource().refresh();
+                }
+            }
+        });
+        var mapComponent = Ext.create('GeoExt.component.Map', {
+            map: olMap
+        });
+        var mapPanel = Ext.create('Ext.panel.Panel', {
+            region: 'center',
+            height: 400,
+            layout: 'fit',
+            items: [mapComponent]
+        });
+        var description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            region: 'north',
+            title: 'Description',
+            height: 230,
+            border: false,
+            bodyPadding: 5,
+            autoScroll: true
+        });
+        Ext.create('Ext.Viewport', {
+            layout: 'border',
+            items: [description, mapPanel, gridWest]
+        });
+    },
+
+    /**
+     * Loads the data for the initial fill of vectorlayer / grid
+     * @param {ol.source.Vector} vectorSource The vector source
+     */
+    getData: function(vectorSource) {
+        Ext.Ajax.request({
+            method: 'POST',
+            url: 'https://maps.dwd.de/geoserver/dwd/ows?',
+            params: {
+                service: 'WFS',
+                version: '1.0.0',
+                request: 'GetFeature',
+                typeName: 'dwd:Warngebiete_Kreise',
+                outputFormat: 'application/json'
+            },
+            success: function(response) {
+                var geojson = Ext.decode(response.responseText);
+                var gjFormat = new ol.format.GeoJSON({
+                    featureProjection: 'EPSG:3857'
+                });
+                var features = gjFormat.readFeatures(geojson);
+                // mockup some real dates
+                features.forEach(function(f) {
+                    f.set('PROCESSTIME', new Date(f.get('PROCESSTIME')));
+                });
+                vectorSource.addFeatures(features);
+            }
+        });
+    }
+});

--- a/examples/features/grid-filter.js
+++ b/examples/features/grid-filter.js
@@ -45,26 +45,21 @@ Ext.application({
                     'request=GetFeature&' +
                     'typeName=dwd:Warngebiete_Kreise&' +
                     'outputFormat=application/json';
-                var xhr = new XMLHttpRequest();
-                xhr.onload = function() {
-                    if (xhr.status == 200) {
+                var method = 'GET';
+                if (wfsGetFeatureFilter) {
+                    method = 'POST';
+                    params += '&filter=' + wfsGetFeatureFilter;
+                }
+                Ext.Ajax.request({
+                    method: method,
+                    url: url,
+                    params: params,
+                    success: function(response) {
                         wfsSource.addFeatures(
                             wfsSource.getFormat().readFeatures(
-                                xhr.responseText));
+                                response.responseText));
                     }
-                };
-                if (wfsGetFeatureFilter) {
-                    params += '&filter=' + wfsGetFeatureFilter;
-                    xhr.open('POST', url);
-                    xhr.setRequestHeader(
-                        'Content-type',
-                        'application/x-www-form-urlencoded'
-                    );
-                    xhr.send(params);
-                } else {
-                    xhr.open('GET', url + params);
-                    xhr.send();
-                }
+                });
             }
         });
         var wfsLayer = new ol.layer.Vector({
@@ -173,13 +168,13 @@ Ext.application({
             listeners: {
                 'filterchange': function(rec, filters) {
                     var wmsFilter = GeoExt.util.OGCFilter.
-                        getOGCWMSFilterFromExtJSFilter(filters);
+                        getOgcWmsFilterFromExtJsFilter(filters);
                     wmsLayer.getSource().updateParams({
                         filter: wmsFilter,
                         cacheBuster: Math.random()
                     });
                     wfsGetFeatureFilter = GeoExt.util.OGCFilter.
-                        getOGCWFSFilterFromExtJSFilter(filters, 'And', '2.0.0');
+                        getOgcWfsFilterFromExtJsFilter(filters, 'And', '2.0.0');
                     wfsLayer.getSource().clear();
                     wfsLayer.getSource().refresh();
                 }

--- a/src/util/OGCFilter.js
+++ b/src/util/OGCFilter.js
@@ -73,41 +73,41 @@ Ext.define('GeoExt.util.OGCFilter', {
 
 
         /**
-         * Given an array of ExtJS Filters, this method will return an OGC
+         * Given an array of ExtJS grid-filters, this method will return an OGC
          * compliant filter which can be used for WMS requests
-         * @param {array} filters array containing all `Ext.grid.filters.filter`
-         *   that should be converted
+         * @param {Ext.grid.filters.filter[]} filters array containing all
+         *   `Ext.grid.filters.filter` that should be converted
          * @param {string} combinator The combinator used for combining multiple
          *   filters. Can be 'and' or 'or'
          * @return {string} The OGC Filter XML
          */
-        getOGCWMSFilterFromExtJSFilter: function(filters, combinator) {
-            return GeoExt.util.OGCFilter.getOGCFilterFromExtJSFilter(
+        getOgcWmsFilterFromExtJsFilter: function(filters, combinator) {
+            return GeoExt.util.OGCFilter.getOgcFilterFromExtJsFilter(
                 filters, 'wms', combinator);
         },
 
         /**
-         * Given an array of ExtJS Filters, this method will return an OGC
+         * Given an array of ExtJS grid-filters, this method will return an OGC
          * compliant filter which can be used for WFS requests
-         * @param {array} filters array containing all `Ext.grid.filters.filter`
-         *   that should be converted
+         * @param {Ext.grid.filters.filter[]} filters array containing all
+         *   `Ext.grid.filters.filter` that should be converted
          * @param {string} combinator The combinator used for combining multiple
          *   filters. Can be 'and' or 'or'
          * @param {string} wfsVersion The WFS version to use, either `1.0.0`,
          *   `1.1.0` or `2.0.0`
          * @return {string} The OGC Filter XML
          */
-        getOGCWFSFilterFromExtJSFilter: function(filters, combinator,
+        getOgcWfsFilterFromExtJsFilter: function(filters, combinator,
             wfsVersion) {
-            return GeoExt.util.OGCFilter.getOGCFilterFromExtJSFilter(
+            return GeoExt.util.OGCFilter.getOgcFilterFromExtJsFilter(
                 filters, 'wfs', combinator, wfsVersion);
         },
 
         /**
-         * Given an ExtJS Filter, this method will return an OGC compliant
+         * Given an ExtJS grid-filter, this method will return an OGC compliant
          * filter which can be used for WMS or WFS queries
-         * @param {array} filters array containing all `Ext.grid.filters.filter`
-         *   that should be converted
+         * @param {Ext.grid.filters.filter[]} filters array containing all
+         *   `Ext.grid.filters.filter` that should be converted
          * @param {string} type The OGC type we will be using, can be
          *   `wms` or `wfs`
          * @param {string} combinator The combinator used for combining multiple
@@ -116,7 +116,7 @@ Ext.define('GeoExt.util.OGCFilter', {
          *   `1.1.0` or `2.0.0`
          * @return {string} the OGC Filter as XML tring
          */
-        getOGCFilterFromExtJSFilter: function(filters, type, combinator,
+        getOgcFilterFromExtJsFilter: function(filters, type, combinator,
             wfsVersion) {
             if (!Ext.isDefined(filters) || !Ext.isArray(filters)) {
                 Ext.Logger.error('Invalid filter argument given to ' +
@@ -132,9 +132,15 @@ Ext.define('GeoExt.util.OGCFilter', {
             }
             var ogcFilters = [];
             Ext.each(filters, function(filter) {
-                var property = filter.config.property;
-                var operator = filter.config.operator;
+                var property = filter.getProperty();
+                var operator = filter.getOperator();
                 var value = filter.getValue();
+                if (Ext.isEmpty(property) || Ext.isEmpty(operator) ||
+                    Ext.isEmpty(value)) {
+                    Ext.Logger.warn('Skipping a filter as some values ' +
+                        'seem to be undefined');
+                    return;
+                }
                 if (filter.isDateValue) {
                     if (filter.getDateFormat) {
                         value = Ext.Date.format(
@@ -144,12 +150,6 @@ Ext.define('GeoExt.util.OGCFilter', {
                     } else {
                         value = Ext.Date.format(filter.getValue(), 'Y-m-d');
                     }
-                }
-                if (Ext.isEmpty(property) || Ext.isEmpty(operator) ||
-                    Ext.isEmpty(value)) {
-                    Ext.Logger.warn('Skipping a filter as some values ' +
-                        'seem to be undefined');
-                    return;
                 }
                 ogcFilters.push(GeoExt.util.OGCFilter.getOgcFilter(
                     property, operator, value, wfsVersion));
@@ -162,8 +162,8 @@ Ext.define('GeoExt.util.OGCFilter', {
         /**
          * Returns a GetFeature XML body containing the filters
          * which can be used to directly request the features
-         * @param {array} filters array containing all `Ext.grid.filters.filter`
-         *   that should be converted
+         * @param {Ext.grid.filters.filter[]} filters array containing all
+         *   `Ext.grid.filters.filter` that should be converted
          * @param {string} combinator The combinator used for combining multiple
          *   filters. Can be 'and' or 'or'
          * @param {string} wfsVersion The WFS version to use, either `1.0.0`,
@@ -173,7 +173,7 @@ Ext.define('GeoExt.util.OGCFilter', {
          */
         buildWfsGetFeatureWithFilter: function(filters, combinator, wfsVersion,
             typeName) {
-            var filter = GeoExt.util.OGCFilter.getOGCWFSFilterFromExtJSFilter(
+            var filter = GeoExt.util.OGCFilter.getOgcWfsFilterFromExtJsFilter(
                 filters, combinator, wfsVersion);
             var tpl = GeoExt.util.OGCFilter.wfs100GetFeatureXmlTpl;
             if (wfsVersion && wfsVersion === '1.1.0') {
@@ -190,12 +190,12 @@ Ext.define('GeoExt.util.OGCFilter', {
 
         /**
          * Returns an OGC filter for the given parameters.
-         * @param {String} property The property to filter on
-         * @param {String} operator The operator to use
+         * @param {string} property The property to filter on
+         * @param {string} operator The operator to use
          * @param {*} value The value for the filter
          * @param {string} wfsVersion The WFS version to use, either `1.0.0`,
          *   `1.1.0` or `2.0.0`
-         * @return {String} The OGC filter.
+         * @return {string} The OGC filter.
          */
         getOgcFilter: function(property, operator, value, wfsVersion) {
             if (Ext.isEmpty(property) || Ext.isEmpty(operator) ||

--- a/src/util/OGCFilter.js
+++ b/src/util/OGCFilter.js
@@ -1,0 +1,328 @@
+/* Copyright (c) 2015-2019 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * A utility class for converting ExtJS filters to OGC compliant filters
+ *
+ * @class GeoExt.util.OGCFilter
+ */
+Ext.define('GeoExt.util.OGCFilter', {
+    statics: {
+
+        /**
+         * The WFS 1.0.0 GetFeature XML body template
+         */
+        wfs100GetFeatureXmlTpl:
+            '<wfs:GetFeature service="WFS" version="1.0.0"' +
+                ' outputFormat="JSON"' +
+                ' xmlns:wfs="http://www.opengis.net/wfs"' +
+                ' xmlns="http://www.opengis.net/ogc"' +
+                ' xmlns:gml="http://www.opengis.net/gml"' +
+                ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+                ' xsi:schemaLocation="http://www.opengis.net/wfs' +
+                ' http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd">' +
+                '<wfs:Query typeName="{0}">{1}' +
+                '</wfs:Query>' +
+            '</wfs:GetFeature>',
+
+        /**
+         * The WFS 1.1.0 GetFeature XML body template
+         */
+        wfs110GetFeatureXmlTpl:
+            '<wfs:GetFeature service="WFS" version="1.1.0"' +
+                ' outputFormat="JSON"' +
+                ' xmlns:wfs="http://www.opengis.net/wfs"' +
+                ' xmlns="http://www.opengis.net/ogc"' +
+                ' xmlns:gml="http://www.opengis.net/gml"' +
+                ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+                ' xsi:schemaLocation="http://www.opengis.net/wfs' +
+                ' http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd">' +
+                '<wfs:Query typeName="{0}">{1}' +
+                '</wfs:Query>' +
+            '</wfs:GetFeature>',
+
+        /**
+         * The WFS 2.0.0 GetFeature XML body template
+         */
+        wfs200GetFeatureXmlTpl:
+            '<wfs:GetFeature service="WFS" version="2.0.0" ' +
+                'xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+                'xmlns:fes="http://www.opengis.net/fes/2.0" ' +
+                'xmlns:gml="http://www.opengis.net/gml/3.2" ' +
+                'xmlns:sf="http://www.openplans.org/spearfish" ' +
+                'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+                'xsi:schemaLocation="http://www.opengis.net/wfs/2.0 ' +
+                'http://schemas.opengis.net/wfs/2.0/wfs.xsd ' +
+                'http://www.opengis.net/gml/3.2 ' +
+                'http://schemas.opengis.net/gml/3.2.1/gml.xsd">' +
+                '<wfs:Query typeName="{0}">{1}' +
+                '</wfs:Query>' +
+            '</wfs:GetFeature>',
+
+
+        /**
+         * Given an array of ExtJS Filters, this method will return an OGC
+         * compliant filter which can be used for WMS requests
+         * @param {array} filters array containing all `Ext.grid.filters.filter`
+         *   that should be converted
+         * @param {string} combinator The combinator used for combining multiple
+         *   filters. Can be 'and' or 'or'
+         * @return {string} The OGC Filter XML
+         */
+        getOGCWMSFilterFromExtJSFilter: function(filters, combinator) {
+            return GeoExt.util.OGCFilter.getOGCFilterFromExtJSFilter(
+                filters, 'wms', combinator);
+        },
+
+        /**
+         * Given an array of ExtJS Filters, this method will return an OGC
+         * compliant filter which can be used for WFS requests
+         * @param {array} filters array containing all `Ext.grid.filters.filter`
+         *   that should be converted
+         * @param {string} combinator The combinator used for combining multiple
+         *   filters. Can be 'and' or 'or'
+         * @param {string} wfsVersion The WFS version to use, either `1.0.0`,
+         *   `1.1.0` or `2.0.0`
+         * @return {string} The OGC Filter XML
+         */
+        getOGCWFSFilterFromExtJSFilter: function(filters, combinator,
+            wfsVersion) {
+            return GeoExt.util.OGCFilter.getOGCFilterFromExtJSFilter(
+                filters, 'wfs', combinator, wfsVersion);
+        },
+
+        /**
+         * Given an ExtJS Filter, this method will return an OGC compliant
+         * filter which can be used for WMS or WFS queries
+         * @param {array} filters array containing all `Ext.grid.filters.filter`
+         *   that should be converted
+         * @param {string} type The OGC type we will be using, can be
+         *   `wms` or `wfs`
+         * @param {string} combinator The combinator used for combining multiple
+         *   filters. Can be 'and' or 'or'
+         * @param {string} wfsVersion The WFS version to use, either `1.0.0`,
+         *   `1.1.0` or `2.0.0`
+         * @return {string} the OGC Filter as XML tring
+         */
+        getOGCFilterFromExtJSFilter: function(filters, type, combinator,
+            wfsVersion) {
+            if (!Ext.isDefined(filters) || !Ext.isArray(filters)) {
+                Ext.Logger.error('Invalid filter argument given to ' +
+                  'GeoExt.util.OGCFilter. You need to pass an array of ' +
+                  '"Ext.grid.filters.filter"');
+                return;
+            }
+
+            var omitNamespaces = false;
+            // filters for WMS layers need to omit the namespaces
+            if (!Ext.isEmpty(type) && type.toLowerCase() === 'wms') {
+                omitNamespaces = true;
+            }
+            var ogcFilters = [];
+            Ext.each(filters, function(filter) {
+                var property = filter.config.property;
+                var operator = filter.config.operator;
+                var value = filter.getValue();
+                if (filter.isDateValue) {
+                    if (filter.getDateFormat) {
+                        value = Ext.Date.format(
+                            filter.getValue(),
+                            filter.getDateFormat()
+                        );
+                    } else {
+                        value = Ext.Date.format(filter.getValue(), 'Y-m-d');
+                    }
+                }
+                if (Ext.isEmpty(property) || Ext.isEmpty(operator) ||
+                    Ext.isEmpty(value)) {
+                    Ext.Logger.warn('Skipping a filter as some values ' +
+                        'seem to be undefined');
+                    return;
+                }
+                ogcFilters.push(GeoExt.util.OGCFilter.getOgcFilter(
+                    property, operator, value, wfsVersion));
+            });
+            var combinedFilters = GeoExt.util.OGCFilter.combineFilters(
+                ogcFilters, combinator, omitNamespaces, wfsVersion);
+            return combinedFilters;
+        },
+
+        /**
+         * Returns a GetFeature XML body containing the filters
+         * which can be used to directly request the features
+         * @param {array} filters array containing all `Ext.grid.filters.filter`
+         *   that should be converted
+         * @param {string} combinator The combinator used for combining multiple
+         *   filters. Can be 'and' or 'or'
+         * @param {string} wfsVersion The WFS version to use, either `1.0.0`,
+         *   `1.1.0` or `2.0.0`
+         * @param {string} typeName The featuretype name to be used
+         * @return {string} the GetFeature XML body as string
+         */
+        buildWfsGetFeatureWithFilter: function(filters, combinator, wfsVersion,
+            typeName) {
+            var filter = GeoExt.util.OGCFilter.getOGCWFSFilterFromExtJSFilter(
+                filters, combinator, wfsVersion);
+            var tpl = GeoExt.util.OGCFilter.wfs100GetFeatureXmlTpl;
+            if (wfsVersion && wfsVersion === '1.1.0') {
+                tpl =  GeoExt.util.OGCFilter.wfs110GetFeatureXmlTpl;
+            } else if (wfsVersion && wfsVersion === '2.0.0') {
+                tpl =  GeoExt.util.OGCFilter.wfs200GetFeatureXmlTpl;
+            }
+            return Ext.String.format(
+                tpl,
+                typeName,
+                filter
+            );
+        },
+
+        /**
+         * Returns an OGC filter for the given parameters.
+         * @param {String} property The property to filter on
+         * @param {String} operator The operator to use
+         * @param {*} value The value for the filter
+         * @param {string} wfsVersion The WFS version to use, either `1.0.0`,
+         *   `1.1.0` or `2.0.0`
+         * @return {String} The OGC filter.
+         */
+        getOgcFilter: function(property, operator, value, wfsVersion) {
+            if (Ext.isEmpty(property) || Ext.isEmpty(operator) ||
+                Ext.isEmpty(value)) {
+                Ext.Logger.error('Invalid argument given to method ' +
+                    '`getOgcFilter`. You need to supply property, ' +
+                    'operator and value.');
+                return;
+            }
+            var ogcFilterType;
+            var closingTag;
+            var propName = 'PropertyName';
+            if (!Ext.isEmpty(wfsVersion) && wfsVersion === '2.0.0') {
+                propName = 'ValueReference';
+            }
+
+            // always replace surrounding quotes
+            value = value.toString().replace(/(^['])/g, '');
+            value = value.toString().replace(/([']$)/g, '');
+
+            switch (operator) {
+            case '==':
+                ogcFilterType = 'PropertyIsEqualTo';
+                break;
+            case 'eq':
+                ogcFilterType = 'PropertyIsEqualTo';
+                break;
+            case '!==':
+                ogcFilterType = 'PropertyIsNotEqualTo';
+                break;
+            case 'ne':
+                ogcFilterType = 'PropertyIsNotEqualTo';
+                break;
+            case 'lt':
+                ogcFilterType = 'PropertyIsLessThan';
+                break;
+            case 'gt':
+                ogcFilterType = 'PropertyIsGreaterThan';
+                break;
+            case 'like':
+                value = '*' + value + '*';
+                var likeFilter =
+                  '<PropertyIsLike wildCard="*" singleChar="."' +
+                    ' escape="!" matchCase="false">' +
+                    '<' + propName + '>' + property + '</' + propName + '>' +
+                    '<Literal>' + value + '</Literal>' +
+                  '</PropertyIsLike>';
+                return likeFilter;
+            case 'in':
+                ogcFilterType = 'Or';
+                // cleanup brackets and quotes
+                value = value.replace(/([()'])/g, '');
+                var values = value.split(',');
+                var filters = '';
+                Ext.each(values, function(val) {
+                    filters +=
+                    '<PropertyIsEqualTo>' +
+                      '<' + propName + '>' + property + '</' + propName + '>' +
+                      '<Literal>' + val + '</Literal>' +
+                    '</PropertyIsEqualTo>';
+                });
+                ogcFilterType = '<' + ogcFilterType + '>';
+                closingTag = Ext.String.insert(ogcFilterType, '/', 1);
+                return ogcFilterType + filters + closingTag;
+            default:
+                Ext.Logger.warn('Method `getOgcFilter` could not ' +
+                    'handle the given operator: ' + operator);
+                return;
+            }
+            ogcFilterType = '<' + ogcFilterType + '>';
+            closingTag = Ext.String.insert(ogcFilterType, '/', 1);
+            var tpl = '' +
+                '{0}' +
+                  '<' + propName + '>{1}</' + propName + '>' +
+                  '<Literal>{2}</Literal>' +
+                '{3}';
+
+            var filter = Ext.String.format(
+                tpl,
+                ogcFilterType,
+                property,
+                value,
+                closingTag
+            );
+            return filter;
+        },
+
+        /**
+         * Combines the passed filters with an `<And>` or `<Or>` and
+         * returns them.
+         *
+         * @param {array} filters The filters to join.
+         * @param {string} combinator The combinator to use, should be
+         *     either `And` (the default) or `Or`.
+         * @param {boolean} omitNamespaces Indicates if namespaces
+         *   should be omitted in filters, which is useful for WMS
+         * @param {string} wfsVersion The WFS version to use, either `1.0.0`,
+         *   `1.1.0` or `2.0.0`
+         * @return {string} An combined OGC filter with the passed filters.
+         */
+        combineFilters: function(filters, combinator, omitNamespaces,
+            wfsVersion) {
+            var defaultCombineWith = 'And';
+            var combineWith = combinator || defaultCombineWith;
+            var numFilters = filters.length;
+            var parts = [];
+            var ns = omitNamespaces ? '' : 'ogc';
+            if (!Ext.isEmpty(wfsVersion) && wfsVersion === '2.0.0') {
+                ns = 'fes/2.0';
+            }
+            parts.push('<Filter' + (omitNamespaces ? '' :
+                ' xmlns="http://www.opengis.net/' + ns + '"') + '>');
+
+            if (numFilters > 1) {
+                parts.push('<' + combineWith + '>');
+            }
+
+            Ext.each(filters, function(filter) {
+                parts.push(filter);
+            });
+
+            if (numFilters > 1) {
+                parts.push('</' + combineWith + '>');
+            }
+
+            parts.push('</' + 'Filter>');
+            return parts.join('');
+        }
+    }
+});

--- a/test/spec/GeoExt/util/OGCFilter.test.js
+++ b/test/spec/GeoExt/util/OGCFilter.test.js
@@ -81,7 +81,7 @@ describe('GeoExt.util.OGCFilter', function() {
                     return 'lt';
                 },
                 getValue: function() {
-                    return new Date(1554501600000);
+                    return new Date('2019-04-06');
                 },
                 isDateValue: true
             }, {
@@ -92,7 +92,7 @@ describe('GeoExt.util.OGCFilter', function() {
                     return 'gt';
                 },
                 getValue: function() {
-                    return new Date(1554069600000);
+                    return new Date('2019-04-01');
                 },
                 isDateValue: true
             }

--- a/test/spec/GeoExt/util/OGCFilter.test.js
+++ b/test/spec/GeoExt/util/OGCFilter.test.js
@@ -14,69 +14,85 @@ describe('GeoExt.util.OGCFilter', function() {
 
         var filters = [
             {
-                config: {
-                    operator: 'like',
-                    property: 'NAME'
+                getProperty: function() {
+                    return 'NAME';
+                },
+                getOperator: function() {
+                    return 'like';
                 },
                 getValue: function() {
                     return 'd';
                 }
             }, {
-                config: {
-                    operator: 'in',
-                    property: '"WARNCELLID"'
+                getProperty: function() {
+                    return 'WARNCELLID';
+                },
+                getOperator: function() {
+                    return 'in';
                 },
                 getValue: function() {
                     return [105120000, 105124000, 105158000];
                 }
             }, {
-                config: {
-                    operator: 'eq',
-                    property: '"WARNCELLID"'
+                getProperty: function() {
+                    return 'WARNCELLID';
+                },
+                getOperator: function() {
+                    return 'eq';
                 },
                 getValue: function() {
                     return 105124000;
                 }
             }, {
-                config: {
-                    operator: 'ne',
-                    property: '"WARNCELLID"'
+                getProperty: function() {
+                    return 'WARNCELLID';
+                },
+                getOperator: function() {
+                    return 'ne';
                 },
                 getValue: function() {
                     return 105124001;
                 }
             }, {
-                config: {
-                    operator: '==',
-                    property: '"BOOLFIELD"'
+                getProperty: function() {
+                    return 'BOOLFIELD';
+                },
+                getOperator: function() {
+                    return '==';
                 },
                 getValue: function() {
                     return true;
                 }
             }, {
-                config: {
-                    operator: '!==',
-                    property: '"BOOLFIELD"'
+                getProperty: function() {
+                    return 'BOOLFIELD';
+                },
+                getOperator: function() {
+                    return '!==';
                 },
                 getValue: function() {
                     return false;
                 }
             }, {
-                config: {
-                    operator: 'lt',
-                    property: '"PROCESSTIME"'
+                getProperty: function() {
+                    return 'PROCESSTIME';
+                },
+                getOperator: function() {
+                    return 'lt';
                 },
                 getValue: function() {
-                    return 1554501600000;
+                    return new Date(1554501600000);
                 },
                 isDateValue: true
             }, {
-                config: {
-                    operator: 'gt',
-                    property: '"PROCESSTIME"'
+                getProperty: function() {
+                    return 'PROCESSTIME';
+                },
+                getOperator: function() {
+                    return 'gt';
                 },
                 getValue: function() {
-                    return 1554069600000;
+                    return new Date(1554069600000);
                 },
                 isDateValue: true
             }
@@ -92,34 +108,42 @@ describe('GeoExt.util.OGCFilter', function() {
                 '</PropertyIsLike>' +
                 '<Or>' +
                 '<PropertyIsEqualTo>' +
-                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<PropertyName>WARNCELLID</PropertyName>' +
                     '<Literal>105120000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsEqualTo>' +
-                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<PropertyName>WARNCELLID</PropertyName>' +
                     '<Literal>105124000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsEqualTo>' +
-                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<PropertyName>WARNCELLID</PropertyName>' +
                     '<Literal>105158000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '</Or>' +
                 '<PropertyIsEqualTo>' +
-                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<PropertyName>WARNCELLID</PropertyName>' +
                     '<Literal>105124000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsNotEqualTo>' +
-                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<PropertyName>WARNCELLID</PropertyName>' +
                     '<Literal>105124001</Literal>' +
                 '</PropertyIsNotEqualTo>' +
                 '<PropertyIsEqualTo>' +
-                    '<PropertyName>"BOOLFIELD"</PropertyName>' +
+                    '<PropertyName>BOOLFIELD</PropertyName>' +
                     '<Literal>true</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsNotEqualTo>' +
-                    '<PropertyName>"BOOLFIELD"</PropertyName>' +
+                    '<PropertyName>BOOLFIELD</PropertyName>' +
                     '<Literal>false</Literal>' +
                 '</PropertyIsNotEqualTo>' +
+                '<PropertyIsLessThan>' +
+                  '<PropertyName>PROCESSTIME</PropertyName>' +
+                  '<Literal>2019-04-06</Literal>' +
+                '</PropertyIsLessThan>' +
+                '<PropertyIsGreaterThan>' +
+                  '<PropertyName>PROCESSTIME</PropertyName>' +
+                  '<Literal>2019-04-01</Literal>' +
+                '</PropertyIsGreaterThan>' +
               '</And>' +
             '</Filter>';
 
@@ -133,34 +157,42 @@ describe('GeoExt.util.OGCFilter', function() {
                 '</PropertyIsLike>' +
                 '<Or>' +
                 '<PropertyIsEqualTo>' +
-                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<PropertyName>WARNCELLID</PropertyName>' +
                     '<Literal>105120000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsEqualTo>' +
-                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<PropertyName>WARNCELLID</PropertyName>' +
                     '<Literal>105124000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsEqualTo>' +
-                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<PropertyName>WARNCELLID</PropertyName>' +
                     '<Literal>105158000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '</Or>' +
                 '<PropertyIsEqualTo>' +
-                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<PropertyName>WARNCELLID</PropertyName>' +
                     '<Literal>105124000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsNotEqualTo>' +
-                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<PropertyName>WARNCELLID</PropertyName>' +
                     '<Literal>105124001</Literal>' +
                 '</PropertyIsNotEqualTo>' +
                 '<PropertyIsEqualTo>' +
-                    '<PropertyName>"BOOLFIELD"</PropertyName>' +
+                    '<PropertyName>BOOLFIELD</PropertyName>' +
                     '<Literal>true</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsNotEqualTo>' +
-                    '<PropertyName>"BOOLFIELD"</PropertyName>' +
+                    '<PropertyName>BOOLFIELD</PropertyName>' +
                     '<Literal>false</Literal>' +
                 '</PropertyIsNotEqualTo>' +
+                '<PropertyIsLessThan>' +
+                  '<PropertyName>PROCESSTIME</PropertyName>' +
+                  '<Literal>2019-04-06</Literal>' +
+                '</PropertyIsLessThan>' +
+                '<PropertyIsGreaterThan>' +
+                  '<PropertyName>PROCESSTIME</PropertyName>' +
+                  '<Literal>2019-04-01</Literal>' +
+                '</PropertyIsGreaterThan>' +
               '</And>' +
             '</Filter>';
 
@@ -174,34 +206,42 @@ describe('GeoExt.util.OGCFilter', function() {
                 '</PropertyIsLike>' +
                 '<Or>' +
                 '<PropertyIsEqualTo>' +
-                    '<ValueReference>"WARNCELLID"</ValueReference>' +
+                    '<ValueReference>WARNCELLID</ValueReference>' +
                     '<Literal>105120000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsEqualTo>' +
-                    '<ValueReference>"WARNCELLID"</ValueReference>' +
+                    '<ValueReference>WARNCELLID</ValueReference>' +
                     '<Literal>105124000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsEqualTo>' +
-                    '<ValueReference>"WARNCELLID"</ValueReference>' +
+                    '<ValueReference>WARNCELLID</ValueReference>' +
                     '<Literal>105158000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '</Or>' +
                 '<PropertyIsEqualTo>' +
-                    '<ValueReference>"WARNCELLID"</ValueReference>' +
+                    '<ValueReference>WARNCELLID</ValueReference>' +
                     '<Literal>105124000</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsNotEqualTo>' +
-                    '<ValueReference>"WARNCELLID"</ValueReference>' +
+                    '<ValueReference>WARNCELLID</ValueReference>' +
                     '<Literal>105124001</Literal>' +
                 '</PropertyIsNotEqualTo>' +
                 '<PropertyIsEqualTo>' +
-                    '<ValueReference>"BOOLFIELD"</ValueReference>' +
+                    '<ValueReference>BOOLFIELD</ValueReference>' +
                     '<Literal>true</Literal>' +
                 '</PropertyIsEqualTo>' +
                 '<PropertyIsNotEqualTo>' +
-                    '<ValueReference>"BOOLFIELD"</ValueReference>' +
+                    '<ValueReference>BOOLFIELD</ValueReference>' +
                     '<Literal>false</Literal>' +
                 '</PropertyIsNotEqualTo>' +
+                '<PropertyIsLessThan>' +
+                  '<ValueReference>PROCESSTIME</ValueReference>' +
+                  '<Literal>2019-04-06</Literal>' +
+                '</PropertyIsLessThan>' +
+                '<PropertyIsGreaterThan>' +
+                  '<ValueReference>PROCESSTIME</ValueReference>' +
+                  '<Literal>2019-04-01</Literal>' +
+                '</PropertyIsGreaterThan>' +
               '</And>' +
             '</Filter>';
 
@@ -248,15 +288,14 @@ describe('GeoExt.util.OGCFilter', function() {
           '</wfs:GetFeature>';
 
 
-        describe('#getOGCWMSFilterFromExtJSFilter', function() {
+        describe('#getOgcWmsFilterFromExtJsFilter', function() {
 
             it('is defined', function() {
-                expect(GeoExt.util.OGCFilter.getOGCWMSFilterFromExtJSFilter).
+                expect(GeoExt.util.OGCFilter.getOgcWmsFilterFromExtJsFilter).
                     to.be.a('function');
             });
-
             var wmsFilter = GeoExt.util.OGCFilter.
-                getOGCWMSFilterFromExtJSFilter(filters);
+                getOgcWmsFilterFromExtJsFilter(filters);
 
             it('returns a valid XML', function() {
                 var parser = new DOMParser();
@@ -275,15 +314,15 @@ describe('GeoExt.util.OGCFilter', function() {
 
         });
 
-        describe('#getOGCWFSFilterFromExtJSFilter', function() {
+        describe('#getOgcWfsFilterFromExtJsFilter', function() {
 
             it('is defined', function() {
-                expect(GeoExt.util.OGCFilter.getOGCWFSFilterFromExtJSFilter).
+                expect(GeoExt.util.OGCFilter.getOgcWfsFilterFromExtJsFilter).
                     to.be.a('function');
             });
 
             var wfsFilter = GeoExt.util.OGCFilter.
-                getOGCWFSFilterFromExtJSFilter(filters);
+                getOgcWfsFilterFromExtJsFilter(filters);
 
             it('returns a valid XML for WFS 1.0.0', function() {
                 var parser = new DOMParser();
@@ -301,7 +340,7 @@ describe('GeoExt.util.OGCFilter', function() {
             });
 
             var wfs2Filter = GeoExt.util.OGCFilter.
-                getOGCWFSFilterFromExtJSFilter(filters, 'And', '2.0.0');
+                getOgcWfsFilterFromExtJsFilter(filters, 'And', '2.0.0');
 
             it('returns a valid XML for WFS 2.0.0', function() {
                 var parser = new DOMParser();
@@ -320,16 +359,16 @@ describe('GeoExt.util.OGCFilter', function() {
 
         });
 
-        describe('#getOGCFilterFromExtJSFilter', function() {
+        describe('#getOgcFilterFromExtJsFilter', function() {
             it('is defined', function() {
-                expect(GeoExt.util.OGCFilter.getOGCWFSFilterFromExtJSFilter).
+                expect(GeoExt.util.OGCFilter.getOgcWfsFilterFromExtJsFilter).
                     to.be.a('function');
             });
 
             it('throws with invalid filter array', function() {
                 var filters;
                 try {
-                    filters = GeoExt.util.OGCFilter.getOGCFilterFromExtJSFilter(
+                    filters = GeoExt.util.OGCFilter.getOgcFilterFromExtJsFilter(
                         null, 'wms');
                 } catch (e) {
                     expect(filters).to.be(undefined);

--- a/test/spec/GeoExt/util/OGCFilter.test.js
+++ b/test/spec/GeoExt/util/OGCFilter.test.js
@@ -1,0 +1,409 @@
+Ext.Loader.syncRequire(['GeoExt.util.OGCFilter']);
+
+describe('GeoExt.util.OGCFilter', function() {
+
+    describe('basics', function() {
+
+        it('is defined', function() {
+            expect(GeoExt.util.OGCFilter).not.to.be(undefined);
+        });
+
+    });
+
+    describe('static methods', function() {
+
+        var filters = [
+            {
+                config: {
+                    operator: 'like',
+                    property: 'NAME'
+                },
+                getValue: function() {
+                    return 'd';
+                }
+            }, {
+                config: {
+                    operator: 'in',
+                    property: '"WARNCELLID"'
+                },
+                getValue: function() {
+                    return [105120000, 105124000, 105158000];
+                }
+            }, {
+                config: {
+                    operator: 'eq',
+                    property: '"WARNCELLID"'
+                },
+                getValue: function() {
+                    return 105124000;
+                }
+            }, {
+                config: {
+                    operator: 'ne',
+                    property: '"WARNCELLID"'
+                },
+                getValue: function() {
+                    return 105124001;
+                }
+            }, {
+                config: {
+                    operator: '==',
+                    property: '"BOOLFIELD"'
+                },
+                getValue: function() {
+                    return true;
+                }
+            }, {
+                config: {
+                    operator: '!==',
+                    property: '"BOOLFIELD"'
+                },
+                getValue: function() {
+                    return false;
+                }
+            }, {
+                config: {
+                    operator: 'lt',
+                    property: '"PROCESSTIME"'
+                },
+                getValue: function() {
+                    return 1554501600000;
+                },
+                isDateValue: true
+            }, {
+                config: {
+                    operator: 'gt',
+                    property: '"PROCESSTIME"'
+                },
+                getValue: function() {
+                    return 1554069600000;
+                },
+                isDateValue: true
+            }
+        ];
+
+        var expectedWMSFilter =
+            '<Filter>' +
+              '<And>' +
+                '<PropertyIsLike wildCard="*" singleChar="." escape="!" ' +
+                'matchCase="false">' +
+                '<PropertyName>NAME</PropertyName>' +
+                '<Literal>*d*</Literal>' +
+                '</PropertyIsLike>' +
+                '<Or>' +
+                '<PropertyIsEqualTo>' +
+                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<Literal>105120000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsEqualTo>' +
+                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<Literal>105124000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsEqualTo>' +
+                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<Literal>105158000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '</Or>' +
+                '<PropertyIsEqualTo>' +
+                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<Literal>105124000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsNotEqualTo>' +
+                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<Literal>105124001</Literal>' +
+                '</PropertyIsNotEqualTo>' +
+                '<PropertyIsEqualTo>' +
+                    '<PropertyName>"BOOLFIELD"</PropertyName>' +
+                    '<Literal>true</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsNotEqualTo>' +
+                    '<PropertyName>"BOOLFIELD"</PropertyName>' +
+                    '<Literal>false</Literal>' +
+                '</PropertyIsNotEqualTo>' +
+              '</And>' +
+            '</Filter>';
+
+        var expectedWFS1xFilter =
+            '<Filter xmlns="http://www.opengis.net/ogc">' +
+              '<And>' +
+                '<PropertyIsLike wildCard="*" singleChar="." escape="!" ' +
+                'matchCase="false">' +
+                    '<PropertyName>NAME</PropertyName>' +
+                    '<Literal>*d*</Literal>' +
+                '</PropertyIsLike>' +
+                '<Or>' +
+                '<PropertyIsEqualTo>' +
+                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<Literal>105120000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsEqualTo>' +
+                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<Literal>105124000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsEqualTo>' +
+                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<Literal>105158000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '</Or>' +
+                '<PropertyIsEqualTo>' +
+                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<Literal>105124000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsNotEqualTo>' +
+                    '<PropertyName>"WARNCELLID"</PropertyName>' +
+                    '<Literal>105124001</Literal>' +
+                '</PropertyIsNotEqualTo>' +
+                '<PropertyIsEqualTo>' +
+                    '<PropertyName>"BOOLFIELD"</PropertyName>' +
+                    '<Literal>true</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsNotEqualTo>' +
+                    '<PropertyName>"BOOLFIELD"</PropertyName>' +
+                    '<Literal>false</Literal>' +
+                '</PropertyIsNotEqualTo>' +
+              '</And>' +
+            '</Filter>';
+
+        var expectedWFS2Filter =
+            '<Filter xmlns="http://www.opengis.net/fes/2.0">' +
+              '<And>' +
+                '<PropertyIsLike wildCard="*" singleChar="." escape="!" ' +
+                'matchCase="false">' +
+                    '<ValueReference>NAME</ValueReference>' +
+                    '<Literal>*d*</Literal>' +
+                '</PropertyIsLike>' +
+                '<Or>' +
+                '<PropertyIsEqualTo>' +
+                    '<ValueReference>"WARNCELLID"</ValueReference>' +
+                    '<Literal>105120000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsEqualTo>' +
+                    '<ValueReference>"WARNCELLID"</ValueReference>' +
+                    '<Literal>105124000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsEqualTo>' +
+                    '<ValueReference>"WARNCELLID"</ValueReference>' +
+                    '<Literal>105158000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '</Or>' +
+                '<PropertyIsEqualTo>' +
+                    '<ValueReference>"WARNCELLID"</ValueReference>' +
+                    '<Literal>105124000</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsNotEqualTo>' +
+                    '<ValueReference>"WARNCELLID"</ValueReference>' +
+                    '<Literal>105124001</Literal>' +
+                '</PropertyIsNotEqualTo>' +
+                '<PropertyIsEqualTo>' +
+                    '<ValueReference>"BOOLFIELD"</ValueReference>' +
+                    '<Literal>true</Literal>' +
+                '</PropertyIsEqualTo>' +
+                '<PropertyIsNotEqualTo>' +
+                    '<ValueReference>"BOOLFIELD"</ValueReference>' +
+                    '<Literal>false</Literal>' +
+                '</PropertyIsNotEqualTo>' +
+              '</And>' +
+            '</Filter>';
+
+        var expectedGetFeature10Filter =
+          '<wfs:GetFeature service="WFS" version="1.0.0" outputFormat="JSON" ' +
+            'xmlns:wfs="http://www.opengis.net/wfs" ' +
+            'xmlns="http://www.opengis.net/ogc" ' +
+            'xmlns:gml="http://www.opengis.net/gml" ' +
+            'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+            'xsi:schemaLocation="http://www.opengis.net/wfs ' +
+            'http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd">' +
+            '<wfs:Query typeName="dwd:Warngebiete_Kreise">' +
+              expectedWFS1xFilter +
+            '</wfs:Query>' +
+          '</wfs:GetFeature>';
+
+        var expectedGetFeature11Filter =
+          '<wfs:GetFeature service="WFS" version="1.1.0" outputFormat="JSON" ' +
+            'xmlns:wfs="http://www.opengis.net/wfs" ' +
+            'xmlns="http://www.opengis.net/ogc" ' +
+            'xmlns:gml="http://www.opengis.net/gml" ' +
+            'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+            'xsi:schemaLocation="http://www.opengis.net/wfs ' +
+            'http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd">' +
+            '<wfs:Query typeName="dwd:Warngebiete_Kreise">' +
+              expectedWFS1xFilter +
+            '</wfs:Query>' +
+          '</wfs:GetFeature>';
+
+        var expectedGetFeature20Filter =
+          '<wfs:GetFeature service="WFS" version="2.0.0" ' +
+            'xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+            'xmlns:fes="http://www.opengis.net/fes/2.0" ' +
+            'xmlns:gml="http://www.opengis.net/gml/3.2" ' +
+            'xmlns:sf="http://www.openplans.org/spearfish" ' +
+            'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+            'xsi:schemaLocation="http://www.opengis.net/wfs/2.0 ' +
+            'http://schemas.opengis.net/wfs/2.0/wfs.xsd ' +
+            'http://www.opengis.net/gml/3.2 ' +
+            'http://schemas.opengis.net/gml/3.2.1/gml.xsd">' +
+            '<wfs:Query typeName="dwd:Warngebiete_Kreise">' +
+                expectedWFS2Filter +
+            '</wfs:Query>' +
+          '</wfs:GetFeature>';
+
+
+        describe('#getOGCWMSFilterFromExtJSFilter', function() {
+
+            it('is defined', function() {
+                expect(GeoExt.util.OGCFilter.getOGCWMSFilterFromExtJSFilter).
+                    to.be.a('function');
+            });
+
+            var wmsFilter = GeoExt.util.OGCFilter.
+                getOGCWMSFilterFromExtJSFilter(filters);
+
+            it('returns a valid XML', function() {
+                var parser = new DOMParser();
+                var doc = parser.parseFromString(wmsFilter, 'application/xml');
+                var parseError = doc.getElementsByTagName('parsererror').length;
+                expect(parseError).to.be(0);
+            });
+
+            it('concatenates filters with `And` per default', function() {
+                expect(wmsFilter).to.contain('<And>');
+            });
+
+            it('contains all filters', function() {
+                expect(wmsFilter).to.be(expectedWMSFilter);
+            });
+
+        });
+
+        describe('#getOGCWFSFilterFromExtJSFilter', function() {
+
+            it('is defined', function() {
+                expect(GeoExt.util.OGCFilter.getOGCWFSFilterFromExtJSFilter).
+                    to.be.a('function');
+            });
+
+            var wfsFilter = GeoExt.util.OGCFilter.
+                getOGCWFSFilterFromExtJSFilter(filters);
+
+            it('returns a valid XML for WFS 1.0.0', function() {
+                var parser = new DOMParser();
+                var doc = parser.parseFromString(wfsFilter, 'application/xml');
+                var parseError = doc.getElementsByTagName('parsererror').length;
+                expect(parseError).to.be(0);
+            });
+
+            it('concatenates filters with `And` per default', function() {
+                expect(wfsFilter).to.contain('<And>');
+            });
+
+            it('contains all filters using wfs 1.0.0 as default', function() {
+                expect(wfsFilter).to.be(expectedWFS1xFilter);
+            });
+
+            var wfs2Filter = GeoExt.util.OGCFilter.
+                getOGCWFSFilterFromExtJSFilter(filters, 'And', '2.0.0');
+
+            it('returns a valid XML for WFS 2.0.0', function() {
+                var parser = new DOMParser();
+                var doc = parser.parseFromString(wfs2Filter, 'application/xml');
+                var parseError = doc.getElementsByTagName('parsererror').length;
+                expect(parseError).to.be(0);
+            });
+
+            it('concatenates filters with `And`', function() {
+                expect(wfs2Filter).to.contain('<And>');
+            });
+
+            it('contains all filters', function() {
+                expect(wfs2Filter).to.be(expectedWFS2Filter);
+            });
+
+        });
+
+        describe('#getOGCFilterFromExtJSFilter', function() {
+            it('is defined', function() {
+                expect(GeoExt.util.OGCFilter.getOGCWFSFilterFromExtJSFilter).
+                    to.be.a('function');
+            });
+
+            it('throws with invalid filter array', function() {
+                var filters;
+                try {
+                    filters = GeoExt.util.OGCFilter.getOGCFilterFromExtJSFilter(
+                        null, 'wms');
+                } catch (e) {
+                    expect(filters).to.be(undefined);
+                }
+            });
+        });
+
+        describe('#getOgcFilter', function() {
+            it('is defined', function() {
+                expect(GeoExt.util.OGCFilter.getOgcFilter).
+                    to.be.a('function');
+            });
+
+            it('throws with invalid properties', function() {
+                var filter;
+                try {
+                    filter = GeoExt.util.OGCFilter.getOgcFilter(
+                        null, 'test', undefined);
+                } catch (e) {
+                    expect(filter).to.be(undefined);
+                }
+            });
+        });
+
+        describe('#buildWfsGetFeatureWithFilter', function() {
+            it('is defined', function() {
+                expect(GeoExt.util.OGCFilter.buildWfsGetFeatureWithFilter).
+                    to.be.a('function');
+            });
+
+            var xml10 = GeoExt.util.OGCFilter.buildWfsGetFeatureWithFilter(
+                filters, 'And', '1.0.0', 'dwd:Warngebiete_Kreise');
+
+            var xml11 = GeoExt.util.OGCFilter.buildWfsGetFeatureWithFilter(
+                filters, 'And', '1.1.0', 'dwd:Warngebiete_Kreise');
+
+            var xml20 = GeoExt.util.OGCFilter.buildWfsGetFeatureWithFilter(
+                filters, 'And', '2.0.0', 'dwd:Warngebiete_Kreise');
+
+            it('returns a valid XML for GetFeature 1.0.0', function() {
+                var parser = new DOMParser();
+                var doc = parser.parseFromString(xml10, 'application/xml');
+                var parseError = doc.getElementsByTagName('parsererror').length;
+                expect(parseError).to.be(0);
+            });
+
+            it('returns a valid XML for GetFeature 1.1.0', function() {
+                var parser = new DOMParser();
+                var doc = parser.parseFromString(xml11, 'application/xml');
+                var parseError = doc.getElementsByTagName('parsererror').length;
+                expect(parseError).to.be(0);
+            });
+
+            it('returns a valid XML for GetFeature 2.0.0', function() {
+                var parser = new DOMParser();
+                var doc = parser.parseFromString(xml20, 'application/xml');
+                var parseError = doc.getElementsByTagName('parsererror').length;
+                expect(parseError).to.be(0);
+            });
+
+            it('contains all filters for WFS 1.0.0', function() {
+                expect(xml10).to.be(expectedGetFeature10Filter);
+            });
+
+            it('contains all filters for WFS 1.1.0', function() {
+                expect(xml11).to.be(expectedGetFeature11Filter);
+            });
+
+            it('contains all filters for WFS 2.0.0', function() {
+                expect(xml20).to.be(expectedGetFeature20Filter);
+            });
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
This PR adds a new utility class which can be used to generate OGC compliant filters based on ExtJS grid filters.

An example has been added to showcase the power of the util by `live-filtering` WMS and WFS layers through the filters that get set by the user in the grid.

![extgrids](https://user-images.githubusercontent.com/1381363/55548171-3348ad80-56d3-11e9-9f45-01d179373e56.png)
