### PR TITLE
Respect a proxy set in env or npm config

### DIFF
--- a/bin/util.js
+++ b/bin/util.js
@@ -6,6 +6,12 @@ var path = require('path');
 var url = require('url');
 var logUpdate = require('log-update');
 
+// Patch http & https modules to use a proxy configured with e.g.
+// environment variables 'http_proxy', 'https_proxy' … or
+// 'https-proxy', 'http-proxy' & 'proxy' npm configs will be used
+var globalTunnel = require('global-tunnel-ng');
+globalTunnel.initialize();
+
 // Make the progress bar configurable with an environment variable, default
 // is to show the progressbar while downloading
 var showProgress = process.env.NO_DOWNLOAD_PROGRESS === 'true' ? false : true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2103,6 +2103,16 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "config-chain": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -4494,6 +4504,18 @@
       "dev": true,
       "requires": {
         "ini": "^1.3.5"
+      }
+    },
+    "global-tunnel-ng": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz",
+      "integrity": "sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "^1.0.2",
+        "lodash": "^4.17.10",
+        "npm-conf": "^1.1.3",
+        "tunnel": "^0.0.6"
       }
     },
     "globals": {
@@ -8249,6 +8271,24 @@
         }
       }
     },
+    "npm-conf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+      "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+      "dev": true,
+      "requires": {
+        "config-chain": "^1.1.11",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "npm-name": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/npm-name/-/npm-name-5.5.0.tgz",
@@ -8904,6 +8944,12 @@
         "function-bind": "^1.1.1",
         "iterate-value": "^1.0.0"
       }
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
     },
     "protocol-buffers-schema": {
       "version": "3.3.2",
@@ -10619,6 +10665,12 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "7.3.1",
     "eslint-config-openlayers": "7.0.0",
     "expect.js": "0.3.1",
+    "global-tunnel-ng": "2.7.1",
     "karma": "5.1.0",
     "karma-chrome-launcher": "3.1.0",
     "karma-coverage": "2.0.2",


### PR DESCRIPTION
Patch `http` & `https` modules to use a proxy configured with e.g. environment variables `http_proxy`, `https_proxy` … or `https-proxy`, `http-proxy` & `proxy` npm configs will be used.

@buehner this might be of use for you, please review.