### PR TITLE
Use prototype onBindStore for WfsPaging

### DIFF
--- a/classic/toolbar/WfsPaging.js
+++ b/classic/toolbar/WfsPaging.js
@@ -29,12 +29,8 @@ Ext.define('GeoExt.toolbar.WfsPaging', {
     /**
      * Ensures that the 'gx-wfsstoreload' event of the WFS store is bound to the
      * onLoad function of this toolbar once we have the store bound.
-     *
-     * @private
-     * @param  {Ext.Component} owner The owner component
-     * @param  {Ext.data.Store} store The store
      */
-    onOwnerStoreChange: function(owner, store) {
+    onBindStore: function() {
         var me = this;
         me.callParent(arguments);
         me.store.on('gx-wfsstoreload', me.onLoad, me);


### PR DESCRIPTION
Use the [onBindStore](https://docs.sencha.com/extjs/6.2.0/classic/Ext.toolbar.Paging.html#method-onBindStore) prototype for setting up the events rather than onOwnerStoreChange. 

The latter worked when the store was bound automatically when the paging toolbar was added at the root of dockedItems, but when it was nested (such as in the example below) using a bind parameter it wasn't called. In this case onBindStore did get called. 

```js
    dockedItems: [{
        xtype: 'toolbar',
        dock: 'top',
        items: [
            {
                xtype: 'gx_wfspaging_toolbar',
                displayInfo: true,
                bind: {
                    store: '{features}'
                }
            },
```