### PR TITLE
Change onDestroy to doDestroy

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -464,7 +464,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
         });
     },
 
-    onDestroy: function() {
+    doDestroy: function() {
         var me = this;
 
         if (me.activeRequest) {


### PR DESCRIPTION
The parent class Ext.data.store has a [doDestroy](https://docs.sencha.com/extjs/6.5.3/classic/Ext.data.Store.html#property-doDestroy) method rather than `onDestroy` so use this. 

Alerted by build warning in SenchaCmd:

`[WRN] C1014: callParent has no target (me.callParent in GeoExt.data.store.WfsFeatures.onDestroy) -- geoext3\src\data\store\WfsFeatures.js:473:14246`