### PR TITLE
Fix loading of "classic-only" sources in examples

### DIFF
--- a/examples/geocoder/geocoder-combo.js
+++ b/examples/geocoder/geocoder-combo.js
@@ -1,6 +1,13 @@
 Ext.require([
-    'GeoExt.form.field.GeocoderComboBox'
+    'Ext.Viewport',
+    'Ext.panel.Panel',
+    'GeoExt.component.Map'
 ]);
+
+// load components, which are only compatible with the classic toolkit
+Ext.Loader.loadScript({
+    url: '../../classic/form/field/GeocoderComboBox.js'
+});
 
 var olMap;
 var mapComponent;

--- a/examples/state/stateful-map.js
+++ b/examples/state/stateful-map.js
@@ -1,9 +1,13 @@
 Ext.require([
     'Ext.panel.Panel',
     'Ext.Viewport',
-    'GeoExt.state.PermalinkProvider',
     'GeoExt.component.Map'
 ]);
+
+// load components, which are only compatible with the classic toolkit
+Ext.Loader.loadScript({
+    url: '../../classic/state/PermalinkProvider.js'
+});
 
 var olMap;
 var mapComponent;


### PR DESCRIPTION
This fixes the broken loading of the classes, which are only usable with the classic toolkit in the examples. Since we use the `Ext.Loader` in the examples, which is only capable of loading one source folder for the `GeoExt` namespace, the classic components need to be loaded separately.