### PR TITLE
Fix common misspellings with codespell

### DIFF
--- a/src/data/model/LayerTreeNode.js
+++ b/src/data/model/LayerTreeNode.js
@@ -98,7 +98,7 @@ Ext.define('GeoExt.data.model.LayerTreeNode', {
     },
 
     /**
-     * Overriden to forward changes to the underlying `ol.Object`. All changes
+     * Overridden to forward changes to the underlying `ol.Object`. All changes
      * on the {Ext.data.Model} properties will be set on the `ol.Object` as
      * well.
      *

--- a/src/data/model/OlObject.js
+++ b/src/data/model/OlObject.js
@@ -36,7 +36,7 @@ Ext.define('GeoExt.data.model.OlObject', {
 
     inheritableStatics: {
         /**
-         * Gets a reference to an ol contructor function.
+         * Gets a reference to an ol constructor function.
          *
          * @param {String} str Description of the form `"ol.layer.Base"`.
          * @return {Function} the ol constructor.
@@ -121,8 +121,9 @@ Ext.define('GeoExt.data.model.OlObject', {
     },
 
     /**
-     * Overriden to foward changes to the underlying `ol.Object`. All changes on
-     * the Ext.data.Models properties will be set on the `ol.Object` as well.
+     * Overridden to forward changes to the underlying `ol.Object`. All changes
+     * on the `Ext.data.Model` properties will be set on the `ol.Object` as
+     * well.
      *
      * @param {String|Object} key The key to set.
      * @param {Object} newValue The value to set.
@@ -153,7 +154,7 @@ Ext.define('GeoExt.data.model.OlObject', {
     },
 
     /**
-     * Overriden to unregister all added event listeners on the ol.Object.
+     * Overridden to unregister all added event listeners on the ol.Object.
      *
      * @inheritdoc
      */

--- a/src/data/serializer/Base.js
+++ b/src/data/serializer/Base.js
@@ -54,13 +54,13 @@ Ext.define('GeoExt.data.serializer.Base', {
          * @return {Object} A serialized representation of source and layer.
          */
         serialize: function() {
-            Ext.raise('This method must be overriden by subclasses.');
+            Ext.raise('This method must be overridden by subclasses.');
             return null; // so that we can have a shared JSDoc comment.
         },
 
         /**
          * Given a subclass of GeoExt.data.serializer.Base, register the class
-         * with the GeoExt.data.MapfishPrintProvider. This method is ususally
+         * with the GeoExt.data.MapfishPrintProvider. This method is usually
          * called inside the 'after-create' function of `Ext.class` definitions.
          *
          * @param {GeoExt.data.serializer.Base} subCls The class to register.

--- a/src/data/store/LayersTree.js
+++ b/src/data/store/LayersTree.js
@@ -353,9 +353,9 @@ Ext.define('GeoExt.data.store.LayersTree', {
      * Bound as an eventlistener for layer nodes which are a folder / group on
      * the beforecollapse event. Whenever a folder gets collapsed, ExtJS seems
      * to actually remove the children from the store, triggering the removal
-     * of the actual layers in the map. This is an undesired behviour. We handle
-     * this as follows: Before the collapsing happens, we mark the childNodes,
-     * so we effectively opt-out in #handleRemove.
+     * of the actual layers in the map. This is an undesired behaviour. We
+     * handle this as follows: Before the collapsing happens, we mark the
+     * childNodes, so we effectively opt-out in #handleRemove.
      *
      * @param {Ext.data.NodeInterface} node The collapsible folder node.
      * @private

--- a/src/mixin/SymbolCheck.js
+++ b/src/mixin/SymbolCheck.js
@@ -70,7 +70,7 @@ Ext.define('GeoExt.mixin.SymbolCheck', {
          * @private
          */
         _checked: {
-            // will be filled while we are checking stuff for existance
+            // will be filled while we are checking stuff for existence
         },
 
         /**

--- a/src/util/OGCFilter.js
+++ b/src/util/OGCFilter.js
@@ -573,9 +573,9 @@ Ext.define('GeoExt.util.OGCFilter', {
         },
 
         /**
-         * Reduce an ol.Coordiate array to a string of whitespace
+         * Reduce an ol.Coordinate array to a string of whitespace
          * separated coordinate values
-         * @param {ol.Coordiate []} coordArray An array of
+         * @param {ol.Coordinate []} coordArray An array of
          * coordinates
          * @return {string} Concatenated array of coordinates
          */


### PR DESCRIPTION
Also reformat lines where eslint found line-length issues afterwards.

Please review.