### PR TITLE
Cache external resources in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ cache:
     - __download
     - __install
     - node_modules
+    - resources/external


### PR DESCRIPTION
Title says it all.

Until we have maybe moved to GitHub actions, this might speed up CI builds on Travis.

This saves us ~6 seconds ([1m30s](https://travis-ci.org/github/geoext/geoext3/builds/761635172) vs. [1m24s](https://travis-ci.org/github/geoext/geoext3/builds/761637931)) isn't that … well it isn't much but doesn't hurt :man_facepalming: 