### PR TITLE
Apply viewbox to GeocoderComboBox

### DIFF
--- a/classic/form/field/GeocoderComboBox.js
+++ b/classic/form/field/GeocoderComboBox.js
@@ -251,10 +251,28 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
         var mapSize = me.map.getSize();
         var mv = me.map.getView();
         var extent = mv.calculateExtent(mapSize);
+        me.addMapExtentParams(extent, mv.getProjection());
+    },
+
+    /**
+     * Update map extent params of AJAX proxy.
+     *
+     * By default, 'viewbox' and 'bounded' are updated since Nominatim is the
+     * default geocoder in this class. If no projection is passed the one of
+     * the map view is used.
+     *
+     * @param {ol.Extent} extent The extend to restrict the geocoder to
+     * @param {ol.proj.Projection} projection The projection of given extent
+     */
+    addMapExtentParams: function(extent, projection) {
+        var me = this;
+        if (!projection) {
+            projection = me.map.getView().getProjection();
+        }
         var ll = ol.proj.transform([extent[0], extent[1]],
-            'EPSG:3857', 'EPSG:4326');
+            projection, 'EPSG:4326');
         var ur = ol.proj.transform([extent[2], extent[3]],
-            'EPSG:3857', 'EPSG:4326');
+            projection, 'EPSG:4326');
 
         ll = Ext.Array.map(ll, function(val) {
             return Math.min(Math.max(val, -180), 180);

--- a/classic/form/field/GeocoderComboBox.js
+++ b/classic/form/field/GeocoderComboBox.js
@@ -289,17 +289,28 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
     },
 
     /**
-     * Remove restriction to viewbox, in particular remove viewbox
-     * and bounded parameters from AJAX proxy and un-register
-     * moveend event from map
+     * Cleanup if extent restriction is omitted.
+     * -> moveend event from map
+     * -> call removeMapExtentParams to reset params set in store
      */
     unRestrictExtent: function() {
+        var me = this;
+        // unbinding moveend event
+        me.map.un('moveend', me.updateExtraParams, me);
+        // cleanup params in store
+        me.removeMapExtentParams();
+    },
+
+    /**
+     * Remove restriction to viewbox, in particular remove viewbox
+     * and bounded parameters from AJAX proxy for nominatim queries
+     */
+    removeMapExtentParams: function() {
         var me = this;
         if (me.store && me.store.getProxy()) {
             me.store.getProxy().setExtraParam('viewbox', undefined);
             me.store.getProxy().setExtraParam('bounded', undefined);
         }
-        me.map.un('moveend', me.updateExtraParams, me);
     },
 
     /**

--- a/examples/geocoder/geocoder-combo.js
+++ b/examples/geocoder/geocoder-combo.js
@@ -49,6 +49,20 @@ Ext.application({
                         color: 'red'
                     })
                 })
+            }, {
+                xtype: 'checkboxfield',
+                boxLabel: 'Restrict to map extent',
+                listeners: {
+                    'change': function(cb, val) {
+                        var combo = cb.up().down('gx_geocoder_combo');
+                        if (combo) {
+                            var evtName = val ?
+                                'restrictToMapExtent' :
+                                'unRestrictMapExtent';
+                            combo.fireEvent(evtName);
+                        }
+                    }
+                }
             }]
         });
 


### PR DESCRIPTION
This MR adds a further flag to `GeocoderComboBox` that allows restriction nomination query to current map extent (parameter `viewbox`). Restriction can be enabled / disabled for an already created component by events 'restrictToMapExtent' / `unRestrictMapExtent`.

 As example is included as well.