### PR TITLE
Add WFS propertyName parameter

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -100,6 +100,13 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
     count: null,
 
     /**
+     * A comma-separated list of property names to retrieve
+     * from the server. If left as null all properties are returned.
+     * @cfg {String}
+     */
+    propertyName: null,
+
+    /**
      * Offset to add to the #startIndex in the WFS request.
      * @cfg {Number}
      */
@@ -377,6 +384,11 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
             typeName: me.typeName,
             outputFormat: me.outputFormat
         };
+
+        // add a propertyName parameter if set
+        if (me.propertyName !== null) {
+            params.propertyName = me.propertyName;
+        }
 
         // add a srsName parameter
         if (me.srsName) {

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -131,7 +131,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 }
             });
         });
-        
+
         it('propertyName is set', function() {
 
             Ext.create('GeoExt.data.store.WfsFeatures', {

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -110,6 +110,48 @@ describe('GeoExt.data.store.WfsFeatures', function() {
         });
     });
 
+    describe('load with propertyName', function() {
+        var dataPath = (typeof __karma__ === 'undefined' ? '' : 'base/test/');
+        var url = dataPath + 'data/wfs_mock.geojson';
+
+        it('by default propertyName is undefined', function() {
+
+            Ext.create('GeoExt.data.store.WfsFeatures', {
+                url: url,
+                format: new ol.format.GeoJSON({
+                    featureProjection: 'EPSG:3857'
+                }),
+                listeners: {
+                    'gx-wfsstoreload-beforeload': function(str, params) {
+                        expect(params.propertyName).to.be(undefined);
+                    },
+                    'gx-wfsstoreload': function(str) {
+                        expect(str.getCount()).to.be(3);
+                    }
+                }
+            });
+        });
+        
+        it('propertyName is set', function() {
+
+            Ext.create('GeoExt.data.store.WfsFeatures', {
+                url: url,
+                format: new ol.format.GeoJSON({
+                    featureProjection: 'EPSG:3857'
+                }),
+                propertyName: 'foo,bar',
+                listeners: {
+                    'gx-wfsstoreload-beforeload': function(str, params) {
+                        expect(params.propertyName).to.be('foo,bar');
+                    },
+                    'gx-wfsstoreload': function(str) {
+                        expect(str.getCount()).to.be(3);
+                    }
+                }
+            });
+        });
+    });
+
     describe('config option "createLayer"', function() {
         var store;
         var div;


### PR DESCRIPTION
This pull request adds a [propertyName](https://docs.geoserver.org/latest/en/user/services/wfs/reference.html) parameter to the store, and then forward this on to the WFS server. 

Setting only the properties required can greatly reduce the data returned from the server. A use case is to only return data for visible properties in a grid based on the WfsFeatures store. 

A sample JS snippet for a grid to check visible columns, add in the model's idProperty, and set the `propertyName` on the store is shown below:

```js
        var visibleColumnNames = Ext.Array.pluck(grid.getVisibleColumns(), 'dataIndex');

        var store = grid.getStore();
        var idProperty = store.model.prototype.idField.name;

        // add the idProperty as the first item in the list
        // if it does not exist
        if (visibleColumnNames.indexOf(idProperty) === -1) {
            visibleColumnNames.unshift(idProperty);
        }

        store.propertyName = visibleColumnNames.join(',');
```
