### PR TITLE
WIP Only define GeocoderComboBox when prerequisites are met

### DIFF
--- a/src/form/field/GeocoderComboBox.js
+++ b/src/form/field/GeocoderComboBox.js
@@ -30,306 +30,307 @@
  *
  * @class GeoExt.form.field.GeocoderComboBox
  */
-Ext.define('GeoExt.form.field.GeocoderComboBox', {
-    extend: 'Ext.form.field.ComboBox',
-    alias: [
-        'widget.gx_geocoder_combo',
-        'widget.gx_geocoder_combobox',
-        'widget.gx_geocoder_field'
-    ],
-    requires: [
-        'Ext.data.JsonStore'
-    ],
-    mixins: [
-        'GeoExt.mixin.SymbolCheck'
-    ],
+Ext.define('GeoExt.form.field.GeocoderComboBox', function() {
+    // define a fallback class when we're on modern that doesn't extend from the
+    // non-existing 'Ext.form.field.ComboBox';
+    if (!Ext.isClassic) {
+        return {};
+    }
+    return {
+        extend: 'Ext.form.field.ComboBox',
+        alias: [
+            'widget.gx_geocoder_combo',
+            'widget.gx_geocoder_combobox',
+            'widget.gx_geocoder_field'
+        ],
+        requires: [
+            'Ext.data.JsonStore'
+        ],
+        mixins: [
+            'GeoExt.mixin.SymbolCheck'
+        ],
 
-    /**
-     * The OpenLayers map to work on. If not provided the selection of an
-     * address would have no effect.
-     *
-     * @cfg {ol.Map}
-     */
-    map: null,
+        /**
+         * The OpenLayers map to work on. If not provided the selection of an
+         * address would have no effect.
+         *
+         * @cfg {ol.Map}
+         */
+        map: null,
 
-    /**
-     * Vector layer to visualize the selected address.
-     * Will be created if not provided.
-     *
-     * @cfg {ol.layer.Vector}
-     * @property {ol.layer.Vector}
-     */
-    locationLayer: null,
+        /**
+         * Vector layer to visualize the selected address.
+         * Will be created if not provided.
+         *
+         * @cfg {ol.layer.Vector}
+         * @property {ol.layer.Vector}
+         */
+        locationLayer: null,
 
-    /**
-     * The style of the #locationLayer. Only has an effect if the layer is not
-     * passed in while creation.
-     *
-     * @cfg {ol.style.Style}
-     */
-    locationLayerStyle: null,
+        /**
+         * The style of the #locationLayer. Only has an effect if the layer is not
+         * passed in while creation.
+         *
+         * @cfg {ol.style.Style}
+         */
+        locationLayerStyle: null,
 
-    /**
-     * The store used for this combo box. Default is a
-     * store with  the url configured as #url
-     * config.
-     *
-     * @cfg {Ext.data.JsonStore}
-     * @propery {Ext.data.JsonStore}
-     */
-    store: null,
+        /**
+         * The store used for this combo box. Default is a
+         * store with  the url configured as #url
+         * config.
+         *
+         * @cfg {Ext.data.JsonStore}
+         * @propery {Ext.data.JsonStore}
+         */
+        store: null,
 
-    /**
-     * The field to display in the combobox result. Default is
-     * "name" for instant use with the default store for this component.
-     *
-     * @cfg {String}
-     */
-    displayField: 'name',
+        /**
+         * The field to display in the combobox result. Default is
+         * "name" for instant use with the default store for this component.
+         *
+         * @cfg {String}
+         */
+        displayField: 'name',
 
-    /**
-     * The field in the GeoCoder service repsonse to be used as mapping for the
-     * 'name' field in the #store.
-     * Ignored when a store is passed in.
-     *
-     * @cfg {String}
-     */
-    displayValueMapping: 'display_name',
+        /**
+         * The field in the GeoCoder service repsonse to be used as mapping for the
+         * 'name' field in the #store.
+         * Ignored when a store is passed in.
+         *
+         * @cfg {String}
+         */
+        displayValueMapping: 'display_name',
 
-    /**
-     * Field from selected record to use when the combo's
-     * #getValue method is called. Default is "extent". This field is
-     * supposed to contain an ol.Extent.
-     * By setting this to 'coordinate' a field holding an ol.Coordinate is used.
-     *
-     * @cfg {String}
-     */
-    valueField: 'extent',
+        /**
+         * Field from selected record to use when the combo's
+         * #getValue method is called. Default is "extent". This field is
+         * supposed to contain an ol.Extent.
+         * By setting this to 'coordinate' a field holding an ol.Coordinate is used.
+         *
+         * @cfg {String}
+         */
+        valueField: 'extent',
 
-    /**
-     * The query parameter for the user entered search text.
-     * Default is 'q' for instant use with OSM Nominatim.
-     *
-     * @cfg {String}
-     */
-    queryParam: 'q',
+        /**
+         * The query parameter for the user entered search text.
+         * Default is 'q' for instant use with OSM Nominatim.
+         *
+         * @cfg {String}
+         */
+        queryParam: 'q',
 
-    /**'Search'
-     * Text to display for an empty field.
-     *
-     * @cfg {String}
-     */
-    emptyText: 'Search a location',
+        /**'Search'
+         * Text to display for an empty field.
+         *
+         * @cfg {String}
+         */
+        emptyText: 'Search a location',
 
-    /**
-     * Minimum number of entered characters to trigger a search.
-     *
-     * @cfg {Number}
-     */
-    minChars: 3,
+        /**
+         * Minimum number of entered characters to trigger a search.
+         *
+         * @cfg {Number}
+         */
+        minChars: 3,
 
-    /**
-     * Delay before the search occurs in ms.
-     *
-     * @cfg {Number}
-     */
-    queryDelay: 100,
+        /**
+         * Delay before the search occurs in ms.
+         *
+         * @cfg {Number}
+         */
+        queryDelay: 100,
 
-    /**
-     * URL template for querying the geocoding service. If a store is
-     * configured, this will be ignored. Note that the #queryParam will be used
-     * to append the user's combo box input to the url.
-     *
-     * @cfg {String}
-     */
-    url: 'https://nominatim.openstreetmap.org/search?format=json',
+        /**
+         * URL template for querying the geocoding service. If a store is
+         * configured, this will be ignored. Note that the #queryParam will be used
+         * to append the user's combo box input to the url.
+         *
+         * @cfg {String}
+         */
+        url: 'https://nominatim.openstreetmap.org/search?format=json',
 
-    /**
-     * The SRS used by the geocoder service.
-     *
-     * @cfg {String}
-     */
-    srs: 'EPSG:4326',
+        /**
+         * The SRS used by the geocoder service.
+         *
+         * @cfg {String}
+         */
+        srs: 'EPSG:4326',
 
-    /**
-     * Zoom level when zooming to a location (#valueField='coordinate')
-     * Not used when zooming to extent.
-     *
-     * @cfg {Number}
-     */
-    zoom: 10,
+        /**
+         * Zoom level when zooming to a location (#valueField='coordinate')
+         * Not used when zooming to extent.
+         *
+         * @cfg {Number}
+         */
+        zoom: 10,
 
-    /**
-     * Flag to steer if selected address feature is drawn on #map
-     * (by #locationLayer).
-     *
-     * @cfg {Boolean}
-     */
-    showLocationOnMap: true,
+        /**
+         * Flag to steer if selected address feature is drawn on #map
+         * (by #locationLayer).
+         *
+         * @cfg {Boolean}
+         */
+        showLocationOnMap: true,
 
-    /**
-     * @private
-     */
-    initComponent: function() {
-        var me = this;
+        /**
+         * @private
+         */
+        initComponent: function() {
+            var me = this;
 
-        if (!me.store) {
-            me.store = Ext.create('Ext.data.JsonStore', {
-                fields: [
-                    {name: 'name', mapping: me.displayValueMapping},
-                    {name: 'extent', convert: me.convertToExtent},
-                    {name: 'coordinate', convert: me.convertToCoordinate}
-                ],
-                proxy: {
-                    type: 'ajax',
-                    url: me.url,
-                    reader: {
-                        type: 'json'
+            if (!me.store) {
+                me.store = Ext.create('Ext.data.JsonStore', {
+                    fields: [
+                        {name: 'name', mapping: me.displayValueMapping},
+                        {name: 'extent', convert: me.convertToExtent},
+                        {name: 'coordinate', convert: me.convertToCoordinate}
+                    ],
+                    proxy: {
+                        type: 'ajax',
+                        url: me.url,
+                        reader: {
+                            type: 'json'
+                        }
                     }
+                });
+            }
+
+            if (!me.locationLayer) {
+                me.locationLayer = new ol.layer.Vector({
+                    source: new ol.source.Vector(),
+                    style: me.locationLayerStyle !== null ?
+                        me.locationLayerStyle : undefined
+                });
+
+                if (me.map) {
+                    me.map.addLayer(me.locationLayer);
                 }
-            });
-        }
+            }
 
-        if (!me.locationLayer) {
-            me.locationLayer = new ol.layer.Vector({
-                source: new ol.source.Vector(),
-                style: me.locationLayerStyle !== null ?
-                    me.locationLayerStyle : undefined
-            });
+            me.callParent(arguments);
 
-            if (me.map) {
-                me.map.addLayer(me.locationLayer);
+            me.on({
+                select: this.onSelect,
+                focus: me.onFocus,
+                scope: me
+            });
+        },
+
+        /**
+         * Function to convert the data delivered by the geocoder service to an
+         * ol.Extent ([minx, miny, maxx, maxy]).
+         * Default implementation converts the Nominatim response.
+         * Can be overwritten to work with other services.
+         *
+         * @param  {Mixed}          v   The data value as read by the Reader
+         * @param  {Ext.data.Model} rec The data record containing raw data
+         * @return {ol.Extent}          The created ol.Extent
+         */
+        convertToExtent: function(v, rec) {
+            var rawExtent = rec.get('boundingbox');
+            var minx = parseFloat(rawExtent[2], 10);
+            var miny = parseFloat(rawExtent[0], 10);
+            var maxx = parseFloat(rawExtent[3], 10);
+            var maxy = parseFloat(rawExtent[1], 10);
+
+            return [minx, miny, maxx, maxy];
+        },
+
+        /**
+         * Function to convert the data delivered by the geocoder service to an
+         * ol.Coordinate ([x, y]).
+         * Default implementation converts the Nominatim response.
+         * Can be overwritten to work with other services.
+         *
+         * @param  {Mixed}          v   The data value as read by the Reader
+         * @param  {Ext.data.Model} rec The data record containing raw data
+         * @return {ol.Coordinate}      The created ol.Coordinate
+         */
+        convertToCoordinate: function(v, rec) {
+            return [parseFloat(rec.get('lon'), 10), parseFloat(rec.get('lat'), 10)];
+        },
+
+        /**
+         * Draws the selected address feature on the map.
+         *
+         * @param  {ol.Coordinate | ol.Extent} coordOrExtent Location feature to be
+         *   drawn on the map
+         */
+        drawLocationFeatureOnMap: function(coordOrExtent) {
+            var me = this;
+            var geom;
+            if (coordOrExtent.length === 2) {
+                geom = new ol.geom.Point(coordOrExtent);
+            } else if (coordOrExtent.length === 4) {
+                geom = ol.geom.Polygon.fromExtent(coordOrExtent);
+            }
+
+            if (geom) {
+                var feat = new ol.Feature({
+                    geometry: geom
+                });
+                me.locationLayer.getSource().clear();
+                me.locationLayer.getSource().addFeature(feat);
+            }
+        },
+
+        /**
+         * Removes the drawn address feature from the map.
+         */
+        removeLocationFeature: function() {
+            this.locationLayer.getSource().clear();
+        },
+
+        /**
+         * Handles the 'focus' event of this ComboBox.
+         */
+        onFocus: function() {
+            var me = this;
+            me.clearValue();
+            me.removeLocationFeature();
+        },
+
+        /**
+         * Handles the 'select' event of this ComboBox.
+         * Zooms to the selected address and draws the address feature on the map
+         * (if configured in #showLocationOnMap)
+         *
+         * @param  {GeoExt.form.field.GeocoderComboBox} combo  [description]
+         * @param  {Ext.data.Model} record [description]
+         *
+         * @private
+         */
+        onSelect: function(combo, record) {
+            var me = this;
+            if (!me.map) {
+                Ext.Logger.warn('No map configured in ' +
+                    'GeoExt.form.field.GeocoderComboBox. Skip zoom to selection.');
+                return;
+            }
+
+            var value = record.get(me.valueField);
+            var projValue;
+            var olMapView = me.map.getView();
+            var targetProj = olMapView.getProjection().getCode();
+            if (value.length === 2) {
+                // point based value
+                projValue = ol.proj.transform(value, me.srs, targetProj);
+
+                // adjust the map
+                olMapView.setCenter(projValue);
+                olMapView.setZoom(me.zoom);
+            } else if (value.length === 4) {
+                // bbox based value
+                projValue = ol.proj.transformExtent(value, me.srs, targetProj);
+
+                // adjust the map
+                olMapView.fit(projValue);
+            }
+
+            if (me.showLocationOnMap) {
+                me.drawLocationFeatureOnMap(projValue);
             }
         }
-
-        me.callParent(arguments);
-
-        me.on({
-            select: this.onSelect,
-            focus: me.onFocus,
-            scope: me
-        });
-    },
-
-    /**
-     * Function to convert the data delivered by the geocoder service to an
-     * ol.Extent ([minx, miny, maxx, maxy]).
-     * Default implementation converts the Nominatim response.
-     * Can be overwritten to work with other services.
-     *
-     * @param  {Mixed}          v   The data value as read by the Reader
-     * @param  {Ext.data.Model} rec The data record containing raw data
-     * @return {ol.Extent}          The created ol.Extent
-     */
-    convertToExtent: function(v, rec) {
-        var rawExtent = rec.get('boundingbox');
-        var minx = parseFloat(rawExtent[2], 10);
-        var miny = parseFloat(rawExtent[0], 10);
-        var maxx = parseFloat(rawExtent[3], 10);
-        var maxy = parseFloat(rawExtent[1], 10);
-
-        return [minx, miny, maxx, maxy];
-    },
-
-    /**
-     * Function to convert the data delivered by the geocoder service to an
-     * ol.Coordinate ([x, y]).
-     * Default implementation converts the Nominatim response.
-     * Can be overwritten to work with other services.
-     *
-     * @param  {Mixed}          v   The data value as read by the Reader
-     * @param  {Ext.data.Model} rec The data record containing raw data
-     * @return {ol.Coordinate}      The created ol.Coordinate
-     */
-    convertToCoordinate: function(v, rec) {
-        return [parseFloat(rec.get('lon'), 10), parseFloat(rec.get('lat'), 10)];
-    },
-
-    /**
-     * Draws the selected address feature on the map.
-     *
-     * @param  {ol.Coordinate | ol.Extent} coordOrExtent Location feature to be
-     *   drawn on the map
-     */
-    drawLocationFeatureOnMap: function(coordOrExtent) {
-        var me = this;
-        var geom;
-        if (coordOrExtent.length === 2) {
-            geom = new ol.geom.Point(coordOrExtent);
-        } else if (coordOrExtent.length === 4) {
-            geom = ol.geom.Polygon.fromExtent(coordOrExtent);
-        }
-
-        if (geom) {
-            var feat = new ol.Feature({
-                geometry: geom
-            });
-            me.locationLayer.getSource().clear();
-            me.locationLayer.getSource().addFeature(feat);
-        }
-    },
-
-    /**
-     * Removes the drawn address feature from the map.
-     */
-    removeLocationFeature: function() {
-        this.locationLayer.getSource().clear();
-    },
-
-    /**
-     * Handles the 'focus' event of this ComboBox.
-     */
-    onFocus: function() {
-        var me = this;
-        me.clearValue();
-        me.removeLocationFeature();
-    },
-
-    /**
-     * Handles the 'select' event of this ComboBox.
-     * Zooms to the selected address and draws the address feature on the map
-     * (if configured in #showLocationOnMap)
-     *
-     * @param  {GeoExt.form.field.GeocoderComboBox} combo  [description]
-     * @param  {Ext.data.Model} record [description]
-     *
-     * @private
-     */
-    onSelect: function(combo, record) {
-        var me = this;
-        if (!me.map) {
-            Ext.Logger.warn('No map configured in ' +
-                'GeoExt.form.field.GeocoderComboBox. Skip zoom to selection.');
-            return;
-        }
-
-        var value = record.get(me.valueField);
-        var projValue;
-        var olMapView = me.map.getView();
-        var targetProj = olMapView.getProjection().getCode();
-        if (value.length === 2) {
-            // point based value
-            projValue = ol.proj.transform(value, me.srs, targetProj);
-
-            // adjust the map
-            olMapView.setCenter(projValue);
-            olMapView.setZoom(me.zoom);
-        } else if (value.length === 4) {
-            // bbox based value
-            projValue = ol.proj.transformExtent(value, me.srs, targetProj);
-
-            // adjust the map
-            olMapView.fit(projValue);
-        }
-
-        if (me.showLocationOnMap) {
-            me.drawLocationFeatureOnMap(projValue);
-        }
-    }
-}, function() {
-    if (!Ext.form || !Ext.form.field || !Ext.form.field.ComboBox) {
-        // empty stub to avoid error in class loader when using this in
-        // app built ontop of modern toolkit
-        Ext.define('Ext.form.field.ComboBox', {});
     }
 });


### PR DESCRIPTION
WIP

Another approach than the one taken in #507 and in #504 

We only define the class with the offending `extends` if we're on classic, otherwise we define the combobox to be an empty class. The API docs warn about not using it in modern.

TODO

* [ ] test in a modern environment