### PR TITLE
Fix ol3 tree node mode

### DIFF
--- a/src/data/model/LayerTreeNode.js
+++ b/src/data/model/LayerTreeNode.js
@@ -115,7 +115,7 @@ Ext.define('GeoExt.data.model.LayerTreeNode', {
 
         // forward changes to ol object
         if (key === 'checked') {
-            if (me.data.checked === newValue && !classicMode) {
+            if (!classicMode && me.data.checked === newValue) {
                 me.getOlLayer().set('visible', newValue);
                 return;
             }

--- a/src/data/model/LayerTreeNode.js
+++ b/src/data/model/LayerTreeNode.js
@@ -115,6 +115,10 @@ Ext.define('GeoExt.data.model.LayerTreeNode', {
 
         // forward changes to ol object
         if (key === 'checked') {
+            if (me.data.checked === newValue && !classicMode) {
+                me.getOlLayer().set('visible', newValue);
+                return;
+            }
             me.__updating = true;
             if (me.get('isLayerGroup') && classicMode) {
                 me.getOlLayer().set('visible', newValue);


### PR DESCRIPTION
Fixes ol3 tree mode to only update layer visibility as specified.
