### PR TITLE
Fixup empty stub for GeoCoder combo in modern app

### DIFF
--- a/src/form/field/GeocoderComboBox.js
+++ b/src/form/field/GeocoderComboBox.js
@@ -327,9 +327,9 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
         }
     }
 }, function() {
-    if (!Ext.form && !Ext.form.field && !Ext.form.field.ComboBox) {
+    if (!Ext.form || !Ext.form.field || !Ext.form.field.ComboBox) {
         // empty stub to avoid error in class loader when using this in
         // app built ontop of modern toolkit
-        Ext.define('Ext.form.field.ComboBox');
+        Ext.define('Ext.form.field.ComboBox', {});
     }
 });


### PR DESCRIPTION
Just added an empty object as second argument to `Ext.define` to get things (dev and production build for classic and modern) running again.

@marcjansen please review