### PR TITLE
Check for multiple values in Or filter

### DIFF
--- a/src/util/OGCFilter.js
+++ b/src/util/OGCFilter.js
@@ -295,8 +295,17 @@ Ext.define('GeoExt.util.OGCFilter', {
                     '</PropertyIsEqualTo>';
                 });
                 ogcFilterType = '<' + ogcFilterType + '>';
+
+                var inFilter;
                 closingTag = Ext.String.insert(ogcFilterType, '/', 1);
-                return ogcFilterType + filters + closingTag;
+
+                // only use an Or filter when there are multiple values
+                if (values.length > 1) {
+                    inFilter = ogcFilterType + filters + closingTag;
+                } else {
+                    inFilter = filters;
+                }
+                return inFilter;
             default:
                 Ext.Logger.warn('Method `getOgcFilter` could not ' +
                     'handle the given operator: ' + operator);


### PR DESCRIPTION
The `getOgcFilterBodyFromExtJsFilterObject` function in `GeoExt.util.OGCFilter` contains the following:

`
var operator = filter.getOperator();
`

When using a list filter on a grid such as:

```
filter: {
    type: 'list',
    labelField: 'name',
    idField: 'name',
```

The operator is set to `In`. If only one list item is selected then the following filter is created. Note there is an Or clause but only one value:

```xml
<Filter xmlns="http://www.opengis.net/ogc"><Or><PropertyIsEqualTo><PropertyName>PropName</PropertyName><Literal>myval</Literal></PropertyIsEqualTo></Or></Filter>
```

This throws an error in MapServer: `msWFSGetFeature(): WFS server error. Invalid or Unsupported FILTER in GetFeature`

This pull request only adds the `Or` element when there are more than one items selected in the list (it could be cleaner to check this beforehand?). 
I'm unsure if it is valid to have an `Or` with one criteria. If so then this issue should be logged with MapServer. 



