### PR TITLE
Introduce separate 'classic' folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ Just clone the repository into your project (manually or as a `git submodule`, e
 
 In the snippet above, `lib/geoext3` is a clone of the GeoExt repo.
 
+GeoExt also offers components, which are only compatible with the classic
+toolkit of ExtJS (e.g. `StateProvider` or `GeocoderCombo`).
+In case you want to use them you also have to add the `classic` folder to the
+`classpath`. So your complete `classpath` definition could look like below:
+
+```javascript
+    "classpath": [
+        "app",
+        "${toolkit.name}/src",
+        "./lib/geoext3/src",
+        "./lib/geoext3/classic"
+    ]
+```
+
 ### Alternatively: As a `sencha cmd` package
 
 The released versions of GeoExt 3 are published as [ExtJS package](http://docs.sencha.com/cmd/6.x/cmd_packages/cmd_packages.html). They can be used as any other ExtJS package, taking advantage of Sencha cmd.

--- a/classic/README.md
+++ b/classic/README.md
@@ -1,0 +1,15 @@
+# ./classic
+
+This folder contains components, which are only compatible with the classic
+toolkit of ExtJS (e.g. `StateProvider` or `GeocoderCombo`).
+In case you want to use them you also have to add the `classic` folder to the
+`classpath`. So your complete `classpath` definition could look like below:
+
+```javascript
+    "classpath": [
+        "app",
+        "${toolkit.name}/src",
+        "./lib/geoext3/src",
+        "./lib/geoext3/classic"
+    ]
+```

--- a/classic/form/field/GeocoderComboBox.js
+++ b/classic/form/field/GeocoderComboBox.js
@@ -326,10 +326,4 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
             me.drawLocationFeatureOnMap(projValue);
         }
     }
-}, function() {
-    if (!Ext.form || !Ext.form.field || !Ext.form.field.ComboBox) {
-        // empty stub to avoid error in class loader when using this in
-        // app built ontop of modern toolkit
-        Ext.define('Ext.form.field.ComboBox', {});
-    }
 });

--- a/classic/state/PermalinkProvider.js
+++ b/classic/state/PermalinkProvider.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2018 The Open Source Geospatial Foundation
+/* Copyright (c) 2015-2019 The Open Source Geospatial Foundation
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -150,9 +150,5 @@ Ext.define('GeoExt.state.PermalinkProvider', {
         me.mapState = value;
         // call 'set' of super class
         me.callParent(arguments);
-    }
-}, function() {
-    if (!Ext.state || !Ext.state.Provider) {
-        Ext.define('Ext.state.Provider', {});
     }
 });

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -35,7 +35,12 @@ module.exports = function(config) {
             // GeoExt source files
             {
                 pattern: 'src/**/*.js',
-                included: false
+                included: true
+            },
+            // GeoExt classic toolkit source files
+            {
+                pattern: 'classic/**/*.js',
+                included: true
             },
             // GeoExt tests specs
             'test/spec/GeoExt/**/*.test.js'


### PR DESCRIPTION
This introduces a separate 'classic' folder for components, which only work with the classic toolkit of ExtJS.

Also moves the two existing "classic-only" components (`StateProvider` and `GeocoderCombo`) to this folder.

In order to use this "classic-only" components in an application configure the app's `classpath` in the app.json like:

```javascript
    "classpath": [
        "app",
        "./lib/geoext3/src/",
        "./lib/geoext3/classic/"
    ],
```

While modern-users would simply have:

```javascript
    "classpath": [
        "app",
        "./lib/geoext3/src/"
    ],
```