### PR TITLE
Remove log output when testing

### DIFF
--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -136,10 +136,36 @@
         teardownTestDiv(createdObjs.mapDiv);
     }
 
+    /**
+     * Disables output via calls to Ext.Logger-methods.
+     */
+    function disableLogger() {
+        var origLog = Ext.Logger.log;
+        var origError = Ext.Logger.error;
+        Ext.Logger.log = function() {};
+        Ext.Logger.error = function() {};
+        Ext.Logger.log.orig = origLog;
+        Ext.Logger.error.orig = origError;
+    }
+
+    /**
+     * Renables output via calls to Ext.Logger-methods.
+     */
+    function enableLogger() {
+        if (Ext.Logger.log.orig) {
+            Ext.Logger.log = Ext.Logger.log.orig;
+        }
+        if (Ext.Logger.error.orig) {
+            Ext.Logger.error = Ext.Logger.error.orig;
+        }
+    }
+
     global.TestUtil = {
         setupTestDiv: setupTestDiv,
         teardownTestDiv: teardownTestDiv,
         setupTestObjects: setupTestObjects,
-        teardownTestObjects: teardownTestObjects
+        teardownTestObjects: teardownTestObjects,
+        disableLogger: disableLogger,
+        enableLogger: enableLogger
     };
 }(this));

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -1,5 +1,8 @@
 Ext.Loader.syncRequire(['GeoExt.data.store.WfsFeatures']);
 
+before(TestUtil.disableLogger);
+after(TestUtil.enableLogger);
+
 describe('GeoExt.data.store.WfsFeatures', function() {
 
     describe('basics', function() {


### PR DESCRIPTION
Before:

```
> @geoext/geoext@3.2.0 test /home/mjansen/code/geoext3
> karma start test/karma.conf.js --single-run

13 06 2019 10:04:48.603:INFO [karma-server]: Karma v4.1.0 server started at http://0.0.0.0:9876/
13 06 2019 10:04:48.606:INFO [launcher]: Launching browsers PhantomJS with concurrency unlimited
13 06 2019 10:04:48.611:INFO [launcher]: Starting browser PhantomJS
13 06 2019 10:04:48.823:INFO [PhantomJS 2.1.1 (Linux 0.0.0)]: Connected on socket -AveLfXOZGlks5mdAAAA with id 26305287
................................................................................
................................................................................
................................................................................
.............................................................................
WARN: '[WARN] No format given for WfsFeatureStore. Skip parsing feature data.'
WARN: '[WARN] No format given for WfsFeatureStore. Skip parsing feature data.'
WARN: '[WARN] No format given for WfsFeatureStore. Skip parsing feature data.'
........................................................
PhantomJS 2.1.1 (Linux 0.0.0): Executed 373 of 373 SUCCESS (5.333 secs / 3.451 secs)

```

After:

```
> @geoext/geoext@3.2.0 test /home/mjansen/code/geoext3
> karma start test/karma.conf.js --single-run

13 06 2019 10:08:11.925:INFO [karma-server]: Karma v4.1.0 server started at http://0.0.0.0:9876/
13 06 2019 10:08:11.929:INFO [launcher]: Launching browsers PhantomJS with concurrency unlimited
13 06 2019 10:08:11.934:INFO [launcher]: Starting browser PhantomJS
13 06 2019 10:08:12.147:INFO [PhantomJS 2.1.1 (Linux 0.0.0)]: Connected on socket wLRy3U-Ec4EyGoCXAAAA with id 72651211
................................................................................
................................................................................
................................................................................
................................................................................
.....................................................
PhantomJS 2.1.1 (Linux 0.0.0): Executed 373 of 373 SUCCESS (5.143 secs / 3.286 secs)
```