### PR TITLE
Use a 'summary' reporter for unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5241,6 +5241,66 @@
       "integrity": "sha1-TjRD8oMP3s/2JNN0cWPxIX2qKpo=",
       "dev": true
     },
+    "karma-summary-reporter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/karma-summary-reporter/-/karma-summary-reporter-2.0.0.tgz",
+      "integrity": "sha512-m9MBLnlsm0wbGrFZF05U9EWZuLD5i14OiXQsWardujd0IadMEy3Te9nDkeJzWPp9vQAhbpv85ZynsNgXC6lNLQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "keyv": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "karma-firefox-launcher": "1.3.0",
     "karma-mocha": "2.0.1",
     "karma-sinon": "1.0.5",
+    "karma-summary-reporter": "^2.0.0",
     "log-update": "4.0.0",
     "mkdirp": "1.0.4",
     "mocha": "8.1.3",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -60,7 +60,7 @@ module.exports = function(config) {
         // test results reporter to use
         // possible values: 'dots', 'progress'
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-        reporters: ['dots', 'coverage'],
+        reporters: ['dots', 'coverage', 'summary'],
 
         // extra config for coverage reporter
         coverageReporter: {
@@ -69,6 +69,17 @@ module.exports = function(config) {
                 {type: 'html', subdir: '.'},
                 {type: 'lcovonly', subdir: '.', file: 'lcov.info'}
             ]
+        },
+
+        summaryReporter: {
+            // 'failed', 'skipped' or 'all'
+            show: 'failed',
+            // Limit the spec label to this length
+            specLength: 50,
+            // Show an 'all' column as a summary
+            overviewColumn: true,
+            // Show a list of test clients, 'always', 'never' or 'ifneeded'
+            browserList: 'always'
         },
 
         // web server port


### PR DESCRIPTION
This adds and configures [a summary reporter](https://www.npmjs.com/package/karma-summary-reporter):

```
npm test

…[skipped a lot]…

SUMMARY
 0: Chrome Headless 88.0.4324.182 (Linux x86_64): Executed 390 of 390 SUCCESS (9.384 secs / 4.165 secs)
 1: Firefox 85.0 (Ubuntu 0.0.0): Executed 390 of 390 SUCCESS (10.388 secs / 4.341 secs)
  384 test cases successful in all browsers

```

Can also be configured to look e.g. like this:

```
      #createSpatialFilter
        is defined                                  ✔    ✔  ✔ 
        returns null for invalid operator type      ✔    ✔  ✔ 
        returns a valid spatial filter              ✔    ✔  ✔ 
  GeoExt.util.Version
    basics
      is defined                                    ✔    ✔  ✔ 

```

This is completely open for feedback, we can very much also live without this dependency, but I really like it.
