### PR TITLE
Layers store - Improve handler for layer changes

### DIFF
--- a/src/data/store/Layers.js
+++ b/src/data/store/Layers.js
@@ -183,17 +183,25 @@ Ext.define('GeoExt.data.store.Layers', {
      * appropriate record within the store.
      *
      * @param {ol.ObjectEvent} evt The emitted `ol.Object` event.
+     * @param {Function} filterFn An optional filter function
      * @private
      */
-    onChangeLayer: function(evt) {
+    onChangeLayer: function(evt, filterFn) {
         var layer = evt.target;
-        var recordIndex = this.findBy(function(rec) {
-            return rec.getOlLayer() === layer;
-        });
+        var recordIndex = -1;
+        if (Ext.isFunction(filterFn)) {
+            recordIndex = this.findBy(filterFn);
+        } else {
+            recordIndex = this.findBy(function(rec) {
+                return rec.getOlLayer() === layer;
+            });
+        }
         if (recordIndex > -1) {
             var record = this.getAt(recordIndex);
             if (evt.key === 'title') {
                 record.set('title', layer.get('title'));
+            } else if (evt.key === 'description') {
+                record.set('qtip', layer.get('description'));
             } else {
                 this.fireEvent('update', this, record, Ext.data.Record.EDIT,
                     null, {});

--- a/src/data/store/Layers.js
+++ b/src/data/store/Layers.js
@@ -64,7 +64,15 @@ Ext.define('GeoExt.data.store.Layers', {
          *
          * @cfg {ol.Collection} layers
          */
-        layers: null
+        layers: null,
+
+        /**
+         * An optional function called to filter records used in changeLayer
+         * function
+         *
+         * @cfg {Function} changeLayerFilterFn
+         */
+        changeLayerFilterFn: null
     },
 
     /**
@@ -183,15 +191,16 @@ Ext.define('GeoExt.data.store.Layers', {
      * appropriate record within the store.
      *
      * @param {ol.ObjectEvent} evt The emitted `ol.Object` event.
-     * @param {Function} filterFn An optional filter function
      * @private
      */
-    onChangeLayer: function(evt, filterFn) {
+    onChangeLayer: function(evt) {
+        var me = this;
         var layer = evt.target;
         var recordIndex = -1;
-        if (Ext.isFunction(filterFn)) {
-            recordIndex = this.findBy(filterFn);
-        } else {
+        if (Ext.isFunction(me.changeLayerFilterFn.bind(layer))) {
+            recordIndex = this.findBy(me.changeLayerFilterFn.bind(layer));
+        }
+        if (recordIndex === -1) {
             recordIndex = this.findBy(function(rec) {
                 return rec.getOlLayer() === layer;
             });

--- a/src/data/store/Layers.js
+++ b/src/data/store/Layers.js
@@ -199,8 +199,7 @@ Ext.define('GeoExt.data.store.Layers', {
         var recordIndex = -1;
         if (Ext.isFunction(me.changeLayerFilterFn)) {
             recordIndex = this.findBy(me.changeLayerFilterFn.bind(layer));
-        }
-        if (recordIndex === -1) {
+        } else {
             recordIndex = this.findBy(function(rec) {
                 return rec.getOlLayer() === layer;
             });

--- a/src/data/store/Layers.js
+++ b/src/data/store/Layers.js
@@ -197,7 +197,7 @@ Ext.define('GeoExt.data.store.Layers', {
         var me = this;
         var layer = evt.target;
         var recordIndex = -1;
-        if (Ext.isFunction(me.changeLayerFilterFn.bind(layer))) {
+        if (Ext.isFunction(me.changeLayerFilterFn)) {
             recordIndex = this.findBy(me.changeLayerFilterFn.bind(layer));
         }
         if (recordIndex === -1) {

--- a/test/spec/GeoExt/data/store/Layers.test.js
+++ b/test/spec/GeoExt/data/store/Layers.test.js
@@ -285,6 +285,83 @@ describe('GeoExt.data.store.Layers', function() {
             });
         });
 
+        describe('function "onChangeLayer"', function() {
+            var id = 'nice-id-1909';
+            var store;
+            var map;
+            var layer;
+            var layer2;
+            var layer2Title = 'LAYER 2';
+            beforeEach(function() {
+                layer = new ol.layer.Vector();
+                layer2 = new ol.layer.Vector();
+                layer.set('id', id);
+                layer2.set('id', 'another id');
+                layer2.set('title', layer2Title);
+                map = new ol.Map({
+                    layers: [layer, layer2]
+                });
+                store = Ext.create('GeoExt.data.store.Layers', {map: map});
+            });
+
+            it('exists', function() {
+                expect(store.onChangeLayer).not.to.be(undefined);
+            });
+
+            it('sets title correctly', function() {
+                var title = 'humpty-dumpty';
+                layer.set('title', title);
+                var evt = {
+                    target: layer,
+                    key: 'title'
+                };
+                store.onChangeLayer(evt);
+
+                var recordIdx = store.findBy(function(record) {
+                    return record.getOlLayer().get('id') === id;
+                });
+                var record = store.getAt(recordIdx);
+                expect(record).not.to.be(undefined);
+                expect(record.get('title')).to.be(title);
+            });
+
+            it('sets description / qtip correctly', function() {
+                var description = 'humpty-dumpty';
+                layer.set('description', description);
+                var evt = {
+                    target: layer,
+                    key: 'description'
+                };
+                store.onChangeLayer(evt);
+
+                var recordIdx = store.findBy(function(record) {
+                    return record.getOlLayer().get('id') === id;
+                });
+                var record = store.getAt(recordIdx);
+                expect(record).not.to.be(undefined);
+                expect(record.get('qtip')).to.be(description);
+            });
+
+            it('uses filter function if provided', function() {
+                var title = 'humpty-dumpty';
+                layer.set('title', title);
+
+                var evt = {
+                    target: layer2,
+                    key: 'title'
+                };
+                var filterFn = function(rec) {
+                    return rec.getOlLayer().get('id').indexOf('another') > -1;
+                };
+                store.onChangeLayer(evt, filterFn);
+                var recordIdx = store.findBy(filterFn);
+                var record = store.getAt(recordIdx);
+                expect(record).not.to.be(null);
+                expect(record.get('title')).to.be(layer2Title);
+            });
+
+        });
+
     });
 
 });

--- a/test/spec/GeoExt/data/store/Layers.test.js
+++ b/test/spec/GeoExt/data/store/Layers.test.js
@@ -353,7 +353,10 @@ describe('GeoExt.data.store.Layers', function() {
                 var filterFn = function(rec) {
                     return rec.getOlLayer().get('id').indexOf('another') > -1;
                 };
-                store.onChangeLayer(evt, filterFn);
+                store.setConfig({
+                    changeLayerFilterFunction: filterFn
+                });
+                store.onChangeLayer(evt);
                 var recordIdx = store.findBy(filterFn);
                 var record = store.getAt(recordIdx);
                 expect(record).not.to.be(null);


### PR DESCRIPTION
 In particular:
* pass optional filter function to `onChangeLayer` by a new config `changeLayerFilterFn`
   * if not set or no result returned by `changeLayerFilterFn`, the already existing check will be applied.
* handle `description` / `qtip` property
* adds some tests