### PR TITLE
Make rootProperty of JSON reader in GeocoderCombo configurable

### DIFF
--- a/classic/form/field/GeocoderComboBox.js
+++ b/classic/form/field/GeocoderComboBox.js
@@ -80,6 +80,14 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
     store: null,
 
     /**
+     * The property in the JSON response of the geocoding service used in
+     * the store's proxy as root object.
+     *
+     * @cfg {String}
+     */
+    proxyRootProperty: null,
+
+    /**
      * The field to display in the combobox result. Default is
      * "name" for instant use with the default store for this component.
      *
@@ -184,7 +192,8 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
                     type: 'ajax',
                     url: me.url,
                     reader: {
-                        type: 'json'
+                        type: 'json',
+                        rootProperty: me.proxyRootProperty
                     }
                 }
             });

--- a/test/spec/GeoExt/form/field/GeocoderComboBox.test.js
+++ b/test/spec/GeoExt/form/field/GeocoderComboBox.test.js
@@ -43,6 +43,7 @@ describe('GeoExt.form.field.GeocoderComboBox', function() {
 
         it('are correctly defined (with defaults)', function() {
             expect(geocoderCombo.map).to.be(null);
+            expect(geocoderCombo.proxyRootProperty).to.be(null);
             expect(geocoderCombo.displayField).to.be('name');
             expect(geocoderCombo.displayValueMapping).to.be('display_name');
             expect(geocoderCombo.valueField).to.be('extent');
@@ -57,10 +58,27 @@ describe('GeoExt.form.field.GeocoderComboBox', function() {
             expect(geocoderCombo.showLocationOnMap).to.be(true);
         });
 
-        it('store is created if not configured', function() {
-            expect(
-                geocoderCombo.store instanceof Ext.data.JsonStore
-            ).to.be(true);
+        describe('store', function() {
+            beforeEach(function() {
+                geocoderCombo =
+                  Ext.create('GeoExt.form.field.GeocoderComboBox', {
+                      proxyRootProperty: 'foo'
+                  });
+            });
+            it('is created if not configured', function() {
+                expect(
+                    geocoderCombo.store instanceof Ext.data.JsonStore
+                ).to.be(true);
+            });
+
+            it('proxyRootProperty is correctly applied to reader of store',
+                function() {
+                    var reader = geocoderCombo.store.getProxy().getReader();
+                    expect(
+                        reader.getRootProperty()
+                    ).to.be('foo');
+                }
+            );
         });
 
         describe('locationLayer', function() {


### PR DESCRIPTION
Adds a config option `proxyRootProperty` to the `GeocoderCombo` component in order to overwrite the property in the JSON response of the geocoding service used in the store's JSON reader as root object.