### PR TITLE
Allow stateful components with PermalinkProvider

### DIFF
--- a/classic/state/PermalinkProvider.js
+++ b/classic/state/PermalinkProvider.js
@@ -59,7 +59,7 @@
  * @class GeoExt.state.PermalinkProvider
  */
 Ext.define('GeoExt.state.PermalinkProvider', {
-    extend: 'Ext.state.Provider',
+    extend: 'Ext.state.CookieProvider',
     requires: [],
 
     alias: 'state.gx_permalinkprovider',
@@ -147,7 +147,11 @@ Ext.define('GeoExt.state.PermalinkProvider', {
     set: function(name, value) {
         var me = this;
         // keep our mapState object in sync with the state
-        me.mapState = value;
+        if (value.center != undefined
+            && value.zoom != undefined
+            && value.rotation != undefined) {
+            me.mapState = value;
+        }
         // call 'set' of super class
         me.callParent(arguments);
     }


### PR DESCRIPTION
Possible fix for #631. 

Inherit from CookieProvider so other components in the application can save state,  and only set map state when map object/value properties are passed. 

This has the drawback that the LocalStorageProvider cannot be used, so perhaps redesigning the PermalinkProvider as a mixin to be added to any Provider class would be a better approach?

CC @leonardospina