### PR TITLE
WFS FeatureStore and WFS PagingToolbar

### DIFF
--- a/classic/toolbar/WfsPaging.js
+++ b/classic/toolbar/WfsPaging.js
@@ -24,25 +24,16 @@ Ext.define('GeoExt.toolbar.WfsPaging', {
     xtype: 'gx_wfspaging_toolbar',
 
     /**
-     * @private
-     */
-    initComponent: function() {
-        var me = this;
-
-        me.callParent();
-
-        me.on('added', me.onAddedToParent, me);
-    },
-
-    /**
-     * Handles the 'added' event.
      * Ensures that the 'gx-wfsstoreload' event of the WFS store is bound to the
-     * onLoad function of this toolbar.
+     * onLoad function of this toolbar once we have the store bound.
+     *
      * @private
+     * @param  {Ext.Component} owner The owner component
+     * @param  {Ext.data.Store} store The store
      */
-    onAddedToParent: function() {
+    onOwnerStoreChange: function(owner, store) {
         var me = this;
-        // ensure the paging toolbar is updated once the store is loaded
+        me.callParent(arguments);
         me.store.on('gx-wfsstoreload', me.onLoad, me);
     }
 });

--- a/classic/toolbar/WfsPaging.js
+++ b/classic/toolbar/WfsPaging.js
@@ -1,0 +1,48 @@
+/* Copyright (c) 2015-2019 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * A paging toolbar which can be used in combionation with a OGC WFS by using
+ * the `GeoExt.data.store.WfsFeatures` class.
+ *
+ * @class GeoExt.toolbar.WfsPaging
+ */
+Ext.define('GeoExt.toolbar.WfsPaging', {
+    extend: 'Ext.toolbar.Paging',
+    xtype: 'gx_wfspaging_toolbar',
+
+    /**
+     * @private
+     */
+    initComponent: function() {
+        var me = this;
+
+        me.callParent();
+
+        me.on('added', me.onAddedToParent, me);
+    },
+
+    /**
+     * Handles the 'added' event.
+     * Ensures that the 'gx-wfsstoreload' event of the WFS store is bound to the
+     * onLoad function of this toolbar.
+     * @private
+     */
+    onAddedToParent: function() {
+        var me = this;
+        // ensure the paging toolbar is updated once the store is loaded
+        me.store.on('gx-wfsstoreload', me.onLoad, me);
+    }
+});

--- a/examples/features/grid-paging.html
+++ b/examples/features/grid-paging.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>WFS Feature Grid with Paging Example</title>
+    <link rel="stylesheet" type="text/css" href="../lib/ol/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
+</head>
+
+<body>
+
+    <div id='description'>
+        <p>
+            This example shows how to use an OGC WFS with a feature grid by
+            using the <code>GeoExt.data.store.WfsFeatures</code> class.<br>
+            Also shown is how to use a paging toolbar (<code>GeoExt.toolbar.WfsPaging</code>)
+            in the grid to page through the WFS features.
+        </p>
+        <p>
+            Have a look at <a href="grid-paging.js">grid-paging.js</a> to see how this is
+            done.
+        </p>
+    </div>
+
+    <script src="../lib/ol/ol.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
+    <script>
+        Ext.Loader.setConfig({
+            enabled: true,
+            paths: {
+                'GeoExt': '../../src'
+            }
+        });
+    </script>
+
+    <script src="grid-paging.js"></script>
+</body>
+</html>

--- a/examples/features/grid-paging.js
+++ b/examples/features/grid-paging.js
@@ -1,0 +1,119 @@
+Ext.require([
+    'Ext.container.Container',
+    'Ext.panel.Panel',
+    'Ext.grid.Panel',
+    'GeoExt.component.Map',
+    'GeoExt.data.store.WfsFeatures'
+]);
+
+Ext.Loader.loadScript({
+    url: '../../classic/toolbar/WfsPaging.js'
+});
+
+var olMap;
+var gridWest;
+var featStore;
+
+Ext.application({
+    name: 'FeatureGridWithPaging',
+    launch: function() {
+        // a WFS feature store
+        featStore = Ext.create('GeoExt.data.store.WfsFeatures', {
+            model: 'GeoExt.data.model.Feature',
+            passThroughFilter: true,
+            createLayer: true,
+            url: 'https://maps.dwd.de/geoserver/dwd/ows?',
+            version: '2.0.0',
+            typeName: 'dwd:Warngebiete_Kreise',
+            outputFormat: 'application/json',
+            sortBy: 'NAME',
+            startIndex: 0,
+            count: 10,
+            format: new ol.format.GeoJSON({
+                featureProjection: 'EPSG:3857'
+            }),
+            style: new ol.style.Style({
+                stroke: new ol.style.Stroke({
+                    color: 'rgba(255, 255, 0, 1.0)',
+                    width: 2
+                })
+            })
+        });
+
+        // feature grid with paging toolbar showing the WFS features
+        gridWest = Ext.create('Ext.grid.Panel', {
+            title: 'WFS Feature Grid with paging toolbar',
+            width: 500,
+            border: true,
+            region: 'west',
+            store: featStore,
+            columns: [
+                {
+                    text: 'Cell ID',
+                    dataIndex: 'WARNCELLID',
+                    flex: 1,
+                    filter: {
+                        type: 'list'
+                    }
+                },
+                {
+                    text: 'Name',
+                    dataIndex: 'NAME',
+                    flex: 2,
+                    filter: {
+                        type: 'string'
+                    }
+                }
+            ],
+            bbar: {
+                // WFS paging toolbar
+                xtype: 'gx_wfspaging_toolbar',
+                displayInfo: true
+            }
+        });
+
+        olMap = new ol.Map({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.TileWMS({
+                        url: 'https://ows.terrestris.de/osm-gray/service',
+                        params: {'LAYERS': 'OSM-WMS', 'TILED': true},
+                        attributions: [new ol.Attribution({
+                            html: '<a href="https://www.openstreetmap.org/' +
+                            'copyright">OpenStreetMap contributors</a>'
+                        })]
+                    })
+                }),
+                // WFS Layer
+                featStore.layer
+            ],
+            view: new ol.View({
+                center: ol.proj.fromLonLat([8, 50]),
+                zoom: 5
+            })
+        });
+
+        var mapComponent = Ext.create('GeoExt.component.Map', {
+            map: olMap
+        });
+        var mapPanel = Ext.create('Ext.panel.Panel', {
+            region: 'center',
+            height: 400,
+            layout: 'fit',
+            items: [mapComponent]
+        });
+        var description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            region: 'north',
+            title: 'Description',
+            height: 150,
+            border: false,
+            bodyPadding: 5,
+            autoScroll: true
+        });
+        Ext.create('Ext.Viewport', {
+            layout: 'border',
+            items: [description, mapPanel, gridWest]
+        });
+    }
+});

--- a/examples/features/grid-paging.js
+++ b/examples/features/grid-paging.js
@@ -22,6 +22,8 @@ Ext.application({
             model: 'GeoExt.data.model.Feature',
             passThroughFilter: true,
             createLayer: true,
+            layerAttribution: '| <a href="https://www.dwd.de/"> ' +
+                'Source: Deutscher Wetterdienst</a>',
             url: 'https://maps.dwd.de/geoserver/dwd/ows?',
             version: '2.0.0',
             typeName: 'dwd:Warngebiete_Kreise',
@@ -78,10 +80,9 @@ Ext.application({
                     source: new ol.source.TileWMS({
                         url: 'https://ows.terrestris.de/osm-gray/service',
                         params: {'LAYERS': 'OSM-WMS', 'TILED': true},
-                        attributions: [new ol.Attribution({
-                            html: '<a href="https://www.openstreetmap.org/' +
+                        attributions:
+                            '<a href="https://www.openstreetmap.org/' +
                             'copyright">OpenStreetMap contributors</a>'
-                        })]
                     })
                 }),
                 // WFS Layer
@@ -98,7 +99,6 @@ Ext.application({
         });
         var mapPanel = Ext.create('Ext.panel.Panel', {
             region: 'center',
-            height: 400,
             layout: 'fit',
             items: [mapComponent]
         });

--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -32,6 +32,8 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
 
     /**
      * The 'version' param value used in the WFS request.
+     * This should be '2.0.0' or higher at least if the paging mechanism
+     * should be used.
      * @cfg {String}
      */
     version: '2.0.0',
@@ -49,7 +51,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
     typeName: null,
 
     /**
-     * The 'typeName' param value used in the WFS request.
+     * The 'outputFormat' param value used in the WFS request.
      * @cfg {String}
      */
     outputFormat: 'application/json',
@@ -83,6 +85,13 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
      * @cfg {ol.format.Feature}
      */
     format: null,
+
+    /**
+     * The attribution added to the created vector layer source. Only has an
+     * effect if #createLayer is set to `true`
+     * @cfg {String}
+     */
+    layerAttribution: null,
 
     /**
      * Constructs the WFS feature store.
@@ -120,7 +129,8 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
         if (createLayer) {
             // the WFS vector layer showing the WFS features on the map
             me.source = new ol.source.Vector({
-                features: []
+                features: [],
+                attributions: me.layerAttribution
             });
             me.layer = new ol.layer.Vector({
                 source: me.source,

--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -1,0 +1,213 @@
+/* Copyright (c) 2015-2019 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * A data store loading features from an OGC WFS.
+ *
+ * @class GeoExt.data.store.WfsFeatures
+ */
+Ext.define('GeoExt.data.store.WfsFeatures', {
+    extend: 'GeoExt.data.store.Features',
+    mixins: [
+        'GeoExt.mixin.SymbolCheck'
+    ],
+
+    /**
+     * The 'service' param value used in the WFS request.
+     * @cfg {String}
+     */
+    service: 'WFS',
+
+    /**
+     * The 'version' param value used in the WFS request.
+     * @cfg {String}
+     */
+    version: '2.0.0',
+
+    /**
+     * The 'request' param value used in the WFS request.
+     * @cfg {String}
+     */
+    request: 'GetFeature',
+
+    /**
+     * The 'typeName' param value used in the WFS request.
+     * @cfg {String}
+     */
+    typeName: null,
+
+    /**
+     * The 'typeName' param value used in the WFS request.
+     * @cfg {String}
+     */
+    outputFormat: 'application/json',
+
+    /**
+     * The 'sortBy' param value used in the WFS request.
+     * @cfg {String}
+     */
+    sortBy: null,
+
+    /**
+     * The 'startIndex' param value used in the WFS request.
+     * @cfg {String}
+     */
+    startIndex: 0,
+
+    /**
+     * The 'count' param value used in the WFS request.
+     * @cfg {String}
+     */
+    count: null,
+
+    /**
+     * Offset to add to the #startIndex in the WFS request.
+     * @cfg {Number}
+     */
+    startIndexOffset: 0,
+
+    /**
+     * The OL format used to parse the WFS GetFeature response.
+     * @cfg {ol.format.Feature}
+     */
+    format: null,
+
+    /**
+     * Constructs the WFS feature store.
+     *
+     * @param {Object} config The configuration object.
+     * @private
+     */
+    constructor: function(config) {
+        var me = this;
+
+        config = config || {};
+
+        // apply count as store's pageSize
+        config.pageSize = config.count || me.count;
+
+        if (config.pageSize > 0) {
+            // calculate initial page
+            var startIndex = config.startIndex || me.startIndex;
+            var currentPage = Math.floor(startIndex / config.pageSize) + 1;
+            config.currentPage = currentPage;
+        }
+
+        // avoid creation of vector layer by parent class (raises error when
+        // applying WFS data) so we can create the WFS vector layer on our own
+        // (if needed)
+        var createLayer = config.createLayer;
+        config.createLayer = false;
+
+        me.callParent([config]);
+
+        if (!me.url) {
+            Ext.raise('No URL given to WfsFeaturesStore');
+        }
+
+        if (createLayer) {
+            // the WFS vector layer showing the WFS features on the map
+            me.source = new ol.source.Vector({
+                features: []
+            });
+            me.layer = new ol.layer.Vector({
+                source: me.source,
+                style: me.style
+            });
+
+            me.layerCreated = true;
+        }
+
+        // initally load the WFS data
+        me.loadWfs();
+
+        // before the store gets re-loaded (e.g. by a paging toolbar) we trigger
+        // the re-loading of the WFS, so the data keeps in sync
+        me.on('beforeload', me.loadWfs, me);
+
+        // add layer to connected map, if available
+        if (me.map && me.layer) {
+            me.map.addLayer(me.layer);
+        }
+    },
+
+    /**
+     * Loads the data from the connected WFS.
+     * @private
+     */
+    loadWfs: function() {
+        var me = this;
+        var url = me.url;
+        var params = {
+            service: me.service,
+            version: me.version,
+            request: me.request,
+            typeName: me.typeName,
+            outputFormat: me.outputFormat,
+            sortBy: me.sortBy
+        };
+
+        // apply paging parameters if necessary
+        if (me.pageSize) {
+            var fromRecord =
+              ((me.currentPage - 1) * me.pageSize) + me.startIndexOffset;
+            me.startIndex = fromRecord;
+            params.startIndex = me.startIndex;
+            params.count = me.pageSize;
+        }
+
+        // fire event 'gx-wfsstoreload-beforeload' and skip loading if listener
+        // function returns false
+        if (me.fireEvent('gx-wfsstoreload-beforeload', me, params) === false) {
+            return;
+        }
+
+        // request features from WFS
+        Ext.Ajax.request({
+            url: url,
+            method: 'GET',
+            params: params,
+            success: function(response) {
+                var respJson = Ext.decode(response.responseText);
+
+                // set number of total features (needed for paging)
+                me.totalCount = respJson.numberMatched;
+
+                if (!me.format) {
+                    Ext.Logger.warn('No format given for WfsFeatureStore. ' +
+                        'Skip parsing feature data.');
+                    return;
+                }
+                var wfsFeats = me.format.readFeatures(respJson);
+
+                // set data for store
+                me.setData(wfsFeats);
+
+                if (me.layer) {
+                    // add features to WFS layer
+                    me.source.clear();
+                    me.source.addFeatures(wfsFeats);
+                }
+
+                me.fireEvent('gx-wfsstoreload', me);
+            },
+            failure: function(response) {
+                Ext.Logger.warn('Error while requesting features from WFS: ' +
+                    response.responseText + ' Status: ' + response.status);
+            }
+
+        });
+    }
+});

--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -155,7 +155,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
 
     /**
      * Detects the total amount of features (without paging) of the given
-     * WFS response. The detectioin is based on the response format (currently
+     * WFS response. The detection is based on the response format (currently
      * GeoJSON and GML >=v3 are supported).
      *
      * @private
@@ -165,15 +165,21 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
     getTotalFeatureCount: function(wfsResponse) {
         var me = this;
         var totalCount = -1;
-        if (me.outputFormat.indexOf('application/json') !== -1) {
-            var respJson = Ext.decode(wfsResponse.responseText);
-            totalCount = respJson.numberMatched;
-        } else {
-            var xml = wfsResponse.responseXML;
-            if (xml && xml.firstChild) {
-                var total = xml.firstChild.getAttribute('numberMatched');
-                totalCount = parseInt(total, 10);
+
+        try {
+            if (me.outputFormat.indexOf('application/json') !== -1) {
+                var respJson = Ext.decode(wfsResponse.responseText);
+                totalCount = respJson.numberMatched;
+            } else {
+                var xml = wfsResponse.responseXML;
+                if (xml && xml.firstChild) {
+                    var total = xml.firstChild.getAttribute('numberMatched');
+                    totalCount = parseInt(total, 10);
+                }
             }
+        } catch (e) {
+            Ext.Logger.warn('Error while detecting total feature count from ' +
+                'WFS response');
         }
 
         return totalCount;

--- a/test/data/wfs_mock.geojson
+++ b/test/data/wfs_mock.geojson
@@ -1,0 +1,38 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"foo": 1},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.8984375,
+          50.51342652633956
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"foo": 2},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -105.1171875,
+          37.996162679728116
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"foo": 3},
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          135.35156249999997,
+          -23.24134610238612
+        ]
+      }
+    }
+  ]
+}

--- a/test/index.html
+++ b/test/index.html
@@ -42,6 +42,7 @@
   <script src='spec/GeoExt/data/model/Feature.test.js'></script>
   <script src='spec/GeoExt/data/model/Layer.test.js'></script>
   <script src='spec/GeoExt/data/model/OlObject.test.js'></script>
+  <script src='spec/GeoExt/data/model/WfsFeatures.test.js'></script>
   <script src='spec/GeoExt/data/model/print/Capability.test.js'></script>
   <script src='spec/GeoExt/data/model/print/Layout.test.js'></script>
   <script src='spec/GeoExt/data/model/print/LayoutAttribute.test.js'></script>

--- a/test/index.html
+++ b/test/index.html
@@ -60,6 +60,7 @@
   <script src='spec/GeoExt/grid/column/Symbolizer.test.js'></script>
   <script src='spec/GeoExt/mixin/SymbolCheck.test.js'></script>
   <script src='spec/GeoExt/state/PermalinkProvider.test.js'></script>
+  <script src='spec/GeoExt/toolbar/WfsPaging.test.js'></script>
   <script src='spec/GeoExt/util/Layer.test.js'></script>
   <script>
     mocha.run();

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -24,9 +24,11 @@ describe('GeoExt.data.store.WfsFeatures', function() {
 
     describe('configs and properties', function() {
         var store;
+        var dataPath = (typeof __karma__ === 'undefined' ? '' : 'base/test/');
+        var url = dataPath + 'data/wfs_mock.geojson';
         beforeEach(function() {
             store = Ext.create('GeoExt.data.store.WfsFeatures', {
-                url: 'foo'
+                url: url
             });
         });
         afterEach(function() {
@@ -116,8 +118,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
         var dataPath = (typeof __karma__ === 'undefined' ? '' : 'base/test/');
         var url = dataPath + 'data/wfs_mock.geojson';
         beforeEach(function() {
-            div = document.createElement('div');
-            document.body.appendChild(div);
+            div = TestUtil.setupTestDiv();
             map = new ol.Map({
                 target: div,
                 layers: [],
@@ -141,8 +142,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
             }
             store = null;
             map = null;
-            document.body.removeChild(div);
-            div = null;
+            TestUtil.teardownTestDiv();
         });
 
         it('creates a new layer on the given map', function() {

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -1,0 +1,166 @@
+Ext.Loader.syncRequire(['GeoExt.data.store.WfsFeatures']);
+
+describe('GeoExt.data.store.WfsFeatures', function() {
+
+    describe('basics', function() {
+        it('is defined', function() {
+            expect(GeoExt.data.store.WfsFeatures).not.to.be(undefined);
+        });
+    });
+
+    describe('constructor (no arguments)', function() {
+
+        it('raises an error', function() {
+            var errRaised = false;
+            try {
+                Ext.create('GeoExt.data.store.WfsFeatures');
+            } catch (e) {
+                errRaised = true;
+            }
+
+            expect(errRaised).to.be(true);
+        });
+    });
+
+    describe('configs and properties', function() {
+        var store;
+        beforeEach(function() {
+            store = Ext.create('GeoExt.data.store.WfsFeatures', {
+                url: 'foo'
+            });
+        });
+        afterEach(function() {
+            store.destroy();
+        });
+
+        it('are correctly defined (with defaults)', function() {
+            expect(store.service).to.be('WFS');
+            expect(store.version).to.be('2.0.0');
+            expect(store.request).to.be('GetFeature');
+            expect(store.typeName).to.be(null);
+            expect(store.outputFormat).to.be('application/json');
+            expect(store.sortBy).to.be(null);
+            expect(store.startIndex).to.be(0);
+            expect(store.count).to.be(null);
+            expect(store.startIndexOffset).to.be(0);
+        });
+    });
+
+    describe('loading without paging', function() {
+        var dataPath = (typeof __karma__ === 'undefined' ? '' : 'base/test/');
+        var url = dataPath + 'data/wfs_mock.geojson';
+
+        it('uses the correct WFS parameters', function() {
+
+            Ext.create('GeoExt.data.store.WfsFeatures', {
+                url: url,
+                format: new ol.format.GeoJSON({
+                    featureProjection: 'EPSG:3857'
+                }),
+                listeners: {
+                    'gx-wfsstoreload-beforeload': function(str, params) {
+                        expect(params.service).to.be(str.service);
+                        expect(params.version).to.be(str.version);
+                        expect(params.request).to.be(str.request);
+                        expect(params.typeName).to.be(str.typeName);
+                        expect(params.outputFormat).to.be(str.outputFormat);
+                        expect(params.sortBy).to.be(str.sortBy);
+                    },
+                    'gx-wfsstoreload': function(str) {
+                        expect(str.getCount()).to.be(3);
+                    }
+                }
+            });
+        });
+    });
+
+    describe('loading with paging', function() {
+        var dataPath = (typeof __karma__ === 'undefined' ? '' : 'base/test/');
+        var url = dataPath + 'data/wfs_mock.geojson';
+
+        it('uses the correct WFS parameters', function() {
+
+            Ext.create('GeoExt.data.store.WfsFeatures', {
+                url: url,
+                format: new ol.format.GeoJSON({
+                    featureProjection: 'EPSG:3857'
+                }),
+                sortBy: 'foo',
+                startIndex: 0,
+                count: 10,
+                listeners: {
+                    'gx-wfsstoreload-beforeload': function(str, params) {
+                        expect(params.service).to.be(str.service);
+                        expect(params.version).to.be(str.version);
+                        expect(params.request).to.be(str.request);
+                        expect(params.typeName).to.be(str.typeName);
+                        expect(params.outputFormat).to.be(str.outputFormat);
+                        expect(params.sortBy).to.be(str.sortBy);
+                        expect(params.startIndex).to.be(str.startIndex);
+                        expect(params.count).to.be(str.pageSize);
+                        expect(params.startIndex).to.be(0);
+                        expect(params.count).to.be(10);
+                    },
+                    'gx-wfsstoreload': function(str) {
+                        expect(str.getCount()).to.be(3);
+                    }
+                }
+            });
+        });
+    });
+
+    describe('config option "createLayer"', function() {
+        var store;
+        var div;
+        var map;
+        var dataPath = (typeof __karma__ === 'undefined' ? '' : 'base/test/');
+        var url = dataPath + 'data/wfs_mock.geojson';
+        beforeEach(function() {
+            div = document.createElement('div');
+            document.body.appendChild(div);
+            map = new ol.Map({
+                target: div,
+                layers: [],
+                view: new ol.View({
+                    center: [0, 0],
+                    zoom: 2
+                })
+            });
+            store = Ext.create('GeoExt.data.store.WfsFeatures', {
+                url: url,
+                map: map,
+                createLayer: true,
+                format: new ol.format.GeoJSON({
+                    featureProjection: 'EPSG:3857'
+                })
+            });
+        });
+        afterEach(function() {
+            if (store.destroy) {
+                store.destroy();
+            }
+            store = null;
+            map = null;
+            document.body.removeChild(div);
+            div = null;
+        });
+
+        it('creates a new layer on the given map', function() {
+            expect(map.getLayers().getLength()).to.be(1);
+        });
+
+        it('creates the layer which is retrievable via #getLayer', function() {
+            expect(store.getLayer()).to.be(map.getLayers().item(0));
+        });
+
+        it('removes the autocreated layer once the store is destroyed',
+            function() {
+                // before
+                expect(map.getLayers().getLength()).to.be(1);
+                store.destroy();
+                // after
+                expect(map.getLayers().getLength()).to.be(0);
+            }
+        );
+    });
+});

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -142,7 +142,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
             }
             store = null;
             map = null;
-            TestUtil.teardownTestDiv();
+            TestUtil.teardownTestDiv(div);
         });
 
         it('creates a new layer on the given map', function() {

--- a/test/spec/GeoExt/toolbar/WfsPaging.test.js
+++ b/test/spec/GeoExt/toolbar/WfsPaging.test.js
@@ -1,0 +1,50 @@
+Ext.Loader.syncRequire(['GeoExt.toolbar.WfsPaging']);
+
+describe('GeoExt.toolbar.WfsPaging', function() {
+
+    describe('basics', function() {
+        it('GeoExt.toolbar.WfsPaging is defined', function() {
+            expect(GeoExt.toolbar.WfsPaging).not.to.be(undefined);
+        });
+
+        describe('constructor', function() {
+            it('can be constructed wo/ arguments via Ext.create()', function() {
+                var wfsPagingTb =
+                    Ext.create('GeoExt.toolbar.WfsPaging');
+                expect(wfsPagingTb).to.be.an(
+                    GeoExt.toolbar.WfsPaging);
+            });
+        });
+    });
+
+    describe('event "gx-wfsstoreload" of connected store', function() {
+        var dataPath = (typeof __karma__ === 'undefined' ? '' : 'base/test/');
+        var url = dataPath + 'data/wfs_mock.geojson';
+        var wfsStore = Ext.create('GeoExt.data.store.WfsFeatures', {
+            url: url,
+            format: new ol.format.GeoJSON({
+                featureProjection: 'EPSG:3857'
+            })
+        });
+
+        var wfsPagingTb = Ext.create('GeoExt.toolbar.WfsPaging');
+        var loadCalled = false;
+        wfsPagingTb.onLoad = function() {
+            loadCalled = true;
+        };
+
+        Ext.create('Ext.grid.Panel', {
+            width: 500,
+            store: wfsStore,
+            columns: [{
+                text: 'FOO',
+                dataIndex: 'foo'
+            }],
+            bbar: wfsPagingTb
+        });
+
+        it('is bound to the "onLoad" function of the toolbar', function() {
+            expect(loadCalled).to.be(true);
+        });
+    });
+});


### PR DESCRIPTION
This PR adds a store to load features from an OGC WFS (`GeoExt.data.store.WfsFeatures`). So WFS features can easily managed and used with common UI components (e.g. grids).

In order to provide a paging mechanism for WFS data a custom WFS PagingToolbar (`GeoExt.toolbar.WfsPaging`) is also introduced by this PR.

See the provided example how to use these two components together.