### PR TITLE
OGCFilter - Support for for Filter Encoding 2.0 - WFS 2.0

### DIFF
--- a/examples/features/grid-spatial-filter.js
+++ b/examples/features/grid-spatial-filter.js
@@ -105,7 +105,7 @@ Ext.application({
             layerAttribution: '| <a href="https://www.dwd.de/"> ' +
                 'Source: Deutscher Wetterdienst</a>',
             url: 'https://maps.dwd.de/geoserver/dwd/ows?',
-            version: '1.1.0',
+            version: '2.0.0',
             typeName: 'dwd:Warngebiete_Kreise',
             outputFormat: 'application/json',
             format: new ol.format.GeoJSON({

--- a/src/util/OGCFilter.js
+++ b/src/util/OGCFilter.js
@@ -506,17 +506,6 @@ Ext.define('GeoExt.util.OGCFilter', {
          * @return {string} The serialized geometry in GML3 format
          */
         getGmlElementForGeometry: function(geometry, srsName, wfsVersion) {
-            var format = new ol.format.GML3({
-                srsName: srsName
-            });
-            var geometryNode = format.writeGeometryNode(geometry, {
-                dataProjection: srsName
-            });
-            if (!geometryNode) {
-                Ext.Logger.warn('Could not serialize geometry');
-                return null;
-            }
-
             if (wfsVersion === '2.0.0') {
                 // supported geometries: Point, LineString and Polygon
                 // in case of multigeometries, the first one is used.
@@ -561,6 +550,16 @@ Ext.define('GeoExt.util.OGCFilter', {
                     return '';
                 }
             } else {
+                var format = new ol.format.GML3({
+                    srsName: srsName
+                });
+                var geometryNode = format.writeGeometryNode(geometry, {
+                    dataProjection: srsName
+                });
+                if (!geometryNode) {
+                    Ext.Logger.warn('Could not serialize geometry');
+                    return null;
+                }
                 var childNodes = geometryNode.children ||
                   geometryNode.childNodes;
                 var serializer = new XMLSerializer();

--- a/src/util/OGCFilter.js
+++ b/src/util/OGCFilter.js
@@ -338,38 +338,32 @@ Ext.define('GeoExt.util.OGCFilter', {
                 value = value.toString().replace(/([']$)/g, '');
             }
 
+            var wfsPrefix = (isWfs20 ? 'fes:' : '');
+
             switch (operator) {
             case '==':
-                ogcFilterType = (isWfs20 ? 'fes:' : '') +
-                    'PropertyIsEqualTo';
+                ogcFilterType = wfsPrefix + 'PropertyIsEqualTo';
                 break;
             case 'eq':
-                ogcFilterType = (isWfs20 ? 'fes:' : '') +
-                    'PropertyIsEqualTo';
+                ogcFilterType = wfsPrefix + 'PropertyIsEqualTo';
                 break;
             case '!==':
-                ogcFilterType = (isWfs20 ? 'fes:' : '') +
-                    'PropertyIsNotEqualTo';
+                ogcFilterType = wfsPrefix + 'PropertyIsNotEqualTo';
                 break;
             case 'ne':
-                ogcFilterType = (isWfs20 ? 'fes:' : '') +
-                    'PropertyIsNotEqualTo';
+                ogcFilterType = wfsPrefix + 'PropertyIsNotEqualTo';
                 break;
             case 'lt':
-                ogcFilterType = (isWfs20 ? 'fes:' : '') +
-                    'PropertyIsLessThan';
+                ogcFilterType = wfsPrefix + 'PropertyIsLessThan';
                 break;
             case 'lte':
-                ogcFilterType = (isWfs20 ? 'fes:' : '') +
-                    'PropertyIsLessThanOrEqualTo';
+                ogcFilterType = wfsPrefix + 'PropertyIsLessThanOrEqualTo';
                 break;
             case 'gt':
-                ogcFilterType = (isWfs20 ? 'fes:' : '') +
-                    'PropertyIsGreaterThan';
+                ogcFilterType = wfsPrefix + 'PropertyIsGreaterThan';
                 break;
             case 'gte':
-                ogcFilterType = (isWfs20 ? 'fes:' : '') +
-                    'PropertyIsGreaterThanOrEqualTo';
+                ogcFilterType = wfsPrefix + 'PropertyIsGreaterThanOrEqualTo';
                 break;
             case 'like':
                 value = '*' + value + '*';
@@ -379,10 +373,9 @@ Ext.define('GeoExt.util.OGCFilter', {
                     '<' + propName + '>' + property + '</' + propName + '>' +
                     '<{0}Literal>' + value + '</{0}Literal>' +
                   '</{0}PropertyIsLike>';
-                return Ext.String.format(likeFilterTpl,
-                    isWfs20 ? 'fes:' : '');
+                return Ext.String.format(likeFilterTpl, wfsPrefix);
             case 'in':
-                ogcFilterType = (isWfs20 ? 'fes:' : '') + 'Or';
+                ogcFilterType = wfsPrefix + 'Or';
                 var values = value;
                 if (!Ext.isArray(value)) {
                     // cleanup brackets and quotes
@@ -392,11 +385,11 @@ Ext.define('GeoExt.util.OGCFilter', {
                 var filters = '';
                 Ext.each(values || value, function(val) {
                     filters +=
-                    '<' + (isWfs20 ? 'fes:' : '') + 'PropertyIsEqualTo>' +
+                    '<' + wfsPrefix + 'PropertyIsEqualTo>' +
                       '<' + propName + '>' + property + '</' + propName + '>' +
-                    '<' + (isWfs20 ? 'fes:' : '') + 'Literal>' + val + '</' +
-                        (isWfs20 ? 'fes:' : '') + 'Literal>' +
-                    '</' + (isWfs20 ? 'fes:' : '') + 'PropertyIsEqualTo>';
+                    '<' + wfsPrefix + 'Literal>' + val + '</' +
+                        wfsPrefix + 'Literal>' +
+                    '</' + wfsPrefix + 'PropertyIsEqualTo>';
                 });
                 ogcFilterType = '<' + ogcFilterType + '>';
 

--- a/test/spec/GeoExt/util/OGCFilter.test.js
+++ b/test/spec/GeoExt/util/OGCFilter.test.js
@@ -198,54 +198,60 @@ describe('GeoExt.util.OGCFilter', function() {
             '</Filter>';
 
         var expectedWFS2Filter =
-            '<Filter xmlns="http://www.opengis.net/fes/2.0" ' +
-                'xmlns:gml="http://www.opengis.net/gml">' +
-              '<And>' +
-                '<PropertyIsLike wildCard="*" singleChar="." escape="!" ' +
+            '<fes:Filter ' +
+                'xsi:schemaLocation="http://www.opengis.net/fes/2.0 ' +
+                'http://schemas.opengis.net/filter/2.0/filterAll.xsd ' +
+                'http://www.opengis.net/gml/3.2 ' +
+                'http://schemas.opengis.net/gml/3.2.1/gml.xsd" ' +
+                'xmlns:fes="http://www.opengis.net/fes/2.0" ' +
+                'xmlns:gml="http://www.opengis.net/gml/3.2" ' +
+                'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+                '<fes:And>' +
+                '<fes:PropertyIsLike wildCard="*" singleChar="." escape="!" ' +
                 'matchCase="false">' +
-                    '<ValueReference>NAME</ValueReference>' +
-                    '<Literal>*d*</Literal>' +
-                '</PropertyIsLike>' +
-                '<Or>' +
-                '<PropertyIsEqualTo>' +
-                    '<ValueReference>WARNCELLID</ValueReference>' +
-                    '<Literal>105120000</Literal>' +
-                '</PropertyIsEqualTo>' +
-                '<PropertyIsEqualTo>' +
-                    '<ValueReference>WARNCELLID</ValueReference>' +
-                    '<Literal>105124000</Literal>' +
-                '</PropertyIsEqualTo>' +
-                '<PropertyIsEqualTo>' +
-                    '<ValueReference>WARNCELLID</ValueReference>' +
-                    '<Literal>105158000</Literal>' +
-                '</PropertyIsEqualTo>' +
-                '</Or>' +
-                '<PropertyIsEqualTo>' +
-                    '<ValueReference>WARNCELLID</ValueReference>' +
-                    '<Literal>105124000</Literal>' +
-                '</PropertyIsEqualTo>' +
-                '<PropertyIsNotEqualTo>' +
-                    '<ValueReference>WARNCELLID</ValueReference>' +
-                    '<Literal>105124001</Literal>' +
-                '</PropertyIsNotEqualTo>' +
-                '<PropertyIsEqualTo>' +
-                    '<ValueReference>BOOLFIELD</ValueReference>' +
-                    '<Literal>true</Literal>' +
-                '</PropertyIsEqualTo>' +
-                '<PropertyIsNotEqualTo>' +
-                    '<ValueReference>BOOLFIELD</ValueReference>' +
-                    '<Literal>false</Literal>' +
-                '</PropertyIsNotEqualTo>' +
-                '<PropertyIsLessThan>' +
-                  '<ValueReference>PROCESSTIME</ValueReference>' +
-                  '<Literal>2019-04-06</Literal>' +
-                '</PropertyIsLessThan>' +
-                '<PropertyIsGreaterThan>' +
-                  '<ValueReference>PROCESSTIME</ValueReference>' +
-                  '<Literal>2019-04-01</Literal>' +
-                '</PropertyIsGreaterThan>' +
-              '</And>' +
-            '</Filter>';
+                    '<fes:ValueReference>NAME</fes:ValueReference>' +
+                    '<fes:Literal>*d*</fes:Literal>' +
+                '</fes:PropertyIsLike>' +
+                '<fes:Or>' +
+                '<fes:PropertyIsEqualTo>' +
+                    '<fes:ValueReference>WARNCELLID</fes:ValueReference>' +
+                    '<fes:Literal>105120000</fes:Literal>' +
+                '</fes:PropertyIsEqualTo>' +
+                '<fes:PropertyIsEqualTo>' +
+                    '<fes:ValueReference>WARNCELLID</fes:ValueReference>' +
+                    '<fes:Literal>105124000</fes:Literal>' +
+                '</fes:PropertyIsEqualTo>' +
+                '<fes:PropertyIsEqualTo>' +
+                    '<fes:ValueReference>WARNCELLID</fes:ValueReference>' +
+                    '<fes:Literal>105158000</fes:Literal>' +
+                '</fes:PropertyIsEqualTo>' +
+                '</fes:Or>' +
+                '<fes:PropertyIsEqualTo>' +
+                    '<fes:ValueReference>WARNCELLID</fes:ValueReference>' +
+                    '<fes:Literal>105124000</fes:Literal>' +
+                '</fes:PropertyIsEqualTo>' +
+                '<fes:PropertyIsNotEqualTo>' +
+                    '<fes:ValueReference>WARNCELLID</fes:ValueReference>' +
+                    '<fes:Literal>105124001</fes:Literal>' +
+                '</fes:PropertyIsNotEqualTo>' +
+                '<fes:PropertyIsEqualTo>' +
+                    '<fes:ValueReference>BOOLFIELD</fes:ValueReference>' +
+                    '<fes:Literal>true</fes:Literal>' +
+                '</fes:PropertyIsEqualTo>' +
+                '<fes:PropertyIsNotEqualTo>' +
+                    '<fes:ValueReference>BOOLFIELD</fes:ValueReference>' +
+                    '<fes:Literal>false</fes:Literal>' +
+                '</fes:PropertyIsNotEqualTo>' +
+                '<fes:PropertyIsLessThan>' +
+                  '<fes:ValueReference>PROCESSTIME</fes:ValueReference>' +
+                  '<fes:Literal>2019-04-06</fes:Literal>' +
+                '</fes:PropertyIsLessThan>' +
+                '<fes:PropertyIsGreaterThan>' +
+                  '<fes:ValueReference>PROCESSTIME</fes:ValueReference>' +
+                  '<fes:Literal>2019-04-01</fes:Literal>' +
+                '</fes:PropertyIsGreaterThan>' +
+              '</fes:And>' +
+            '</fes:Filter>';
 
         var expectedGetFeature10Filter =
           '<wfs:GetFeature service="WFS" version="1.0.0" outputFormat="JSON" ' +
@@ -352,7 +358,7 @@ describe('GeoExt.util.OGCFilter', function() {
             });
 
             it('concatenates filters with `And`', function() {
-                expect(wfs2Filter).to.contain('<And>');
+                expect(wfs2Filter).to.contain('<fes:And>');
             });
 
             it('contains all filters', function() {
@@ -476,7 +482,45 @@ describe('GeoExt.util.OGCFilter', function() {
 
                     expect(filter).to.equal(expected);
                 });
+            });
 
+            it('supports WFS 2.0.0 - FES 2.0 filters', function() {
+                var wfsVersion = '2.0.0';
+                var coords = [[16, 48], [19, 9]];
+                var epsg = 'EPSG:4326';
+                var geometry = new ol.geom.LineString(coords);
+                var propertyName = 'nice-geometry-attribute';
+                var topologicalOperators = {
+                    'intersect': 'Intersects',
+                    'within': 'Within',
+                    'contains': 'Contains',
+                    'equals': 'Equals',
+                    'disjoint': 'Disjoint',
+                    'crosses': 'Crosses',
+                    'touches': 'Touches',
+                    'overlaps': 'Overlaps'
+                };
+
+                var gmlElement = Ext.String.format(
+                    GeoExt.util.OGCFilter.gml32LineStringTpl,
+                    epsg,
+                    GeoExt.util.OGCFilter.flattenCoordinates(coords)
+                );
+
+                Ext.iterate(topologicalOperators, function(key, val) {
+                    var filter = GeoExt.util.OGCFilter.getOgcFilter(
+                        propertyName, key, geometry, wfsVersion, epsg
+                    );
+
+                    var expected = Ext.String.format(
+                        GeoExt.util.OGCFilter.spatialFilterWfs2xXmlTpl,
+                        val,
+                        propertyName,
+                        gmlElement
+                    );
+
+                    expect(filter).to.equal(expected);
+                });
             });
 
             it('supports bbox filters', function() {


### PR DESCRIPTION
This PR adds the missing support for Filter Encoding 2.0 that is required for WFS requests.

Resolves issue https://github.com/geoext/geoext3/issues/568