### PR TITLE
Add classic source folder to classpath for single file builds

### DIFF
--- a/.sencha/package/sencha.cfg
+++ b/.sencha/package/sencha.cfg
@@ -17,7 +17,7 @@ package.sass.namespace=Ext
 # This is the comma-separated list of folders where classes reside. These
 # classes must be explicitly required to be included in the build.
 #
-package.classpath=${package.dir}/src
+package.classpath=${package.dir}/src,${package.dir}/classic
 
 # This is the comma-separated list of folders of overrides. All files in this
 # path will be given a tag of "packageOverrides" which is automatically


### PR DESCRIPTION
To create a full and minified build of the GeoExt library the new classic folder and source files should be included. 

The commands below can then be run as per the instructions at https://github.com/geoext/geoext3/blob/master/CONTRIBUTING.md#sencha-cmd

```
SET PATH=D:\Tools\Sencha\Cmd\6.2.2;%PATH%
cd geoext3
sencha -sdk D:\Tools\Sencha\ext-6.2.0 generate workspace .
sencha package build
```

This then creates output files in `build\@geoext` e.g. `geoext.js` (minified) and `geoext-debug.js` - single file unminified. 

@chrismayer - this is the method I use for a single file build - you asked on the mailing list [1] - I did reply but I don't think the mail got through. 
See also #406. 



[1] https://www.geoext.org/pipermail/users/2019-October/003575.html