### PR TITLE
Fix broken loading of PermalinkProvider in modern apps

### DIFF
--- a/src/state/PermalinkProvider.js
+++ b/src/state/PermalinkProvider.js
@@ -148,4 +148,8 @@ Ext.define('GeoExt.state.PermalinkProvider', {
         // call 'set' of super class
         me.callParent(arguments);
     }
+}, function() {
+    if (!Ext.state || !Ext.state.Provider) {
+        Ext.define('Ext.state.Provider', {});
+    }
 });

--- a/src/state/PermalinkProvider.js
+++ b/src/state/PermalinkProvider.js
@@ -16,6 +16,9 @@
 /**
  * The permalink provider.
  *
+ * CAUTION: This class is only usable in applications using the classic toolkit
+ *          of ExtJS 6.
+ *
  * Sample code displaying a new permalink each time the map is moved:
  *
  *     @example preview


### PR DESCRIPTION
This fixes the broken loading of the `PermalinkProvider` class in apps using the modern toolkit due to the fact that `Ext.state.Provider` is not available in the modern toolkit (see #457).
This is done by adding the `onClassCreated` callback to `PermalinkProvider`, which defines the missing `Ext.state.Provider` as empty stub.

This also adds a warning to the API-docs of the `PermalinkProvider` class, which states that this component is only usable with the classic toolkit.