### PR TITLE
Support lte and gte filters

### DIFF
--- a/src/util/OGCFilter.js
+++ b/src/util/OGCFilter.js
@@ -263,8 +263,14 @@ Ext.define('GeoExt.util.OGCFilter', {
             case 'lt':
                 ogcFilterType = 'PropertyIsLessThan';
                 break;
+            case 'lte':
+                ogcFilterType = 'PropertyIsLessThanOrEqualTo';
+                break;
             case 'gt':
                 ogcFilterType = 'PropertyIsGreaterThan';
+                break;
+            case 'gte':
+                ogcFilterType = 'PropertyIsGreaterThanOrEqualTo';
                 break;
             case 'like':
                 value = '*' + value + '*';

--- a/test/spec/GeoExt/util/OGCFilter.test.js
+++ b/test/spec/GeoExt/util/OGCFilter.test.js
@@ -416,6 +416,27 @@ describe('GeoExt.util.OGCFilter', function() {
                     expect(filter).to.be(undefined);
                 }
             });
+
+            it('supports lte filter', function() {
+                var filter = GeoExt.util.OGCFilter.getOgcFilter(
+                    'humpty-dumpty', 'lte', 4711
+                );
+                var expected = '<PropertyIsLessThanOrEqualTo>'
+                    + '<PropertyName>humpty-dumpty</PropertyName>'
+                    + '<Literal>4711</Literal>'
+                    + '</PropertyIsLessThanOrEqualTo>';
+                expect(filter).to.be(expected);
+            });
+            it('supports gte filter', function() {
+                var filter = GeoExt.util.OGCFilter.getOgcFilter(
+                    'humpty-dumpty', 'gte', 4711
+                );
+                var expected = '<PropertyIsGreaterThanOrEqualTo>'
+                    + '<PropertyName>humpty-dumpty</PropertyName>'
+                    + '<Literal>4711</Literal>'
+                    + '</PropertyIsGreaterThanOrEqualTo>';
+                expect(filter).to.be(expected);
+            });
         });
 
         describe('#buildWfsGetFeatureWithFilter', function() {


### PR DESCRIPTION
This PR adds support for `lte` and `gte` filters which will result in `<PropertyIsLessThanOrEqualTo>` and `<PropertyIsGreaterThanOrEqualTo>` to be produced.

Please review.