### PR TITLE
Deactivate Sencha Package creation on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - gem install jsduck
 script:
   - npm test
-  - ./ci/create-sencha-package.sh
+  #- ./ci/create-sencha-package.sh
 after_success:
   - npm run-script coveralls
   - ./ci/update-gh-pages.sh


### PR DESCRIPTION
This (temp.) deactivates the creation of the Sencha Package for GeoExt since this breaks the whole CI chain (see https://travis-ci.org/geoext/geoext3/builds/520762857?utm_source=github_status&utm_medium=notification).
Since CI seems not to work properly anyway (#464) and needs an overhaul and we do not recommend to use GeoExt as Sencha Package it seems OK for the moment to deactivate this.

Any concerns / ideas?