### PR TITLE
Implement sorting of the WFS store with tests

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -216,8 +216,8 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
      * Sends the sortBy parameter to the WFS Server
      * If multiple sorters are specified then multiple fields are
      * sent to the server.
-     * Ascending sorts will append A and descending sorts D
-     * E.g. sortBy=attribute1 D,attribute2 A
+     * Ascending sorts will append ASC and descending sorts DESC
+     * E.g. sortBy=attribute1 DESC,attribute2 ASC
      * @private
      * @return {String} The sortBy string
      */
@@ -229,8 +229,8 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
         var property;
 
         me.getSorters().each(function(sorter) {
-            // direction will be either A from ASC or D from DESC
-            direction = sorter.getDirection().charAt(0);
+            // direction will be ASC or DESC
+            direction = sorter.getDirection();
             property = sorter.getProperty();
             sortStrings.push(Ext.String.format('{0} {1}', property, direction));
         });

--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -216,8 +216,8 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
      * Sends the sortBy parameter to the WFS Server
      * If multiple sorters are specified then multiple fields are
      * sent to the server.
-     * Ascending sorts appends +A and descending sorts +D
-     * E.g. sortBy=attribute1+D,attribute1+A
+     * Ascending sorts will append A and descending sorts D
+     * E.g. sortBy=attribute1 D,attribute2 A
      * @private
      * @return {String} The sortBy string
      */
@@ -228,7 +228,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
         var direction;
         var property;
 
-        Ext.each(me.getSorters().items, function(sorter) {
+        me.getSorters().each(function(sorter) {
             // direction will be either A from ASC or D from DESC
             direction = sorter.getDirection().charAt(0);
             property = sorter.getProperty();

--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -188,7 +188,6 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
      * @return {Integer}            Total amount of features
      */
     getTotalFeatureCount: function(wfsResponse) {
-        var me = this;
         var totalCount = -1;
         // get the response type from the header
         var contentType = wfsResponse.getResponseHeader('Content-Type');
@@ -216,29 +215,31 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
     /**
      * Sends the sortBy parameter to the WFS Server
      * If multiple sorters are specified then multiple fields are
-     * sent to the server. 
-     * Ascending sorts append +A appended and descending sorts +D
+     * sent to the server.
+     * Ascending sorts appends +A and descending sorts +D
      * E.g. sortBy=attribute1+D,attribute1+A
      * @private
+     * @return {String} The sortBy string
      */
     createSortByParameter: function() {
 
         var me = this;
         var sortStrings = [];
-        var direction, property;
+        var direction;
+        var property;
 
         Ext.each(me.getSorters().items, function(sorter) {
             // direction will be either A from ASC or D from DESC
             direction = sorter.getDirection().charAt(0);
             property = sorter.getProperty();
-            sortStrings.push(Ext.String.format('{0} {1}', property, direction))
+            sortStrings.push(Ext.String.format('{0} {1}', property, direction));
         });
 
         return sortStrings.join(',');
     },
 
     /**
-     * Gets the number of features for the WFS typeName 
+     * Gets the number of features for the WFS typeName
      * using resultType=hits and caches it so it only needs to be calculated
      * the first time the store is used.
      * @private

--- a/test/data/wfs_mock.geojson
+++ b/test/data/wfs_mock.geojson
@@ -3,7 +3,10 @@
   "features": [
     {
       "type": "Feature",
-      "properties": {"foo": 1},
+      "properties": {
+        "foo": 1,
+        "bar": "a"
+      },
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -14,7 +17,10 @@
     },
     {
       "type": "Feature",
-      "properties": {"foo": 2},
+      "properties": {
+        "foo": 2,
+        "bar": "b"
+      },
       "geometry": {
         "type": "Point",
         "coordinates": [
@@ -25,7 +31,10 @@
     },
     {
       "type": "Feature",
-      "properties": {"foo": 3},
+      "properties": {
+        "foo": 3,
+        "bar": "c"
+      },
       "geometry": {
         "type": "Point",
         "coordinates": [

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -165,8 +165,12 @@ describe('GeoExt.data.store.WfsFeatures', function() {
 
     describe('sorting', function() {
 
+        var dataPath = (typeof __karma__ === 'undefined' ? '' : 'base/test/');
+        var url = dataPath + 'data/wfs_mock.geojson';
+
         it('sorters are created', function() {
             var store = Ext.create('GeoExt.data.store.WfsFeatures', {
+                url: url,
                 sorters: [{
                     property: 'foo',
                     direction: 'ASC'
@@ -183,6 +187,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
 
         it('creates sort string', function() {
             var store = Ext.create('GeoExt.data.store.WfsFeatures', {
+                url: url,
                 sorters: [{
                     property: 'foo',
                     direction: 'ASC'
@@ -194,6 +199,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
 
         it('creates multiple sorters string', function() {
             var store = Ext.create('GeoExt.data.store.WfsFeatures', {
+                url: url,
                 sorters: [{
                     property: 'foo',
                     direction: 'ASC'

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -194,7 +194,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 }]
             });
 
-            expect(store.createSortByParameter().to.be('foo A'));
+            expect(store.createSortByParameter()).to.be('foo A');
         });
 
         it('creates multiple sorters string', function() {
@@ -209,7 +209,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 }]
             });
 
-            expect(store.createSortByParameter().to.be('foo A, foo D'));
+            expect(store.createSortByParameter()).to.be('foo A, foo D');
         });
     });
 });

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -204,12 +204,12 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                     property: 'foo',
                     direction: 'ASC'
                 }, {
-                    property: 'foo',
+                    property: 'bar',
                     direction: 'DESC'
                 }]
             });
 
-            expect(store.createSortByParameter()).to.be('foo A, foo D');
+            expect(store.createSortByParameter()).to.be('foo A,bar D');
         });
     });
 });

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -44,7 +44,6 @@ describe('GeoExt.data.store.WfsFeatures', function() {
             expect(store.request).to.be('GetFeature');
             expect(store.typeName).to.be(null);
             expect(store.outputFormat).to.be('application/json');
-            expect(store.sortBy).to.be(null);
             expect(store.startIndex).to.be(0);
             expect(store.count).to.be(null);
             expect(store.startIndexOffset).to.be(0);
@@ -69,7 +68,6 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                         expect(params.request).to.be(str.request);
                         expect(params.typeName).to.be(str.typeName);
                         expect(params.outputFormat).to.be(str.outputFormat);
-                        expect(params.sortBy).to.be(str.sortBy);
                     },
                     'gx-wfsstoreload': function(str) {
                         expect(str.getCount()).to.be(3);
@@ -90,7 +88,6 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 format: new ol.format.GeoJSON({
                     featureProjection: 'EPSG:3857'
                 }),
-                sortBy: 'foo',
                 startIndex: 0,
                 count: 10,
                 listeners: {
@@ -100,7 +97,6 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                         expect(params.request).to.be(str.request);
                         expect(params.typeName).to.be(str.typeName);
                         expect(params.outputFormat).to.be(str.outputFormat);
-                        expect(params.sortBy).to.be(str.sortBy);
                         expect(params.startIndex).to.be(str.startIndex);
                         expect(params.count).to.be(str.pageSize);
                         expect(params.startIndex).to.be(0);
@@ -165,5 +161,49 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 expect(map.getLayers().getLength()).to.be(0);
             }
         );
+    });
+
+    describe('sorting', function() {
+
+        it('sorters are created', function() {
+            var store = Ext.create('GeoExt.data.store.WfsFeatures', {
+                sorters: [{
+                    property: 'foo',
+                    direction: 'ASC'
+                }],
+            });
+
+            var sorters = store.getSorters();
+            expect(sorters.items.length).to.be(1);
+
+            var sorter = sorters.items[0];
+            expect(sorter.getProperty()).to.be('foo');
+            expect(sorter.getDirection()).to.be('ASC');
+        });
+
+        it('creates sort string', function() {
+            var store = Ext.create('GeoExt.data.store.WfsFeatures', {
+                sorters: [{
+                    property: 'foo',
+                    direction: 'ASC'
+                }],
+            });
+
+            expect(store.createSortByParameter().to.be('foo A'));
+        });
+
+        it('creates multiple sorters string', function() {
+            var store = Ext.create('GeoExt.data.store.WfsFeatures', {
+                sorters: [{
+                    property: 'foo',
+                    direction: 'ASC'
+                }, {
+                    property: 'foo',
+                    direction: 'DESC'
+                }],
+            });
+
+            expect(store.createSortByParameter().to.be('foo A, foo D'));
+        });
     });
 });

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -194,7 +194,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 }]
             });
 
-            expect(store.createSortByParameter()).to.be('foo A');
+            expect(store.createSortByParameter()).to.be('foo ASC');
         });
 
         it('creates multiple sorters string', function() {
@@ -209,7 +209,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 }]
             });
 
-            expect(store.createSortByParameter()).to.be('foo A,bar D');
+            expect(store.createSortByParameter()).to.be('foo ASC,bar DESC');
         });
     });
 });

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -178,9 +178,9 @@ describe('GeoExt.data.store.WfsFeatures', function() {
             });
 
             var sorters = store.getSorters();
-            expect(sorters.items.length).to.be(1);
+            expect(sorters.length).to.be(1);
 
-            var sorter = sorters.items[0];
+            var sorter = sorters.getAt(0);
             expect(sorter.getProperty()).to.be('foo');
             expect(sorter.getDirection()).to.be('ASC');
         });

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -170,7 +170,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 sorters: [{
                     property: 'foo',
                     direction: 'ASC'
-                }],
+                }]
             });
 
             var sorters = store.getSorters();
@@ -186,7 +186,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 sorters: [{
                     property: 'foo',
                     direction: 'ASC'
-                }],
+                }]
             });
 
             expect(store.createSortByParameter().to.be('foo A'));
@@ -200,7 +200,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 }, {
                     property: 'foo',
                     direction: 'DESC'
-                }],
+                }]
             });
 
             expect(store.createSortByParameter().to.be('foo A, foo D'));


### PR DESCRIPTION
This pull request allows sorting of the WFS store by passing the WFS server a sortBy querystring based on the sorters in the store. 

If multiple sorters are specified then multiple fields are sent to the server. Ascending sorts append +A and descending sorts +D. E.g. sortBy=attribute1+D,attribute1+A