### PR TITLE
Fix empty invalid OGC filters

### DIFF
--- a/src/util/OGCFilter.js
+++ b/src/util/OGCFilter.js
@@ -124,7 +124,9 @@ Ext.define('GeoExt.util.OGCFilter', {
                   '"Ext.grid.filters.filter"');
                 return;
             }
-
+            if (Ext.isEmpty(filters)) {
+                return null;
+            }
             var omitNamespaces = false;
             // filters for WMS layers need to omit the namespaces
             if (!Ext.isEmpty(type) && type.toLowerCase() === 'wms') {

--- a/test/spec/GeoExt/util/OGCFilter.test.js
+++ b/test/spec/GeoExt/util/OGCFilter.test.js
@@ -374,6 +374,12 @@ describe('GeoExt.util.OGCFilter', function() {
                     expect(filters).to.be(undefined);
                 }
             });
+
+            it('returns null if called with empty filters array', function() {
+                var got = GeoExt.util.OGCFilter.getOgcFilterFromExtJsFilter(
+                    [], 'wms');
+                expect(got).to.be(null);
+            });
         });
 
         describe('#getOgcFilter', function() {


### PR DESCRIPTION
Prevent building and sending of [invalid](http://schemas.opengis.net/filter/2.0/filter.xsd) OGC filters without body like `<Filter></Filter>`, if no ExtJS filter were provided. 
