### PR TITLE
Fire gx-wfsstoreload on failure

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -324,11 +324,12 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
                     me.source.addFeatures(wfsFeats);
                 }
 
-                me.fireEvent('gx-wfsstoreload', me);
+                me.fireEvent('gx-wfsstoreload', me, wfsFeats, true);
             },
             failure: function(response) {
                 Ext.Logger.warn('Error while requesting features from WFS: ' +
                     response.responseText + ' Status: ' + response.status);
+                me.fireEvent('gx-wfsstoreload', me, null, false);
             }
 
         });


### PR DESCRIPTION
Also pass parameters similar to https://docs.sencha.com/extjs/6.2.0/classic/Ext.data.Store.html#event-load including the `successful` flag. This allows any loadMasks to be hidden on an associated grid by listening to the event. 

MapServer seems to return a `Status: 403 Server processing failed ` header if an y WFS filter causes 0 records to return (unsure if this is to spec or an error in MapServer). 

```
<ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
  <ows:Exception exceptionCode="OperationProcessingFailed" locator="mapserv">
    <ows:ExceptionText>msWFSGetFeature(): WFS server error. FLTApplyFilterToLayer() failed</ows:ExceptionText>
  </ows:Exception>
</ows:ExceptionReport>
```

