### PR TITLE
Add a generic GeocoderCombo component

### DIFF
--- a/examples/geocoder/geocoder-combo.html
+++ b/examples/geocoder/geocoder-combo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Geocoder Combo Example</title>
+    <link rel="stylesheet" type="text/css" href="../lib/ol/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
+</head>
+
+<body>
+
+    <div id='description'>
+        <p>
+            This example shows how to use the <code>GeoExt.form.field.GeocoderComboBox</code>
+            to let the user perform geocoding with the Nominatim API.
+        </p>
+        <p>
+            Have a look at <a href="geocoder-combo.js">geocoder-combo.js</a> to see how this is
+            done.
+        </p>
+    </div>
+
+    <script src="../lib/ol/ol.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
+    <script>
+        Ext.Loader.setConfig({
+            enabled: true,
+            paths: {
+                'GeoExt': '../../src/'
+            }
+        });
+    </script>
+
+    <script src="geocoder-combo.js"></script>
+</body>
+</html>

--- a/examples/geocoder/geocoder-combo.js
+++ b/examples/geocoder/geocoder-combo.js
@@ -1,0 +1,60 @@
+Ext.require([
+    'GeoExt.form.field.GeocoderComboBox'
+]);
+
+var olMap;
+var mapComponent;
+var mapPanel;
+var description;
+Ext.application({
+    name: 'geocoder-combo',
+    launch: function() {
+
+        olMap = new ol.Map({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.OSM()
+                })
+            ],
+            view: new ol.View({
+                center: ol.proj.fromLonLat([0, 0]),
+                zoom: 2
+            })
+        });
+
+        mapComponent = Ext.create('GeoExt.component.Map', {
+            map: olMap
+        });
+
+        mapPanel = Ext.create('Ext.panel.Panel', {
+            title: 'GeoExt.form.field.GeocoderComboBox Example',
+            region: 'center',
+            layout: 'fit',
+            items: [mapComponent],
+            tbar: [{
+                xtype: 'gx_geocoder_combo',
+                width: 300,
+                url: 'https://nominatim.openstreetmap.org/search?format=json',
+                map: olMap,
+                showLocationOnMap: true
+            }]
+        });
+
+        description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            title: 'Description',
+            region: 'south',
+            height: 200,
+            border: false,
+            bodyPadding: 5
+        });
+
+        Ext.create('Ext.Viewport', {
+            layout: 'border',
+            items: [
+                mapPanel,
+                description
+            ]
+        });
+    }
+});

--- a/examples/geocoder/geocoder-combo.js
+++ b/examples/geocoder/geocoder-combo.js
@@ -36,7 +36,12 @@ Ext.application({
                 width: 300,
                 url: 'https://nominatim.openstreetmap.org/search?format=json',
                 map: olMap,
-                showLocationOnMap: true
+                showLocationOnMap: true,
+                locationLayerStyle: new ol.style.Style({
+                    stroke: new ol.style.Stroke({
+                        color: 'red'
+                    })
+                })
             }]
         });
 

--- a/src/form/field/GeocoderComboBox.js
+++ b/src/form/field/GeocoderComboBox.js
@@ -62,6 +62,14 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
     locationLayer: null,
 
     /**
+     * The style of the #locationLayer. Only has an effect if the layer is not
+     * passed in while creation.
+     *
+     * @cfg {ol.style.Style}
+     */
+    locationLayerStyle: null,
+
+    /**
      * The store used for this combo box. Default is a
      * store with  the url configured as #url
      * config.
@@ -184,7 +192,9 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
 
         if (!me.locationLayer) {
             me.locationLayer = new ol.layer.Vector({
-                source: new ol.source.Vector()
+                source: new ol.source.Vector(),
+                style: me.locationLayerStyle !== null ?
+                    me.locationLayerStyle : undefined
             });
 
             if (me.map) {

--- a/src/form/field/GeocoderComboBox.js
+++ b/src/form/field/GeocoderComboBox.js
@@ -245,9 +245,7 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
         var me = this;
         var geom;
         if (coordOrExtent.length === 2) {
-
             geom = new ol.geom.Point(coordOrExtent);
-
         } else if (coordOrExtent.length === 4) {
             geom = ol.geom.Polygon.fromExtent(coordOrExtent);
         }

--- a/src/form/field/GeocoderComboBox.js
+++ b/src/form/field/GeocoderComboBox.js
@@ -1,0 +1,327 @@
+/* Copyright (c) 2015-2019 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Creates a combo box that handles results from a geocoding service. By
+ * default it uses OSM Nominatim, but the component offers all config options
+ * to overwrite in order to other custom services.
+ * If the user enters a valid address in the search box, the combo's store will
+ * be populated with records that match the
+ * address. By default, records have the following fields:
+ *
+ *   * name   - `String` The formatted address.
+ *   * extent - `ol.Extent` The extent of the matching address
+ *   * bounds - `ol.Coordinate` The point coordinate of the matching address
+ *
+ * CAUTION: This class is only usable in applications using the classic toolkit
+ *          of ExtJS 6.
+ *
+ * @class GeoExt.form.field.GeocoderComboBox
+ */
+Ext.define('GeoExt.form.field.GeocoderComboBox', {
+    extend: 'Ext.form.field.ComboBox',
+    alias: [
+        'widget.gx_geocoder_combo',
+        'widget.gx_geocoder_combobox',
+        'widget.gx_geocoder_field'
+    ],
+    requires: [
+        'Ext.data.JsonStore'
+    ],
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
+    ],
+
+    /**
+     * The OpenLayers map to work on. If not provided the selection of an
+     * address would have no effect.
+     *
+     * @cfg {ol.Map}
+     */
+    map: null,
+
+    /**
+     * Vector layer to visualize the selected address.
+     * Will be created if not provided.
+     *
+     * @cfg {ol.layer.Vector}
+     * @property {ol.layer.Vector}
+     */
+    locationLayer: null,
+
+    /**
+     * The store used for this combo box. Default is a
+     * store with  the url configured as #url
+     * config.
+     *
+     * @cfg {Ext.data.JsonStore}
+     * @propery {Ext.data.JsonStore}
+     */
+    store: null,
+
+    /**
+     * The field to display in the combobox result. Default is
+     * "name" for instant use with the default store for this component.
+     *
+     * @cfg {String}
+     */
+    displayField: 'name',
+
+    /**
+     * The field in the GeoCoder service repsonse to be used as mapping for the
+     * 'name' field in the #store.
+     * Ignored when a store is passed in.
+     *
+     * @cfg {String}
+     */
+    displayValueMapping: 'display_name',
+
+    /**
+     * Field from selected record to use when the combo's
+     * #getValue method is called. Default is "extent". This field is
+     * supposed to contain an ol.Extent.
+     * By setting this to 'coordinate' a field holding an ol.Coordinate is used.
+     *
+     * @cfg {String}
+     */
+    valueField: 'extent',
+
+    /**
+     * The query parameter for the user entered search text.
+     * Default is 'q' for instant use with OSM Nominatim.
+     *
+     * @cfg {String}
+     */
+    queryParam: 'q',
+
+    /**'Search'
+     * Text to display for an empty field.
+     *
+     * @cfg {String}
+     */
+    emptyText: 'Search a location',
+
+    /**
+     * Minimum number of entered characters to trigger a search.
+     *
+     * @cfg {Number}
+     */
+    minChars: 3,
+
+    /**
+     * Delay before the search occurs in ms.
+     *
+     * @cfg {Number}
+     */
+    queryDelay: 100,
+
+    /**
+     * URL template for querying the geocoding service. If a store is
+     * configured, this will be ignored. Note that the #queryParam will be used
+     * to append the user's combo box input to the url.
+     *
+     * @cfg {String}
+     */
+    url: 'https://nominatim.openstreetmap.org/search?format=json',
+
+    /**
+     * The SRS used by the geocoder service.
+     *
+     * @cfg {String}
+     */
+    srs: 'EPSG:4326',
+
+    /**
+     * Zoom level when zooming to a location (#valueField='coordinate')
+     * Not used when zooming to extent.
+     *
+     * @cfg {Number}
+     */
+    zoom: 10,
+
+    /**
+     * Flag to steer if selected address feature is drawn on #map
+     * (by #locationLayer).
+     *
+     * @cfg {Boolean}
+     */
+    showLocationOnMap: true,
+
+    /**
+     * @private
+     */
+    initComponent: function() {
+        var me = this;
+
+        if (!me.store) {
+            me.store = Ext.create('Ext.data.JsonStore', {
+                fields: [
+                    {name: 'name', mapping: me.displayValueMapping},
+                    {name: 'extent', convert: me.convertToExtent},
+                    {name: 'coordinate', convert: me.convertToCoordinate}
+                ],
+                proxy: {
+                    type: 'ajax',
+                    url: me.url,
+                    reader: {
+                        type: 'json'
+                    }
+                }
+            });
+        }
+
+        if (!me.locationLayer) {
+            me.locationLayer = new ol.layer.Vector({
+                source: new ol.source.Vector()
+            });
+
+            if (me.map) {
+                me.map.addLayer(me.locationLayer);
+            }
+        }
+
+        me.callParent(arguments);
+
+        me.on({
+            select: this.onSelect,
+            focus: me.onFocus,
+            scope: me
+        });
+    },
+
+    /**
+     * Function to convert the data delivered by the geocoder service to an
+     * ol.Extent ([minx, miny, maxx, maxy]).
+     * Default implementation converts the Nominatim response.
+     * Can be overwritten to work with other services.
+     *
+     * @param  {Mixed}          v   The data value as read by the Reader
+     * @param  {Ext.data.Model} rec The data record containing raw data
+     * @return {ol.Extent}          The created ol.Extent
+     */
+    convertToExtent: function(v, rec) {
+        var rawExtent = rec.get('boundingbox');
+        var minx = parseFloat(rawExtent[2], 10);
+        var miny = parseFloat(rawExtent[0], 10);
+        var maxx = parseFloat(rawExtent[3], 10);
+        var maxy = parseFloat(rawExtent[1], 10);
+
+        return [minx, miny, maxx, maxy];
+    },
+
+    /**
+     * Function to convert the data delivered by the geocoder service to an
+     * ol.Coordinate ([x, y]).
+     * Default implementation converts the Nominatim response.
+     * Can be overwritten to work with other services.
+     *
+     * @param  {Mixed}          v   The data value as read by the Reader
+     * @param  {Ext.data.Model} rec The data record containing raw data
+     * @return {ol.Coordinate}      The created ol.Coordinate
+     */
+    convertToCoordinate: function(v, rec) {
+        return [parseFloat(rec.get('lon'), 10), parseFloat(rec.get('lat'), 10)];
+    },
+
+    /**
+     * Draws the selected address feature on the map.
+     *
+     * @param  {ol.Coordinate | ol.Extent} coordOrExtent Location feature to be
+     *   drawn on the map
+     */
+    drawLocationFeatureOnMap: function(coordOrExtent) {
+        var me = this;
+        var geom;
+        if (coordOrExtent.length === 2) {
+
+            geom = new ol.geom.Point(coordOrExtent);
+
+        } else if (coordOrExtent.length === 4) {
+            geom = ol.geom.Polygon.fromExtent(coordOrExtent);
+        }
+
+        if (geom) {
+            var feat = new ol.Feature({
+                geometry: geom
+            });
+            me.locationLayer.getSource().clear();
+            me.locationLayer.getSource().addFeature(feat);
+        }
+    },
+
+    /**
+     * Removes the drawn address feature from the map.
+     */
+    removeLocationFeature: function() {
+        this.locationLayer.getSource().clear();
+    },
+
+    /**
+     * Handles the 'focus' event of this ComboBox.
+     */
+    onFocus: function() {
+        var me = this;
+        me.clearValue();
+        me.removeLocationFeature();
+    },
+
+    /**
+     * Handles the 'select' event of this ComboBox.
+     * Zooms to the selected address and draws the address feature on the map
+     * (if configured in #showLocationOnMap)
+     *
+     * @param  {GeoExt.form.field.GeocoderComboBox} combo  [description]
+     * @param  {Ext.data.Model} record [description]
+     *
+     * @private
+     */
+    onSelect: function(combo, record) {
+        var me = this;
+        if (!me.map) {
+            Ext.Logger.warn('No map configured in ' +
+                'GeoExt.form.field.GeocoderComboBox. Skip zoom to selection.');
+            return;
+        }
+
+        var value = record.get(me.valueField);
+        var projValue;
+        var olMapView = me.map.getView();
+        var targetProj = olMapView.getProjection().getCode();
+        if (value.length === 2) {
+            // point based value
+            projValue = ol.proj.transform(value, me.srs, targetProj);
+
+            // adjust the map
+            olMapView.setCenter(projValue);
+            olMapView.setZoom(me.zoom);
+        } else if (value.length === 4) {
+            // bbox based value
+            projValue = ol.proj.transformExtent(value, me.srs, targetProj);
+
+            // adjust the map
+            olMapView.fit(projValue);
+        }
+
+        if (me.showLocationOnMap) {
+            me.drawLocationFeatureOnMap(projValue);
+        }
+    }
+}, function() {
+    if (!Ext.form && !Ext.form.field && !Ext.form.field.ComboBox) {
+        // empty stub to avoid error in class loader when using this in
+        // app built ontop of modern toolkit
+        Ext.define('Ext.form.field.ComboBox');
+    }
+});

--- a/test/index.html
+++ b/test/index.html
@@ -55,6 +55,7 @@
   <script src='spec/GeoExt/data/store/Layers.test.js'></script>
   <script src='spec/GeoExt/data/store/LayersTree.test.js'></script>
   <script src='spec/GeoExt/data/store/OlObjects.test.js'></script>
+  <script src='spec/GeoExt/form/field/GeocoderComboBox.test.js'></script>
   <script src='spec/GeoExt/grid/column/Symbolizer.test.js'></script>
   <script src='spec/GeoExt/mixin/SymbolCheck.test.js'></script>
   <script src='spec/GeoExt/state/PermalinkProvider.test.js'></script>

--- a/test/spec/GeoExt/form/field/GeocoderComboBox.test.js
+++ b/test/spec/GeoExt/form/field/GeocoderComboBox.test.js
@@ -89,12 +89,18 @@ describe('GeoExt.form.field.GeocoderComboBox', function() {
             it('centers the map to coordinate', function() {
                 var record = {
                     get: function() {
-                        return [0, 0];
+                        return [1, 1];
                     }
                 };
                 geocoderCombo.onSelect(geocoderCombo, record);
-                expect(Math.round(olMap.getView().getCenter()[0])).to.be(0);
-                expect(Math.round(olMap.getView().getCenter()[1])).to.be(0);
+                expect(
+                    Math.round(olMap.getView().getCenter()[0])
+                // EPSG:3857
+                ).to.be(111319);
+                expect(
+                    Math.round(olMap.getView().getCenter()[1])
+                // EPSG:3857
+                ).to.be(111325);
             });
 
             it('centers the map to extent', function() {

--- a/test/spec/GeoExt/form/field/GeocoderComboBox.test.js
+++ b/test/spec/GeoExt/form/field/GeocoderComboBox.test.js
@@ -1,0 +1,148 @@
+Ext.Loader.syncRequire(['GeoExt.form.field.GeocoderComboBox']);
+
+describe('GeoExt.form.field.GeocoderComboBox', function() {
+
+    describe('basics', function() {
+        it('GeoExt.form.field.GeocoderComboBox is defined', function() {
+            expect(GeoExt.component.Map).not.to.be(undefined);
+        });
+
+        describe('constructor', function() {
+            it('can be constructed wo/ arguments via Ext.create()', function() {
+                var geocoderCombo =
+                    Ext.create('GeoExt.form.field.GeocoderComboBox');
+                expect(geocoderCombo).to.be.an(
+                    GeoExt.form.field.GeocoderComboBox);
+            });
+        });
+    });
+
+    describe('public functions', function() {
+        var geocoderCombo;
+        beforeEach(function() {
+            geocoderCombo = Ext.create('GeoExt.form.field.GeocoderComboBox');
+        });
+
+        it('are correctly defined', function() {
+            expect(typeof geocoderCombo.convertToExtent).to.be('function');
+            expect(typeof geocoderCombo.convertToCoordinate).to.be('function');
+            expect(
+                typeof geocoderCombo.drawLocationFeatureOnMap
+            ).to.be('function');
+            expect(
+                typeof geocoderCombo.removeLocationFeature
+            ).to.be('function');
+        });
+    });
+
+    describe('configs and properties', function() {
+        var geocoderCombo;
+        beforeEach(function() {
+            geocoderCombo = Ext.create('GeoExt.form.field.GeocoderComboBox');
+        });
+
+        it('are correctly defined (with defaults)', function() {
+            expect(geocoderCombo.map).to.be(null);
+            expect(geocoderCombo.displayField).to.be('name');
+            expect(geocoderCombo.displayValueMapping).to.be('display_name');
+            expect(geocoderCombo.valueField).to.be('extent');
+            expect(geocoderCombo.queryParam).to.be('q');
+            expect(geocoderCombo.emptyText).to.be('Search a location');
+            expect(geocoderCombo.minChars).to.be(3);
+            expect(geocoderCombo.queryDelay).to.be(100);
+            expect(geocoderCombo.url).to.be(
+                'https://nominatim.openstreetmap.org/search?format=json');
+            expect(geocoderCombo.srs).to.be('EPSG:4326');
+            expect(geocoderCombo.zoom).to.be(10);
+            expect(geocoderCombo.showLocationOnMap).to.be(true);
+        });
+
+        it('store is created if not configured', function() {
+            expect(
+                geocoderCombo.store instanceof Ext.data.JsonStore
+            ).to.be(true);
+        });
+
+        it('locationLayer is created if not configured', function() {
+            expect(
+                geocoderCombo.locationLayer instanceof ol.layer.Vector
+            ).to.be(true);
+        });
+    });
+
+    describe('event handling', function() {
+        var geocoderCombo;
+        var olMap;
+        beforeEach(function() {
+            olMap = new ol.Map({
+                view: new ol.View({
+                    center: [10, 10],
+                    zoom: 0
+                })
+            });
+            geocoderCombo = Ext.create('GeoExt.form.field.GeocoderComboBox', {
+                map: olMap
+            });
+        });
+
+        describe('select', function() {
+            it('centers the map to coordinate', function() {
+                var record = {
+                    get: function() {
+                        return [0, 0];
+                    }
+                };
+                geocoderCombo.onSelect(geocoderCombo, record);
+                expect(Math.round(olMap.getView().getCenter()[0])).to.be(0);
+                expect(Math.round(olMap.getView().getCenter()[1])).to.be(0);
+            });
+
+            it('centers the map to extent', function() {
+                var record = {
+                    get: function() {
+                        return [0, 0, 0, 0];
+                    }
+                };
+                geocoderCombo.onSelect(geocoderCombo, record);
+                expect(Math.round(olMap.getView().getCenter()[0])).to.be(0);
+                expect(Math.round(olMap.getView().getCenter()[1])).to.be(0);
+            });
+
+            it('calls "drawLocationFeatureOnMap" if configured with ' +
+                '"showLocationOnMap"', function() {
+                var record = {
+                    get: function() {
+                        return [0, 0];
+                    }
+                };
+                geocoderCombo.showLocationOnMap = true;
+                var cnt = 0;
+                geocoderCombo.drawLocationFeatureOnMap = function() {
+                    cnt++;
+                };
+                geocoderCombo.onSelect(geocoderCombo, record);
+                expect(cnt).to.be(1);
+            });
+        });
+
+        describe('focus', function() {
+            it('clears the value', function() {
+                geocoderCombo.setValue('foo');
+                geocoderCombo.onFocus();
+                expect(geocoderCombo.getValue()).to.be(null);
+            });
+
+            it('clears the location feature', function() {
+                geocoderCombo.locationLayer = new ol.layer.Vector({
+                    source: new ol.source.Vector({
+                        features: [new ol.Feature()]
+                    })
+                });
+                geocoderCombo.onFocus();
+                var src = geocoderCombo.locationLayer.getSource();
+                expect(src.getFeatures().length).to.be(0);
+            });
+        });
+
+    });
+});

--- a/test/spec/GeoExt/form/field/GeocoderComboBox.test.js
+++ b/test/spec/GeoExt/form/field/GeocoderComboBox.test.js
@@ -63,11 +63,34 @@ describe('GeoExt.form.field.GeocoderComboBox', function() {
             ).to.be(true);
         });
 
-        it('locationLayer is created if not configured', function() {
-            expect(
-                geocoderCombo.locationLayer instanceof ol.layer.Vector
-            ).to.be(true);
+        describe('locationLayer', function() {
+            var style;
+            beforeEach(function() {
+                style = new ol.style.Style({
+                    stroke: new ol.style.Stroke({
+                        color: 'red'
+                    })
+                });
+                geocoderCombo =
+                  Ext.create('GeoExt.form.field.GeocoderComboBox', {
+                      locationLayerStyle: style
+                  });
+            });
+            it('is created if not configured', function() {
+                expect(
+                    geocoderCombo.locationLayer instanceof ol.layer.Vector
+                ).to.be(true);
+            });
+
+            it('has the right style if configured', function() {
+                var locStyle = geocoderCombo.locationLayer.getStyle();
+                expect(locStyle instanceof ol.style.Style).to.be(true);
+                expect(
+                    locStyle.getStroke().getColor()
+                ).to.be(style.getStroke().getColor());
+            });
         });
+
     });
 
     describe('event handling', function() {


### PR DESCRIPTION
This adds a generic `GeocoderCombo` component similar to those we had in previous GeoExt versions.

To sum it up it is a combo box that handles results from a geocoding service. By default it uses OSM Nominatim, but the component offers all config options to overwrite in order to use other custom services.

The component is only usable with the classic toolkit. An appropriate `onClassCreated` callback for not breaking modern apps is implemented. Also a warning is placed in the API docs. 