### PR TITLE
Add browser sync for classic folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:coverage": "karma start test/karma.conf.js --single-run --reporters coverage",
     "test:watch": "karma start test/karma.conf.js",
     "test:watch:debug": "karma start test/karma.conf.js --debug",
-    "start": "browser-sync start --server --directory --files 'src, test, examples'",
+    "start": "browser-sync start --server --directory --files 'src, classic, test, examples'",
     "coveralls": "cat coverage/lcov.info | coveralls",
     "generate:example": "node bin/example-generator/index.js",
     "generate:docs": "jsduck --config jsduck.json",


### PR DESCRIPTION
Watch the `classic` folder when synchronizing with the browser while running `npm start`.  