### PR TITLE
Add Missing Requires

### DIFF
--- a/src/data/MapfishPrintProvider.js
+++ b/src/data/MapfishPrintProvider.js
@@ -27,7 +27,10 @@ Ext.define('GeoExt.data.MapfishPrintProvider', {
     ],
     requires: [
         'GeoExt.data.model.print.Capability',
-        'Ext.data.JsonStore'
+        'Ext.data.JsonStore',
+        'Ext.data.Store',
+        'Ext.data.proxy.Ajax',
+        'Ext.data.proxy.JsonP'
     ],
     // <debug>
     symbols: [


### PR DESCRIPTION
This adds missing requires for `MapfishPrintProvider` that lead to errors on production builds.