### PR TITLE
Don't log WfsFeatures warnings if the transaction is aborted

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -352,14 +352,14 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
             url: url,
             method: me.requestMethod,
             params: params,
-            success: function (resp) {
+            success: function(resp) {
                 // set number of total features (needed for paging)
                 me.cachedTotalCount = me.getTotalFeatureCount(resp);
                 if (!skipLoad) {
                     me.loadWfs();
                 }
             },
-            failure: function (resp) {
+            failure: function(resp) {
                 Ext.Logger.warn('Error while requesting features from WFS: ' +
                     resp.responseText + ' Status: ' + resp.status);
             }

--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -352,16 +352,16 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
             url: url,
             method: me.requestMethod,
             params: params,
-            success: function(response) {
+            success: function (resp) {
                 // set number of total features (needed for paging)
-                me.cachedTotalCount = me.getTotalFeatureCount(response);
+                me.cachedTotalCount = me.getTotalFeatureCount(resp);
                 if (!skipLoad) {
                     me.loadWfs();
                 }
             },
-            failure: function(response) {
+            failure: function (resp) {
                 Ext.Logger.warn('Error while requesting features from WFS: ' +
-                    response.responseText + ' Status: ' + response.status);
+                    resp.responseText + ' Status: ' + resp.status);
             }
         });
     },
@@ -450,7 +450,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
             url: url,
             method: me.requestMethod,
             params: params,
-            success: function(response) {
+            success: function(resp) {
 
                 if (!me.format) {
                     Ext.Logger.warn('No format given for WfsFeatureStore. ' +
@@ -463,7 +463,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
                     me.totalCount = me.cachedTotalCount;
                 } else {
                     // set number of total features (needed for paging)
-                    me.totalCount = me.getTotalFeatureCount(response);
+                    me.totalCount = me.getTotalFeatureCount(resp);
                 }
 
                 // parse WFS response to OL features
@@ -471,7 +471,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
                 var wfsFeats = [];
 
                 try {
-                    wfsFeats = me.format.readFeatures(response.responseText);
+                    wfsFeats = me.format.readFeatures(resp.responseText);
                 } catch (error) {
                     Ext.Logger.warn('Error parsing features into the ' +
                         'OpenLayers format. Check the server response.');
@@ -488,9 +488,11 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
 
                 me.fireEvent('gx-wfsstoreload', me, wfsFeats, true);
             },
-            failure: function(response) {
-                Ext.Logger.warn('Error while requesting features from WFS: ' +
-                    response.responseText + ' Status: ' + response.status);
+            failure: function(resp) {
+                if (resp.aborted !== true) {
+                    Ext.Logger.warn('Error while requesting features from WFS: '
+                        + resp.responseText + ' Status: ' + resp.status);
+                }
                 me.fireEvent('gx-wfsstoreload', me, null, false);
             }
 


### PR DESCRIPTION
#589 aborts requests if a new request is made to the store. This causes a `failure` response and a warning to be logged. As every initial load of the store triggers 2 requests hiding the warning in this case removes log clutter. 