### PR TITLE
WIP:Fix broken Sencha CMD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - gem install jsduck
 script:
   - npm test
-  #- ./ci/create-sencha-package.sh
+  - ./ci/create-sencha-package.sh
 after_success:
   - npm run-script coveralls
   - ./ci/update-gh-pages.sh

--- a/src/form/field/GeocoderComboBox.js
+++ b/src/form/field/GeocoderComboBox.js
@@ -330,6 +330,6 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
     if (!Ext.form && !Ext.form.field && !Ext.form.field.ComboBox) {
         // empty stub to avoid error in class loader when using this in
         // app built ontop of modern toolkit
-        Ext.define('Ext.form.field.ComboBox');
+        Ext.define('Ext.form.field.ComboBox', {});
     }
 });


### PR DESCRIPTION
Currently using Sencha CMD with the master of GeoExt does not work anymore. The problem is the introduced fallback creation of the Ext base class of `GeoExt.form.field.GeocoderComboBox` if it is not available (modern toolkit). Because of the missing config object as second parameter in the `Ext.define` statement Sencha CMD breaks while running `sencha app watch` or `sencha package build`. 

Since this should also fix the package generation on CI, which was deactivated in #500, this is activated again. Nevertheless we should get rid of the Sencha Package creation in the future (as discussed in #500).