### PR TITLE
Catch WFS Parsing Errors

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -473,7 +473,8 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
                 try {
                     wfsFeats = me.format.readFeatures(response.responseText);
                 } catch (error) {
-                    Ext.Logger.warn('Error parsing features into the OpenLayers format. Check the server response.');
+                    Ext.Logger.warn('Error parsing features into the ' +
+                        'OpenLayers format. Check the server response.');
                 }
 
                 // set data for store

--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -472,7 +472,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
 
                 try {
                     wfsFeats = me.format.readFeatures(response.responseText);
-                } catch {
+                } catch (error) {
                     Ext.Logger.warn('Error parsing features into the OpenLayers format. Check the server response.');
                 }
 

--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -467,7 +467,14 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
                 }
 
                 // parse WFS response to OL features
-                var wfsFeats = me.format.readFeatures(response.responseText);
+
+                var wfsFeats = [];
+
+                try {
+                    wfsFeats = me.format.readFeatures(response.responseText);
+                } catch {
+                    Ext.Logger.warn('Error parsing features into the OpenLayers format. Check the server response.');
+                }
 
                 // set data for store
                 me.setData(wfsFeats);


### PR DESCRIPTION
Catch any parsing errors when converting from a WFS respnse to the OpenLayers format. 
Without catching this any stores with loading masks will become unusable. 

A WFS server can often return an error, which has a valid HTTP code (200), but instead of features returns an error message as HTML. If an attempt to parse this is made then an exception occurs. 