### PR TITLE
Add GeoExt.selection.FeatureModel

### DIFF
--- a/classic/selection/FeatureModel.js
+++ b/classic/selection/FeatureModel.js
@@ -111,7 +111,7 @@ Ext.define('GeoExt.selection.FeatureModel', {
         // detect a layer from the store if not passed in
         if (!me.layer || !me.layer instanceof ol.layer.Vector) {
             var store = me.getStore();
-            if (store && store.getLayer() &&
+            if (store && store.getLayer && store.getLayer() &&
                 store.getLayer() instanceof ol.layer.Vector) {
                 me.layer = store.getLayer();
             }
@@ -271,12 +271,12 @@ Ext.define('GeoExt.selection.FeatureModel', {
 
     /**
      * Overwrites the onSelectChange function of the father class.
-     * Ensures that the selected feature are added / removed to / from
+     * Ensures that the selected feature is added / removed to / from
      * #selectedFeatures lookup object.
      *
      * @private
      * @param  {GeoExt.data.model.Feature} record Selected / deselected record
-     * @param  {Boolean} isSelected Record id selected or deselected
+     * @param  {Boolean} isSelected Record is selected or deselected
      */
     onSelectChange: function(record, isSelected) {
         var me = this;

--- a/classic/selection/FeatureModel.js
+++ b/classic/selection/FeatureModel.js
@@ -153,15 +153,13 @@ Ext.define('GeoExt.selection.FeatureModel', {
     unbindOlEvents: function() {
         var me = this;
 
+        // remove 'add' / 'remove' listener from selected feature collection
         if (me.selectedFeatures) {
-            // change style of selected feature
             me.selectedFeatures.un('add', me.onSelectFeatAdd, me);
-
-            // reset style of no more selected feature
             me.selectedFeatures.un('remove', me.onSelectFeatRemove, me);
         }
 
-        // create a map click listener for connected vector layer
+        // remove 'singleclick' listener for connected vector layer
         if (me.mapClickRegistered) {
             me.map.un('singleclick', me.onFeatureClick, me);
             me.mapClickRegistered = false;
@@ -206,6 +204,7 @@ Ext.define('GeoExt.selection.FeatureModel', {
             if (fid && me.existingFeatStyles[fid]) {
                 // restore existing feature style
                 feat.setStyle(me.existingFeatStyles[fid]);
+                delete me.existingFeatStyles[fid];
             } else {
                 // reset feature style, so layer style gets active
                 feat.setStyle();
@@ -295,7 +294,7 @@ Ext.define('GeoExt.selection.FeatureModel', {
     },
 
     /**
-     * Ovrwrite parent's destroy method in order to unregister the OL events,
+     * Overwrites parent's destroy method in order to unregister the OL events,
      * that were added on init.
      * Needed due to the lack of destroy event of the parent class.
      *
@@ -322,6 +321,6 @@ Ext.define('GeoExt.selection.FeatureModel', {
      */
     getRandomFid: function() {
         // current timestamp plus a random int between 0 and 10
-        return new Date().getTime() + Math.floor(Math.random() * 11);
+        return new Date().getTime() + '' +  Math.floor(Math.random() * 11);
     }
 });

--- a/classic/selection/FeatureModel.js
+++ b/classic/selection/FeatureModel.js
@@ -1,0 +1,238 @@
+/* Copyright (c) 2015-2019 The Open Source Geospatial Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+  * A row selection model which enables automatic selection of features
+  * in the map when rows are selected in the grid and vice-versa.
+  *
+  * @class GeoExt.selection.FeatureModel
+  */
+Ext.define('GeoExt.selection.FeatureModel', {
+    extend: 'Ext.selection.RowModel',
+    alias: 'selection.featuremodel',
+
+    /**
+     * The currently selected features.
+     * @property {ol.Collection<ol.Feature>}
+     */
+    selectedFeatures: null,
+
+    /**
+     * The connected vector layer.
+     * @cfg {ol.layer.Vector}
+     * @property {ol.layer.Vector}
+     */
+    layer: null,
+
+    /**
+     * The OpenLayers map we work on
+     * @cfg {ol.Map}
+     */
+    map: null,
+
+    /**
+     * Set to true to create a click handler on the map selecting a clicked
+     * object in the #layer.
+     * @cfg {Boolean}
+     */
+    mapSelection: false,
+
+    /**
+     * The default style for the selected features.
+     * @cfg {ol.style.Style}
+     */
+    selectStyle: new ol.style.Style({
+        image: new ol.style.Circle({
+            radius: 6,
+            fill: new ol.style.Fill({
+                color: 'rgba(255,255,255,0.8)'
+            }),
+            stroke: new ol.style.Stroke({
+                color: 'darkblue',
+                width: 2
+            })
+        }),
+        fill: new ol.style.Fill({
+            color: 'rgba(255,255,255,0.8)'
+        }),
+        stroke: new ol.style.Stroke({
+            color: 'darkblue',
+            width: 2
+        })
+    }),
+
+    /**
+     * The attribute key to mark an OL feature as selected.
+     * @cfg {String}
+     * @property
+     * @readonly
+     */
+    selectedFeatureAttr: 'gx_selected',
+
+    /**
+     * Prepare several connected objects once the selection model is ready.
+     *
+     * @private
+     */
+    bindComponent: function() {
+        var me = this;
+
+        me.callParent(arguments);
+
+        me.selectedFeatures = new ol.Collection();
+
+        // detect a layer from the store if not passed in
+        if (!me.layer || !me.layer instanceof ol.layer.Vector) {
+            var store = me.getStore();
+            if (store && store.getLayer() &&
+                store.getLayer() instanceof ol.layer.Vector) {
+                me.layer = store.getLayer();
+            }
+        }
+
+        // bind several OL events
+        me.bindOlEvents();
+    },
+
+    /**
+     * Binds several events on the OL objects used in this class.
+     *
+     * @private
+     */
+    bindOlEvents: function() {
+        var me = this;
+
+        // change style of selected feature
+        me.selectedFeatures.on('add', me.onSelectFeatAdd, me);
+
+        // reset style of no more selected feature
+        me.selectedFeatures.on('remove', me.onSelectFeatRemove, me);
+
+        // create a map click listener for connected vector layer
+        if (me.mapSelection && me.layer && me.map) {
+            me.map.on('singleclick', me.onFeatureClick, me);
+        }
+    },
+
+    /**
+     * Handles 'add' event of #selectedFeatures.
+     * Ensures that added feature gets the #selectStyle.
+     *
+     * @private
+     * @param  {ol.Collection.Event} evt OL event object
+     */
+    onSelectFeatAdd: function(evt) {
+        var me = this;
+        var feat = evt.element;
+        if (feat) {
+            feat.setStyle(me.selectStyle);
+        }
+    },
+
+    /**
+     * Handles 'remove' event of #selectedFeatures.
+     * Ensures that the #selectStyle is reset on the removed feature.
+     *
+     * @private
+     * @param  {ol.Collection.Event} evt OL event object
+     */
+    onSelectFeatRemove: function(evt) {
+        var feat = evt.element;
+        if (feat) {
+            feat.setStyle();
+        }
+    },
+
+    /**
+     * Handles the 'singleclick' event of the #map.
+     * Detects if a feature of the connected #layer has been clicked and selects
+     * this feature by selecting its corresponding grid row.
+     *
+     * @private
+     * @param  {ol.MapBrowserEvent} evt OL event object
+     */
+    onFeatureClick: function(evt) {
+        var me = this;
+        var feat = me.map.forEachFeatureAtPixel(evt.pixel,
+            function(feature) {
+                return feature;
+            }, {
+                layerFilter: function(layer) {
+                    return layer === me.layer;
+                }
+            });
+
+        if (feat) {
+            // select clicked feature in grid
+            me.selectMapFeature(feat);
+        }
+    },
+
+    /**
+     * Selects / deselects a feature by triggering the corresponding actions in
+     * the grid (e.g. selecting / deselecting a grid row).
+     *
+     * @private
+     * @param  {ol.Feature} feature The feature to select
+     */
+    selectMapFeature: function(feature) {
+        var me = this;
+        var row = me.store.findBy(function(record, id) {
+            return record.getFeature() == feature;
+        });
+
+        // deselect all if only one can be selected at a time
+        if (me.getSelectionMode() === 'SINGLE') {
+            me.deselectAll();
+        }
+
+        if (feature.get(me.selectedFeatureAttr)) {
+            // deselect feature by deselecting grid row
+            me.deselect(row);
+        } else {
+            // select the feature by selecting grid row
+            if (row != -1 && !me.isSelected(row)) {
+                me.select(row, !this.singleSelect);
+                // focus the row in the grid to ensure it is visible
+                me.view.focusRow(row);
+            }
+        }
+    },
+
+    /**
+     * Overwrites the onSelectChange function of the father class.
+     * Ensures that the selected feature are added / removed to / from
+     * #selectedFeatures lookup object.
+     *
+     * @private
+     * @param  {GeoExt.data.model.Feature} record Selected / deselected record
+     * @param  {Boolean} isSelected Record id selected or deselected
+     */
+    onSelectChange: function(record, isSelected) {
+        var me = this;
+        var selFeature = record.getFeature();
+
+        // toggle feature's selection state
+        selFeature.set(me.selectedFeatureAttr, isSelected);
+
+        if (isSelected) {
+            me.selectedFeatures.push(selFeature);
+        } else {
+            me.selectedFeatures.remove(selFeature);
+        }
+
+        me.callParent(arguments);
+    }
+});

--- a/examples/features/grid-map-selection.html
+++ b/examples/features/grid-map-selection.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Feature Grid Map Selection Example</title>
+    <link rel="stylesheet" type="text/css" href="../lib/ol/ol.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/classic/theme-crisp/resources/theme-crisp-all.css"/>
+</head>
+
+<body>
+
+    <div id='description'>
+        <p>
+            This example shows how to use the <code>GeoExt.selection.FeatureModel</code> to select
+            features in the map when rows are selected in the grid and vice-versa.
+        </p>
+        <p>
+            Have a look at <a href="grid-map-selection.js">grid-map-selection.js</a> to see how this is
+            done.
+        </p>
+    </div>
+
+    <script src="../lib/ol/ol.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all.js"></script>
+    <script>
+        Ext.Loader.setConfig({
+            enabled: true,
+            paths: {
+                'GeoExt': '../../src/'
+            }
+        });
+    </script>
+
+    <script src="grid-map-selection.js"></script>
+</body>
+</html>

--- a/examples/features/grid-map-selection.js
+++ b/examples/features/grid-map-selection.js
@@ -1,0 +1,268 @@
+Ext.require([
+    'Ext.container.Container',
+    'Ext.panel.Panel',
+    'Ext.grid.Panel',
+    'GeoExt.component.Map',
+    'GeoExt.data.store.Features'
+]);
+
+// load components, which are only compatible with the classic toolkit
+Ext.Loader.loadScript({
+    url: '../../classic/selection/FeatureModel.js'
+});
+
+var olMap;
+var gridWest;
+var featStore;
+
+Ext.application({
+    name: 'FeatureGridMapSelection',
+    launch: function() {
+        var geojson = {
+            'type': 'FeatureCollection',
+            'features': [
+                {
+                    'type': 'Feature',
+                    'properties': {
+                        'city': 'Hamburg',
+                        'pop': 1700000
+                    },
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [
+                            10.107421874999998,
+                            53.527247970102465
+                        ]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'properties': {
+                        'city': 'Frankfurt / Main',
+                        'pop': 700000
+                    },
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [
+                            8.76708984375,
+                            50.064191736659104
+                        ]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'properties': {
+                        'city': 'Berlin',
+                        'pop': 3500000
+                    },
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [
+                            13.447265624999998,
+                            52.53627304145948
+                        ]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'properties': {
+                        'city': 'München',
+                        'pop': 1400000
+                    },
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [
+                            11.6455078125,
+                            48.1367666796927
+                        ]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'properties': {
+                        'city': 'Paris',
+                        'pop': 2200000
+                    },
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [
+                            2.35107421875,
+                            48.83579746243093
+                        ]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'properties': {
+                        'city': 'Amsterdam',
+                        'pop': 870000
+                    },
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [
+                            4.888916015625,
+                            52.36218321674427
+                        ]
+                    }
+                },
+                {
+                    'type': 'Feature',
+                    'properties': {
+                        'city': 'London',
+                        'pop': 8700000
+                    },
+                    'geometry': {
+                        'type': 'Point',
+                        'coordinates': [
+                            -0.1318359375,
+                            51.467696956223364
+                        ]
+                    }
+                }
+            ]
+        };
+
+        // style object for the vector layer
+        var vectorStyle = new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 6,
+                fill: new ol.style.Fill({
+                    color: '#0099CC'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: '#f0f',
+                    width: 2
+                })
+            })
+        });
+        // style object for selected features
+        var selectStyle = new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: '#0099CC'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: '#f0f',
+                    width: 2
+                }),
+                points: 5,
+                radius: 10,
+                radius2: 4,
+                angle: 0
+            })
+        });
+
+        // create a feature collection in order to put into a feature store
+        var features = new ol.format.GeoJSON().readFeatures(geojson, {
+            dataProjection: 'EPSG:4326',
+            featureProjection: 'EPSG:3857'
+        });
+        var featColl = new ol.Collection(features);
+
+        olMap = new ol.Map({
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.TileWMS({
+                        url: 'https://ows.terrestris.de/osm-gray/service',
+                        params: {'LAYERS': 'OSM-WMS', 'TILED': true}
+                    })
+                })
+            ],
+            view: new ol.View({
+                center: ol.proj.fromLonLat([8, 50]),
+                zoom: 5
+            })
+        });
+
+        // create feature store by passing a feature collection
+        featStore = Ext.create('GeoExt.data.store.Features', {
+            fields: ['city', 'pop'],
+            model: 'GeoExt.data.model.Feature',
+            features: featColl,
+            map: olMap,
+            createLayer: true,
+            style: vectorStyle
+        });
+
+        // feature grid with a feature selection model
+        gridWest = Ext.create('Ext.grid.Panel', {
+            title: 'Feature Grid w. SelectionModel',
+            border: true,
+            region: 'west',
+            width: 300,
+            store: featStore,
+            selModel: {
+                type: 'featuremodel',
+                mode: 'SINGLE',
+                mapSelection: true,
+                map: olMap,
+                selectStyle: selectStyle
+            },
+            columns: [
+                {text: 'Name', dataIndex: 'city', flex: 1},
+                {
+                    text: 'Population',
+                    dataIndex: 'pop',
+                    xtype: 'numbercolumn',
+                    format: '0,000',
+                    flex: 1
+                }
+            ],
+            bbar: [{
+                // segmented button to change the selection mode
+                xtype: 'segmentedbutton',
+                items: [{
+                    text: 'Single',
+                    tooltip: 'Only allows selecting one item at a time.',
+                    pressed: true
+                }, {
+                    text: 'Simple',
+                    tooltip: 'Allows simple selection of multiple items ' +
+                        'one-by-one.'
+                }, {
+                    text: 'Multi',
+                    tooltip: 'Allows complex selection of multiple items.'
+                }],
+                listeners: {
+                    toggle: function(container, button, pressed) {
+                        if (pressed) {
+                            var gridSelModel = gridWest.getSelectionModel();
+                            if (button.text === 'Single') {
+                                // reset possible multiple selections for single
+                                gridSelModel.deselectAll();
+                            }
+                            // set new selection mode
+                            gridSelModel.setSelectionMode(
+                                button.text.toUpperCase()
+                            );
+                        }
+                    }
+                }
+            }]
+        });
+
+        var mapComponent = Ext.create('GeoExt.component.Map', {
+            map: olMap
+        });
+        var mapPanel = Ext.create('Ext.panel.Panel', {
+            region: 'center',
+            layout: 'fit',
+            items: [mapComponent]
+        });
+
+        var description = Ext.create('Ext.panel.Panel', {
+            contentEl: 'description',
+            region: 'south',
+            title: 'Description',
+            height: 180,
+            border: false,
+            bodyPadding: 5,
+            autoScroll: true
+        });
+
+        Ext.create('Ext.Viewport', {
+            layout: 'border',
+            items: [mapPanel, gridWest, description]
+        });
+    }
+});

--- a/test/index.html
+++ b/test/index.html
@@ -58,6 +58,7 @@
   <script src='spec/GeoExt/form/field/GeocoderComboBox.test.js'></script>
   <script src='spec/GeoExt/grid/column/Symbolizer.test.js'></script>
   <script src='spec/GeoExt/mixin/SymbolCheck.test.js'></script>
+  <script src='spec/GeoExt/selection/FeatureModel.test.js'></script>
   <script src='spec/GeoExt/state/PermalinkProvider.test.js'></script>
   <script src='spec/GeoExt/util/Layer.test.js'></script>
   <script>

--- a/test/spec/GeoExt/selection/FeatureModel.test.js
+++ b/test/spec/GeoExt/selection/FeatureModel.test.js
@@ -197,6 +197,24 @@ describe('GeoExt.selection.FeatureModel', function() {
             selFeatStyle = selFeat.getStyle();
             expect(selFeatStyle).to.be(undefined);
         });
+
+        it('deselection restores a possibly exist. feature style', function() {
+            var existingFeatStyle = new ol.style.Style({
+                image: new ol.style.Circle({
+                    radius: 16,
+                    fill: new ol.style.Fill({
+                        color: 'green'
+                    })
+                })
+            });
+            selFeat.setStyle(existingFeatStyle);
+
+            grid.getView().setSelection(selRec);
+            grid.getView().deselect([selRec]);
+
+            var selFeatStyle = selFeat.getStyle();
+            expect(selFeatStyle).to.be(existingFeatStyle);
+        });
     });
 
     describe('selection / deselection of multi. features by grid', function() {

--- a/test/spec/GeoExt/selection/FeatureModel.test.js
+++ b/test/spec/GeoExt/selection/FeatureModel.test.js
@@ -1,0 +1,262 @@
+Ext.Loader.syncRequire(['GeoExt.selection.FeatureModel']);
+
+describe('GeoExt.selection.FeatureModel', function() {
+
+    describe('basics', function() {
+        it('is defined', function() {
+            expect(GeoExt.selection.FeatureModel).not.to.be(undefined);
+        });
+    });
+
+    describe('constructor (no arguments)', function() {
+        var selModel = Ext.create('GeoExt.selection.FeatureModel', {});
+        it('constructs an instance of GeoExt.selection.FeatureModel',
+            function() {
+                expect(selModel).to.be.an(GeoExt.selection.FeatureModel);
+            }
+        );
+    });
+
+    describe('configs and properties', function() {
+        var selModel;
+        beforeEach(function() {
+            selModel = Ext.create('GeoExt.selection.FeatureModel');
+        });
+        afterEach(function() {
+            selModel.destroy();
+        });
+
+        it('are correctly defined (with defaults)', function() {
+            expect(selModel.selectedFeatures).to.be(null);
+            expect(selModel.layer).to.be(null);
+            expect(selModel.selectStyle instanceof ol.style.Style).to.be(true);
+            expect(selModel.selectedFeatureAttr).to.be('gx_selected');
+        });
+    });
+
+    describe('Init process', function() {
+
+        var selModel;
+        beforeEach(function() {
+            selModel = Ext.create('GeoExt.selection.FeatureModel');
+        });
+        afterEach(function() {
+            selModel.destroy();
+        });
+
+        it('creates an empty OL collection "selectedFeatures"', function() {
+            selModel.bindComponent();
+            expect(selModel.selectedFeatures).to.be.an(ol.Collection);
+            expect(selModel.selectedFeatures.getLength()).to.be(0);
+        });
+
+        it('binds "add" event of "selectedFeatures"', function() {
+            var called = false;
+            selModel.onSelectFeatAdd = function() {
+                called = true;
+            };
+            selModel.bindComponent();
+
+            selModel.selectedFeatures.push(new ol.Feature());
+            expect(called).to.be(true);
+        });
+
+        it('bind "remove" event of "selectedFeatures"', function() {
+            var called = false;
+            selModel.onSelectFeatAdd = function() {
+                called = true;
+            };
+            selModel.bindComponent();
+
+            var feat = new ol.Feature();
+            selModel.selectedFeatures.push(feat);
+            selModel.selectedFeatures.remove(feat);
+            expect(called).to.be(true);
+        });
+    });
+
+    describe('Layer detection', function() {
+        var selModel;
+        var featStore;
+        var layer;
+        beforeEach(function() {
+            layer = new ol.layer.Vector();
+            featStore =
+                Ext.create('GeoExt.data.store.Features', {});
+
+            selModel = Ext.create('GeoExt.selection.FeatureModel', {});
+            // feature grid with a feature selection model
+            Ext.create('Ext.grid.Panel', {
+                title: 'Feature Grid w. SelectionModel',
+                store: featStore,
+                selModel: selModel
+            });
+        });
+        afterEach(function() {
+            selModel.destroy();
+            featStore.destroy();
+            selModel = null;
+            featStore = null;
+            layer = null;
+        });
+
+        it('is done by store if not configured', function() {
+            expect(selModel.layer).to.be(featStore.layer);
+        });
+
+        it('is skipped if passed in',
+            function() {
+                selModel = Ext.create('GeoExt.selection.FeatureModel', {
+                    layer: layer
+                });
+                expect(selModel.layer).not.to.be(featStore.layer);
+                expect(selModel.layer).to.be(layer);
+            }
+        );
+    });
+
+    describe('selection / deselection of single features by grid', function() {
+        var selModel;
+        var grid;
+        var featStore;
+        var selRec;
+        var selFeat;
+        beforeEach(function() {
+            var feat = new ol.Feature();
+            var coll = new ol.Collection();
+            coll.push(feat);
+            featStore =
+                Ext.create('GeoExt.data.store.Features', {features: coll});
+
+            selModel = Ext.create('GeoExt.selection.FeatureModel', {
+                mode: 'SINGLE'});
+            // feature grid with a feature selection model
+            grid = Ext.create('Ext.grid.Panel', {
+                store: featStore,
+                selModel: selModel
+            });
+            selRec = featStore.getAt(0);
+            selFeat = selRec.getFeature();
+        });
+        afterEach(function() {
+            selModel.destroy();
+            featStore.destroy();
+            grid.destroy();
+            selModel = null;
+            featStore = null;
+            grid = null;
+            selRec = null;
+            selFeat = null;
+        });
+
+        it('selection adds feature to "selectedFeatures"', function() {
+            grid.getView().setSelection(selRec);
+
+            expect(selModel.selectedFeatures.getLength()).to.be(1);
+            expect(selModel.selectedFeatures.item(0)).to.be(selFeat);
+        });
+
+        it('selection tags the feature as selected', function() {
+            grid.getView().setSelection(selRec);
+
+            expect(selFeat.get(selModel.selectedFeatureAttr)).to.be(true);
+        });
+
+        it('selection sets the select style to the feature', function() {
+            var selFeatStyle = selFeat.getStyle();
+            expect(selFeatStyle).to.be(null);
+
+            grid.getView().setSelection(selRec);
+
+            selFeatStyle = selFeat.getStyle();
+            expect(
+                selFeatStyle.getImage().getFill().getColor()).to.
+                be('rgba(255,255,255,0.8)');
+        });
+
+        it('deselection removes feature from "selectedFeatures"', function() {
+            grid.getView().setSelection(selRec);
+            grid.getView().deselect([selRec]);
+
+            expect(selModel.selectedFeatures.getLength()).to.be(0);
+        });
+
+        it('deselection tags the feature as not selected', function() {
+            grid.getView().setSelection(selRec);
+            grid.getView().deselect([selRec]);
+
+            expect(selFeat.get(selModel.selectedFeatureAttr)).to.be(false);
+        });
+
+        it('deselection resets the select style of the feature', function() {
+            var selFeatStyle = selFeat.getStyle();
+
+            grid.getView().setSelection(selRec);
+            grid.getView().deselect([selRec]);
+
+            selFeatStyle = selFeat.getStyle();
+            expect(selFeatStyle).to.be(undefined);
+        });
+    });
+
+    describe('selection / deselection of multi. features by grid', function() {
+        var selModel;
+        var grid;
+        var featStore;
+        var selRec1;
+        var selFeat1;
+        var selRec2;
+        var selFeat2;
+        beforeEach(function() {
+            var feat1 = new ol.Feature();
+            var feat2 = new ol.Feature();
+            var coll = new ol.Collection();
+            coll.push(feat1);
+            coll.push(feat2);
+            featStore =
+                Ext.create('GeoExt.data.store.Features', {features: coll});
+
+            selModel = Ext.create('GeoExt.selection.FeatureModel', {
+                mode: 'SIMPLE' // allows selection multiple records at a time
+            });
+            // feature grid with a feature selection model
+            grid = Ext.create('Ext.grid.Panel', {
+                store: featStore,
+                selModel: selModel
+            });
+            selRec1 = featStore.getAt(0);
+            selFeat1 = selRec1.getFeature();
+            selRec2 = featStore.getAt(1);
+            selFeat2 = selRec2.getFeature();
+        });
+        afterEach(function() {
+            selModel.destroy();
+            featStore.destroy();
+            grid.destroy();
+            selModel = null;
+            featStore = null;
+            grid = null;
+            selRec1 = null;
+            selFeat1 = null;
+            selRec2 = null;
+            selFeat2 = null;
+        });
+
+        it('selection adds multip. features to "selectedFeatures"', function() {
+            grid.getView().select([selRec1, selRec2]);
+
+            expect(selModel.selectedFeatures.getLength()).to.be(2);
+            expect(selModel.selectedFeatures.item(0)).to.be(selFeat1);
+            expect(selModel.selectedFeatures.item(1)).to.be(selFeat2);
+        });
+
+        it('deselection removes multiple features from "selectedFeatures"',
+            function() {
+                grid.getView().select([selRec1, selRec2]);
+                grid.getView().deselect([selRec1, selRec2]);
+
+                expect(selModel.selectedFeatures.getLength()).to.be(0);
+            }
+        );
+    });
+});


### PR DESCRIPTION
This adds an extended row-selection model, which enables automatic selection of features in the map when rows are selected in a feature grid and vice-versa.

This does not use an `ol.interaction.Select` by purpose to keep it simple and flexible. A simple `singleclick` handler is registered to the map (if configured), which syncs with the grid in case a feature has been clicked.

![grafik](https://user-images.githubusercontent.com/1185547/58563940-52277400-822c-11e9-8b84-7773ee3ce9a0.png)

If needed we can easily introduce an `ol.interaction.Select` later on (if really needed). Maybe by adding a second "actionMode" to the `GeoExt.selection.FeatureModel` or by sub-classing or similar. The architecture of this FeatureModel would let us this freedom  in the future.