### PR TITLE
Allow custom options on a WfsFeatures layer

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -100,6 +100,13 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
     layerAttribution: null,
 
     /**
+     * Additional OpenLayers properties to apply to the created vector layer source. Only has an
+     * effect if #createLayer is set to `true`
+     * @cfg {String}
+     */
+    layerOptions: null,
+
+    /**
      * Cache the total number of features be queried from when the store is
      * first loaded to use for the remaining life of the store.
      * This uses resultType=hits to get the number of features and can improve
@@ -158,10 +165,17 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
                 features: [],
                 attributions: me.layerAttribution
             });
-            me.layer = new ol.layer.Vector({
+
+            var layerOptions = {
                 source: me.source,
                 style: me.style
-            });
+            }
+
+            if (me.layerOptions) {
+                Ext.applyIf(layerOptions, me.layerOptions);
+            }
+
+            me.layer = new ol.layer.Vector(layerOptions);
 
             me.layerCreated = true;
         }

--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -100,8 +100,8 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
     layerAttribution: null,
 
     /**
-     * Additional OpenLayers properties to apply to the created vector layer source. Only has an
-     * effect if #createLayer is set to `true`
+     * Additional OpenLayers properties to apply to the created vector layer.
+     * Only has an effect if #createLayer is set to `true`
      * @cfg {String}
      */
     layerOptions: null,
@@ -169,7 +169,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
             var layerOptions = {
                 source: me.source,
                 style: me.style
-            }
+            };
 
             if (me.layerOptions) {
                 Ext.applyIf(layerOptions, me.layerOptions);

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -161,7 +161,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
 
         it('layerOptions have been set correctly', function() {
             var layer = store.getLayer();
-            expect(layer.getOpacity().to.be(0.7));
+            expect(layer.getOpacity()).to.be(0.7);
         });
 
         it('removes the autocreated layer once the store is destroyed',

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -134,6 +134,9 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 url: url,
                 map: map,
                 createLayer: true,
+                layerOptions: {
+                    opacity: 0.7
+                },
                 format: new ol.format.GeoJSON({
                     featureProjection: 'EPSG:3857'
                 })
@@ -154,6 +157,11 @@ describe('GeoExt.data.store.WfsFeatures', function() {
 
         it('creates the layer which is retrievable via #getLayer', function() {
             expect(store.getLayer()).to.be(map.getLayers().item(0));
+        });
+
+        it('layerOptions have been set correctly', function() {
+            var layer = store.getLayer();
+            expect(layer.getOpacity().to.be(0.7));
         });
 
         it('removes the autocreated layer once the store is destroyed',


### PR DESCRIPTION
Allows custom options to be configured on the layer generated by `GeoExt.data.store.WfsFeatures`.

This allows options such as `opacity` and `displayInLayerSwitcher` to be set when configuring the store. 