### PR TITLE
 Allow download progressbar to be hidden with environment variable 

### DIFF
--- a/bin/util.js
+++ b/bin/util.js
@@ -6,6 +6,10 @@ var path = require('path');
 var url = require('url');
 var logUpdate = require('log-update');
 
+// Make the progress bar configurable with an environment variable, default
+// is to show the progressbar while downloading
+var showProgress = process.env.NO_DOWNLOAD_PROGRESS === 'true' ? false : true;
+
 /**
  * The frames for the progressbar.
  * @type {Array}
@@ -38,17 +42,21 @@ var logProgress = function(totalSteps, runningMsg) {
             if (totalSteps <= 0) {
                 return;
             }
-            progressInterval = setInterval(function() {
-                var frame = progressFrames[frameIdx++ % progressFrames.length];
-                logUpdate('  ' + frame + ' ' + runningMsg);
-            }, 100);
+            if (showProgress) {
+                progressInterval = setInterval(function() {
+                    var frame = progressFrames[frameIdx++ % progressFrames.length];
+                    logUpdate('  ' + frame + ' ' + runningMsg);
+                }, 100);
+            }
         },
         oneDoneCheckIfAllDone: function(stepDescription, ok, allDoneCb) {
             finishedSteps++;
             logUpdate((ok ? '  ✔ ' : '  ✖ ') + stepDescription);
             logUpdate.done();
             if (finishedSteps >= totalSteps) {
-                clearInterval(progressInterval);
+                if (progressInterval) {
+                    clearInterval(progressInterval);
+                }
                 allDoneCb();
             }
         }

--- a/development.md
+++ b/development.md
@@ -32,7 +32,10 @@ There are a number of preconfigured scripts that can be executed via
 
 * `clean` removes generated files and folders.
 * `lint` checks code for linting errors.
-* `test` runs the headless test suite.
+* `test` runs the headless test suite. This will also download some external
+resources if needed. If you do not want a progress bar being rendered during
+the download phase, just set the environment variable `NO_DOWNLOAD_PROGRESS`
+to `true` like so: `NO_DOWNLOAD_PROGRESS=true npm test`.
 * `test:debug` runs the headless test suite with ExtJS in debug mode.
 * `test:coverage` runs the headless test suite only outputting coverage files.
 * `test:watch` runs the test suite when changes in the `src` or `test`


### PR DESCRIPTION
If the environment variable `NO_DOWNLOAD_PROGRESS` is set to `true`, we will not be polluting stdout with progress symbols.

By default we'll keep the old behavior of showing a progress bar for the user while we download external resources.

The development instructions have been updated to reflect this possibility.

Please review.