### PR TITLE
Abort previous WfsFeatures requests on new request

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -140,6 +140,15 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
     featureCountOutputFormat: 'gml3',
 
     /**
+    * Any currently executing request to the WFS server.
+    * A reference to this is kept so any new requests can
+    * abort the previous request to ensure only the most recently
+    * requested results are returned.
+    * @cfg {Ext.data.request.Ajax}
+    */
+    activeRequest: null,
+
+    /**
      * Constructs the WFS feature store.
      *
      * @param {Object} config The configuration object.
@@ -349,6 +358,11 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
      */
     loadWfs: function() {
         var me = this;
+
+        if (me.activeRequest) {
+            me.activeRequest.abort();
+        }
+
         var url = me.url;
         var params = {
             service: me.service,
@@ -391,7 +405,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
         }
 
         // request features from WFS
-        Ext.Ajax.request({
+        me.activeRequest = Ext.Ajax.request({
             url: url,
             method: me.requestMethod,
             params: params,
@@ -432,5 +446,15 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
             }
 
         });
+    },
+
+    onDestroy: function() {
+        var me = this;
+
+        if (me.activeRequest) {
+            me.activeRequest.destroy();
+        }
+
+        me.callParent(arguments);
     }
 });


### PR DESCRIPTION
This is to address #567 where a previous async request could overwrite records returned from a more recent request. 
The current request is stored as a class property, and on any new request the last request is aborted. 
The onDestroy is added to clean up any referenced request. 
This also addresses #550 which is a similar related issue - two requests made in quick succession. 
I'm unsure how this could be tested. 